### PR TITLE
[sigproc] fix a logic hole in BreakROI()

### DIFF
--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -1820,6 +1820,13 @@ void ROI_refinement::BreakROI(SignalROI *roi, float rms){
       //std::cout << roi->get_plane() << " " << roi->get_chid() << " " << npeaks << " " << npeaks1 << " " ;
       //std::cout << start_bin << " " << end_bin << std::endl;
 
+      // sometimes NO individual peaks identified due to low_peak_sep_threshold
+      // but still want to keep the entire ROI as good
+      if (npeaks1==0) {
+        npeaks1 =1;
+        valley_pos1[0] = valley_pos[0];
+        valley_pos1[1] = valley_pos[npeaks];
+      }
 
       // if (roi->get_chid() == 1240 && roi->get_plane() == 0){
       // 	for (int j=0;j!=npeaks1;j++){


### PR DESCRIPTION
In the **ROI_refinement::BreakROI()**, individual peaks will be identified given a threshold (low_peak_sep_threshold). However, if no peak is found, the current algorithm seems to ignore the entire ROI. The event display below shows that a small gap can be cured by fixing this bug.
![image](https://user-images.githubusercontent.com/10663117/63804238-bd90e880-c8e4-11e9-8fc1-96d85be1aac2.png)

To verify that this bug fixing does NOT change the signal processing significantly, I directly subtract the two TH2F. Only a few channels/ROIs are found to be different before and after the bug fixing.
And those differences seem to be reasonable. For example, channel 137 below also has one low-amplitude ROI that was kept by the new BreakROI. As a result, the adjacent channel 136 keeps more ROI in a similar tick range because of the rules in ShrinkROI().

![image](https://user-images.githubusercontent.com/10663117/63804398-18c2db00-c8e5-11e9-8d5e-abb3064daecc.png)

