### PR TITLE
Remove multi-plane protection when shrinking

### DIFF
--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -1379,9 +1379,9 @@ void ROI_refinement::CleanUpInductionROIs(int plane){
 }
 
 void ROI_refinement::ShrinkROI(SignalROI *roi, ROI_formation& roi_form){
-  if(proteced_rois.find({roi->get_chid(),roi->get_start_bin()})!=proteced_rois.end()) {
-    return;
-  }
+  // if(proteced_rois.find({roi->get_chid(),roi->get_start_bin()})!=proteced_rois.end()) {
+  //   return;
+  // }
   // get tight ROI as a inner boundary
   // get the nearby ROIs with threshold as some sort of boundary 
   int start_bin = roi->get_start_bin();


### PR DESCRIPTION
A quick update from #2 , simply removed protection when shrinking ROIs.
This change recovered the shrinking effect without affecting the protection power much.
Compared with #2, now the results are more usable:
![image](https://user-images.githubusercontent.com/10383186/64312288-596dc480-cf75-11e9-920d-d2c0bb5e84b5.png)
