### PR TITLE
[sp][test feature] Muti-Plane ROI protection

### DIFF
--- a/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
@@ -197,8 +197,8 @@ namespace WireCell {
 
       // Per-plane temporary working arrays.  Each column is one tick,
       // each row is indexec by an "OSP wire" number
-      Array::array_xxf m_r_data;
-      Array::array_xxc m_c_data;
+      Array::array_xxf m_r_data[3];
+      Array::array_xxc m_c_data[3];
       
       //average overall responses
       std::vector<Waveform::realseq_t> overall_resp[3];

--- a/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
@@ -221,6 +221,8 @@ namespace WireCell {
       std::string m_shrink_roi_tag;
       std::string m_extend_roi_tag;
 
+      bool m_use_multi_plane_protection;
+
       // If true, safe output as a sparse frame.  Traces will only
       // cover segments of waveforms which have non-zero signal
       // samples.

--- a/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
@@ -183,6 +183,9 @@ namespace WireCell {
       // except that it is nonnegative.  
       int m_nwires[3];
 
+      // ROI->chid() -> wct ch ident
+      std::map<int, int> m_roi_ch_ch_ident;
+
       // Need to go from WCT channel ident to {OSP channel, wire and plane}
       std::map<int,OspChan> m_channel_map;
 

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -248,6 +248,7 @@ void OmnibusSigProc::configure(const WireCell::Configuration& config)
     for (auto ichan : plane_channels[iplane]) {
       const int wct_chan_ident = ichan->ident();
       OspChan och(osp_channel_number, osp_wire_number, iplane, wct_chan_ident);
+      m_roi_ch_ch_ident[osp_channel_number] = wct_chan_ident;
       m_channel_map[wct_chan_ident] = och; // we could save some space by storing
       m_channel_range[iplane].push_back(och);// wct ident here instead of a whole och.
       ++osp_wire_number;
@@ -1278,7 +1279,7 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
       save_roi(*itraces, cleanup_roi_traces, iplane, roi_refine.get_rois_by_plane(iplane));
 
       if(iplane==0)
-        roi_refine.multi_plane_protection(iplane, m_anode);
+        roi_refine.multi_plane_protection(iplane, m_anode, m_roi_ch_ch_ident);
 
       std::cout << "[wgu] BreakROIs ..." << std::endl;
       roi_refine.refine_data_debug_mode(iplane, roi_form, "BreakROIs");

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -1379,6 +1379,9 @@ void ROI_refinement::CleanUpInductionROIs(int plane){
 }
 
 void ROI_refinement::ShrinkROI(SignalROI *roi, ROI_formation& roi_form){
+  if(proteced_rois.find({roi->get_chid(),roi->get_start_bin()})!=proteced_rois.end()) {
+    return;
+  }
   // get tight ROI as a inner boundary
   // get the nearby ROIs with threshold as some sort of boundary 
   int start_bin = roi->get_start_bin();
@@ -1629,11 +1632,14 @@ void ROI_refinement::ShrinkROIs(int plane, ROI_formation& roi_form){
   }
 }
 
-void ROI_refinement::BreakROI(SignalROI *roi, float rms){
+void ROI_refinement::BreakROI(SignalROI *roi, float rms) {
 
-  if(proteced_rois.find(roi)!=proteced_rois.end()) {
-    std::cout << "Skip BreakROI" << std::endl;
+  if (proteced_rois.find({roi->get_chid(),roi->get_start_bin()})!=proteced_rois.end()) {
     return;
+  } else if (roi->get_plane() == 0) {
+    std::cout << "Not protected ROI: " << roi->get_chid() << ", "
+              << roi->get_start_bin() << ", " << roi->get_end_bin()
+              << std::endl;
   }
 
   //  std::cout << "haha " << std::endl;
@@ -2247,42 +2253,30 @@ void ROI_refinement::refine_data_debug_mode(int plane, ROI_formation& roi_form, 
  }
 
  void ROI_refinement::multi_plane_protection(const int plane,
-                                             const IAnodePlane::pointer anode) {
-   std::cout << "[yuhw] multi_plane_protection:" << std::endl;
-   
+                                             const IAnodePlane::pointer anode,
+                                             const std::map<int, int> &map_ch) {
+   std::cout << "ROI_refinement::multi_plane_protection:" << std::endl;
+
    if (plane == 2)
      return;
-   int roi_resolution = 10;
-   int match_range = 10;
-   int faceid = 0;
+   int tick_resolution = 10;
+   int wire_resolution = 2;
+   int faceid = 1;
+   int nbounds_layers = 2;
 
    int ref_planes[2] = {0, 2};
    if (plane == 0) ref_planes[0] = 1;
 
-   std::vector<std::map<int, std::vector<WireCell::RayGrid::coordinate_t>>>
-       map_tick_coord;
-   map_tick_coord.resize(3);
-
+   std::map<int, std::vector<WireCell::RayGrid::coordinate_t>> map_tick_coord[3];
    std::map<int, std::map<int, SignalROI *>> map_tick_pitch_roi[3];
 
    auto face = anode->face(faceid);
-
-   std::cout << anode->channels().front() << std::endl;
-   std::cout << anode->channels().back() << std::endl;
-
-   std::cout
-   << " centers: " << face->raygrid().centers()[0]
-   << " centers: " << face->raygrid().centers()[1]
-   << " centers: " << face->raygrid().centers()[2]
-   << " centers: " << face->raygrid().centers()[3]
-   << " centers: " << face->raygrid().centers()[4]
-   << std::endl;
 
    for (int iplane = 0; iplane < 3; ++iplane) {
      auto rois_chan = get_rois_by_plane(iplane);
      for (auto rois : rois_chan) {
        for (auto roi : rois) {
-         auto chid = roi->get_chid() + anode->channels().front();
+         auto chid = map_ch.at(roi->get_chid());
          WireCell::RayGrid::coordinate_t coord;
          auto ch = anode->channel(chid);
          auto wires = ch->wires();
@@ -2291,9 +2285,9 @@ void ROI_refinement::refine_data_debug_mode(int plane, ROI_formation& roi_form, 
              continue;
            auto pit_id = wire->index();
            coord.grid = pit_id;
-           coord.layer = iplane + face->raygrid().nlayers() - 3;
-           for (int tick = roi->get_start_bin() / roi_resolution;
-                tick < roi->get_end_bin() / roi_resolution; ++tick) {
+           coord.layer = iplane + nbounds_layers;
+           for (int tick = roi->get_start_bin() / tick_resolution;
+                tick < roi->get_end_bin() / tick_resolution; ++tick) {
              if (map_tick_coord[iplane].find(tick) ==
                  map_tick_coord[iplane].end()) {
                std::vector<WireCell::RayGrid::coordinate_t> vtmp;
@@ -2321,7 +2315,7 @@ void ROI_refinement::refine_data_debug_mode(int plane, ROI_formation& roi_form, 
                << std::endl;
    }
 
-   WireCell::RayGrid::layer_index_t layer = plane+face->raygrid().nlayers()-3;
+   WireCell::RayGrid::layer_index_t layer = plane+nbounds_layers;
    for (auto tc1 : map_tick_coord[ref_planes[0]]) {
      for (auto tc2 : map_tick_coord[ref_planes[1]]) {
        if (tc2.first != tc1.first)
@@ -2329,21 +2323,24 @@ void ROI_refinement::refine_data_debug_mode(int plane, ROI_formation& roi_form, 
        auto tick = tc1.first;
        for (auto c1 : tc1.second) {
          for (auto c2 : tc2.second) {
-           std::cout
-           << " { " << c1.layer << ", " << c1.grid << " } "
-           << " { " << c2.layer << ", " << c2.grid << " } "
-           << std::endl;
+          //  std::cout
+          //  << " { " << c1.layer << ", " << c1.grid << " } "
+          //  << " { " << c2.layer << ", " << c2.grid << " } "
+          //  << std::endl;
            auto pitch = face->raygrid().pitch_location(c1, c2, layer);
            auto index = face->raygrid().pitch_index(pitch, layer);
            if(map_tick_pitch_roi[plane].find(tick) == map_tick_pitch_roi[plane].end()) continue;
            for (auto pitch_roi : map_tick_pitch_roi[plane][tick]) {
              auto pitch = pitch_roi.first;
-             if (abs(pitch - index) < match_range) {
-               proteced_rois.insert(pitch_roi.second);
-               std::cout << " { " << map_tick_pitch_roi[0][tick][pitch]->get_chid() + anode->channels().front() << " } "
-                         << " { " << map_tick_pitch_roi[1][tick][c1.grid]->get_chid() + anode->channels().front() << " } "
-                         << " { " << map_tick_pitch_roi[2][tick][c2.grid]->get_chid() + anode->channels().front() << " } "
-                         << std::endl;
+             if (abs(pitch - index) < wire_resolution) {
+               proteced_rois.insert({pitch_roi.second->get_chid(), pitch_roi.second->get_start_bin()});
+               std::cout
+               << tick * tick_resolution
+               << " { " << map_ch.at(map_tick_pitch_roi[0][tick][pitch]->get_chid()) << " } "
+               << " { " << map_ch.at(pitch_roi.second->get_chid()) << " } "
+               << " { " << map_ch.at(map_tick_pitch_roi[1][tick][c1.grid]->get_chid()) << " } "
+               << " { " << map_ch.at(map_tick_pitch_roi[2][tick][c2.grid]->get_chid()) << " } "
+               << std::endl;
              }
            }
          }
@@ -2351,12 +2348,17 @@ void ROI_refinement::refine_data_debug_mode(int plane, ROI_formation& roi_form, 
      }
    }
 
-   std::cout
-   << " total rois:          "     << get_rois_by_plane(plane).size()
-   << " protected_rois:      "     << proteced_rois.size()
-   << std::endl;
-   for(auto roi : proteced_rois) {
-     std::cout << roi->get_chid()+anode->channels().front() << std::endl;
+   {
+     std::cout << " total rois:          " << get_rois_by_plane(plane).size()
+               << " protected_rois:      " << proteced_rois.size() << std::endl;
+     std::map<int, std::pair<int, int>> tmp;
+     for (auto roi : proteced_rois) {
+       tmp[map_ch.at(roi.first)] = roi;
+     }
+     for (auto ch : tmp) {
+       std::cout << ch.first << ", " << ch.second.first << ", "
+                 << ch.second.second << ", " << std::endl;
+     }
    }
  }
 

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -1631,6 +1631,11 @@ void ROI_refinement::ShrinkROIs(int plane, ROI_formation& roi_form){
 
 void ROI_refinement::BreakROI(SignalROI *roi, float rms){
 
+  if(proteced_rois.find(roi)!=proteced_rois.end()) {
+    std::cout << "Skip BreakROI" << std::endl;
+    return;
+  }
+
   //  std::cout << "haha " << std::endl;
   
   // main algorithm 
@@ -2241,26 +2246,149 @@ void ROI_refinement::refine_data_debug_mode(int plane, ROI_formation& roi_form, 
 
  }
 
-void ROI_refinement::TestROIs(){
-  
-  for (int chid = 0; chid != nwire_u; chid ++){
-    for (auto it = rois_u_loose.at(chid).begin(); it!= rois_u_loose.at(chid).end();it++){
-      SignalROI *roi =  *it;
-      //loop through front
-      for (auto it1 = front_rois[roi].begin(); it1!=front_rois[roi].end(); it1++){
-	SignalROI *roi1 = *it1;
-	if (find(rois_u_loose.at(chid+1).begin(), rois_u_loose.at(chid+1).end(), roi1) == rois_u_loose.at(chid+1).end())
-	  std::cout << chid << " u " << +1 << " " << roi << " " << roi1 << std::endl;
-      }
-	
-      // loop through back 
-      for (auto it1 = back_rois[roi].begin(); it1!=back_rois[roi].end(); it1++){
-	SignalROI *roi1 = *it1;
-	if (find(rois_u_loose.at(chid-1).begin(), rois_u_loose.at(chid-1).end(), roi1) == rois_u_loose.at(chid-1).end())
-	  std::cout << chid << " u " << -1 << " " << roi << " " << roi1 << std::endl;
-      }
-    }
-  }
+ void ROI_refinement::multi_plane_protection(const int plane,
+                                             const IAnodePlane::pointer anode) {
+   std::cout << "[yuhw] multi_plane_protection:" << std::endl;
+   
+   if (plane == 2)
+     return;
+   int roi_resolution = 10;
+   int match_range = 10;
+   int faceid = 0;
+
+   int ref_planes[2] = {0, 2};
+   if (plane == 0) ref_planes[0] = 1;
+
+   std::vector<std::map<int, std::vector<WireCell::RayGrid::coordinate_t>>>
+       map_tick_coord;
+   map_tick_coord.resize(3);
+
+   std::map<int, std::map<int, SignalROI *>> map_tick_pitch_roi[3];
+
+   auto face = anode->face(faceid);
+
+   std::cout << anode->channels().front() << std::endl;
+   std::cout << anode->channels().back() << std::endl;
+
+   std::cout
+   << " centers: " << face->raygrid().centers()[0]
+   << " centers: " << face->raygrid().centers()[1]
+   << " centers: " << face->raygrid().centers()[2]
+   << " centers: " << face->raygrid().centers()[3]
+   << " centers: " << face->raygrid().centers()[4]
+   << std::endl;
+
+   for (int iplane = 0; iplane < 3; ++iplane) {
+     auto rois_chan = get_rois_by_plane(iplane);
+     for (auto rois : rois_chan) {
+       for (auto roi : rois) {
+         auto chid = roi->get_chid() + anode->channels().front();
+         WireCell::RayGrid::coordinate_t coord;
+         auto ch = anode->channel(chid);
+         auto wires = ch->wires();
+         for (auto wire : wires) {
+           if (wire->planeid().face() != faceid)
+             continue;
+           auto pit_id = wire->index();
+           coord.grid = pit_id;
+           coord.layer = iplane + face->raygrid().nlayers() - 3;
+           for (int tick = roi->get_start_bin() / roi_resolution;
+                tick < roi->get_end_bin() / roi_resolution; ++tick) {
+             if (map_tick_coord[iplane].find(tick) ==
+                 map_tick_coord[iplane].end()) {
+               std::vector<WireCell::RayGrid::coordinate_t> vtmp;
+               vtmp.push_back(coord);
+               map_tick_coord[iplane][tick] = vtmp;
+             } else {
+               map_tick_coord[iplane][tick].push_back(coord);
+             }
+
+             if (map_tick_pitch_roi[iplane].find(tick) ==
+                 map_tick_pitch_roi[iplane].end()) {
+               std::map<int, SignalROI *> mtmp;
+               mtmp[pit_id] = roi;
+               map_tick_pitch_roi[iplane][tick] = mtmp;
+             } else {
+               map_tick_pitch_roi[iplane][tick][pit_id] = roi;
+             }
+           }
+         }
+       }
+     }
+
+     std::cout << " map_tick_coord:     " << map_tick_coord[iplane].size()
+               << " map_tick_pitch_roi: " << map_tick_pitch_roi[iplane].size()
+               << std::endl;
+   }
+
+   WireCell::RayGrid::layer_index_t layer = plane+face->raygrid().nlayers()-3;
+   for (auto tc1 : map_tick_coord[ref_planes[0]]) {
+     for (auto tc2 : map_tick_coord[ref_planes[1]]) {
+       if (tc2.first != tc1.first)
+         continue;
+       auto tick = tc1.first;
+       for (auto c1 : tc1.second) {
+         for (auto c2 : tc2.second) {
+           std::cout
+           << " { " << c1.layer << ", " << c1.grid << " } "
+           << " { " << c2.layer << ", " << c2.grid << " } "
+           << std::endl;
+           auto pitch = face->raygrid().pitch_location(c1, c2, layer);
+           auto index = face->raygrid().pitch_index(pitch, layer);
+           if(map_tick_pitch_roi[plane].find(tick) == map_tick_pitch_roi[plane].end()) continue;
+           for (auto pitch_roi : map_tick_pitch_roi[plane][tick]) {
+             auto pitch = pitch_roi.first;
+             if (abs(pitch - index) < match_range) {
+               proteced_rois.insert(pitch_roi.second);
+               std::cout << " { " << map_tick_pitch_roi[0][tick][pitch]->get_chid() + anode->channels().front() << " } "
+                         << " { " << map_tick_pitch_roi[1][tick][c1.grid]->get_chid() + anode->channels().front() << " } "
+                         << " { " << map_tick_pitch_roi[2][tick][c2.grid]->get_chid() + anode->channels().front() << " } "
+                         << std::endl;
+             }
+           }
+         }
+       }
+     }
+   }
+
+   std::cout
+   << " total rois:          "     << get_rois_by_plane(plane).size()
+   << " protected_rois:      "     << proteced_rois.size()
+   << std::endl;
+   for(auto roi : proteced_rois) {
+     std::cout << roi->get_chid()+anode->channels().front() << std::endl;
+   }
+ }
+
+ void ROI_refinement::TestROIs() {
+
+   for (int chid = 0; chid != nwire_u; chid++) {
+     for (auto it = rois_u_loose.at(chid).begin();
+          it != rois_u_loose.at(chid).end(); it++) {
+       SignalROI *roi = *it;
+       // loop through front
+       for (auto it1 = front_rois[roi].begin(); it1 != front_rois[roi].end();
+            it1++) {
+         SignalROI *roi1 = *it1;
+         if (find(rois_u_loose.at(chid + 1).begin(),
+                  rois_u_loose.at(chid + 1).end(),
+                  roi1) == rois_u_loose.at(chid + 1).end())
+           std::cout << chid << " u " << +1 << " " << roi << " " << roi1
+                     << std::endl;
+       }
+
+       // loop through back
+       for (auto it1 = back_rois[roi].begin(); it1 != back_rois[roi].end();
+            it1++) {
+         SignalROI *roi1 = *it1;
+         if (find(rois_u_loose.at(chid - 1).begin(),
+                  rois_u_loose.at(chid - 1).end(),
+                  roi1) == rois_u_loose.at(chid - 1).end())
+           std::cout << chid << " u " << -1 << " " << roi << " " << roi1
+                     << std::endl;
+       }
+     }
+   }
 
 
    for (int chid = 0; chid != nwire_v; chid ++){

--- a/sigproc/src/ROI_refinement.h
+++ b/sigproc/src/ROI_refinement.h
@@ -29,7 +29,30 @@ namespace WireCell{
       void refine_data(int plane, ROI_formation& roi_form);
       void refine_data_debug_mode(int plane, ROI_formation& roi_form, const std::string& cmd);
 
-      void multi_plane_protection(const int plane, const IAnodePlane::pointer anode, const std::map<int, int> & map_ch);
+      void MultiPlaneProtection(const int plane,
+                                const IAnodePlane::pointer anode,
+                                const std::map<int, int> &map_ch,
+                                const int faceid = 1,
+                                const int tick_resolution = 10,
+                                const int wire_resolution = 2,
+                                const int nbounds_layers = 2);
+
+      void CleanUpROIs(int plane);
+      void generate_merge_ROIs(int plane);
+      void CheckROIs(int plane, ROI_formation& roi_form);
+
+      void CleanUpCollectionROIs();
+      void CleanUpInductionROIs(int plane);
+      void ShrinkROIs(int plane, ROI_formation& roi_form);
+      void ShrinkROI(SignalROI *roi, ROI_formation& roi_form);
+
+      void BreakROIs(int plane, ROI_formation& roi_form);
+      void BreakROI(SignalROI *roi, float rms);
+      void BreakROI1(SignalROI *roi);
+      
+      void ExtendROIs();
+
+      void TestROIs();
 
       void apply_roi(int plane, Array::array_xxf& r_data);
       
@@ -61,22 +84,6 @@ namespace WireCell{
       
       void unlink(SignalROI *prev_roi, SignalROI *next_roi);
       void link(SignalROI *prev_roi, SignalROI *next_roi);
-      void CleanUpROIs(int plane);
-      void generate_merge_ROIs(int plane);
-      void CheckROIs(int plane, ROI_formation& roi_form);
-
-      void CleanUpCollectionROIs();
-      void CleanUpInductionROIs(int plane);
-      void ShrinkROIs(int plane, ROI_formation& roi_form);
-      void ShrinkROI(SignalROI *roi, ROI_formation& roi_form);
-
-      void BreakROIs(int plane, ROI_formation& roi_form);
-      void BreakROI(SignalROI *roi, float rms);
-      void BreakROI1(SignalROI *roi);
-      
-      void ExtendROIs();
-
-      void TestROIs();
       
       std::map<int,std::vector<std::pair<int,int>>> bad_ch_map;
       

--- a/sigproc/src/ROI_refinement.h
+++ b/sigproc/src/ROI_refinement.h
@@ -4,8 +4,10 @@
 #include "SignalROI.h"
 #include "ROI_formation.h"
 #include "WireCellUtil/Array.h"
+#include "WireCellUtil/RayGrid.h"
 #include "WireCellUtil/Waveform.h"
 #include "WireCellUtil/Logging.h"
+#include "WireCellIface/IAnodePlane.h"
 
 #include <vector>
 #include <map>
@@ -26,6 +28,8 @@ namespace WireCell{
       void load_data(int plane, const Array::array_xxf& r_data, ROI_formation& roi_form);
       void refine_data(int plane, ROI_formation& roi_form);
       void refine_data_debug_mode(int plane, ROI_formation& roi_form, const std::string& cmd);
+
+      void multi_plane_protection(const int plane, const IAnodePlane::pointer  anode);
 
       void apply_roi(int plane, Array::array_xxf& r_data);
       
@@ -83,6 +87,8 @@ namespace WireCell{
     
       SignalROIChList rois_u_loose;
       SignalROIChList rois_v_loose;
+
+      std::set<SignalROI*> proteced_rois;
    
     
       SignalROIMap front_rois;

--- a/sigproc/src/ROI_refinement.h
+++ b/sigproc/src/ROI_refinement.h
@@ -29,7 +29,7 @@ namespace WireCell{
       void refine_data(int plane, ROI_formation& roi_form);
       void refine_data_debug_mode(int plane, ROI_formation& roi_form, const std::string& cmd);
 
-      void multi_plane_protection(const int plane, const IAnodePlane::pointer  anode);
+      void multi_plane_protection(const int plane, const IAnodePlane::pointer anode, const std::map<int, int> & map_ch);
 
       void apply_roi(int plane, Array::array_xxf& r_data);
       
@@ -88,7 +88,7 @@ namespace WireCell{
       SignalROIChList rois_u_loose;
       SignalROIChList rois_v_loose;
 
-      std::set<SignalROI*> proteced_rois;
+      std::set<std::pair<int, int>> proteced_rois; //using chid and start_bin as id
    
     
       SignalROIMap front_rois;


### PR DESCRIPTION
Adding a test feature to the `ROI_refinement` and `OmnibusSigProc`.
Make a protection dictionary for ROIs that have corresponding ROIs from other two planes.
The projection was made using the `RayGrid` utilities from @brettviren 
Then skip the Breaking and Shrinking steps if a ROI is tagged as 'protected'.

Test on single track simulation shown below. We could see the prolonged track from u view was largely recovered.
![image](https://user-images.githubusercontent.com/10383186/64046388-c2020f00-cb39-11e9-9ed7-9841550b957d.png)

Test on the example data from [here](https://czczc.github.io/wire-cell-tutorial/quickstart/explore-data.html#get-data). Thanks @goowenq for preparing the data. We could see the prolonged track from v view was largely recovered.
![image](https://user-images.githubusercontent.com/10383186/64046552-1907e400-cb3a-11e9-922e-f844de25b47a.png)

There are a lot more tear-drop like stuff using this 'multi-plane protection' which can be largely removed by using some threshold (1000 used below). But not all can be removed by reasonable threshold:
![image](https://user-images.githubusercontent.com/10383186/64046675-8156c580-cb3a-11e9-98e2-dd139ac7373c.png)

The computing time cost didn't change for single track simulation; increased about 1.7 times in this data signal processing (12 sec/apa -> 20 sec/apa).

I want to propose to add this 'multi-plane protection' as a test feature. Future development would be based on this. By default, it is turned off. One can enable it by adding `use_multi_plane_protection : true` in the `OmnibusSigProc` configuration.
