### PR TITLE
Add timer function to Pgraher node execution

### DIFF
--- a/pgraph/inc/WireCellPgraph/Graph.h
+++ b/pgraph/inc/WireCellPgraph/Graph.h
@@ -62,12 +62,17 @@ namespace WireCell {
             // Return false if any node is not connected.
             bool connected();
 
+            // Print out cumulated CPU time for executing each node
+            void print_timers() const;
+
         private:
             std::vector<std::pair<Node*,Node*> > m_edges;
             std::unordered_set<Node*> m_nodes;
             std::unordered_map< Node*, std::vector<Node*> > m_edges_forward,
                 m_edges_backward;
             Log::logptr_t l;
+            Log::logptr_t l_timer;
+            std::unordered_map<Node*, float> m_nodes_timer;
         };
 }
 }

--- a/pgraph/src/Pgrapher.cxx
+++ b/pgraph/src/Pgrapher.cxx
@@ -62,6 +62,8 @@ void Pgrapher::configure(const WireCell::Configuration& cfg)
 void Pgrapher::execute()
 {
     m_graph.execute();
+
+    m_graph.print_timers();
 }
 
 


### PR DESCRIPTION
Timing and printing out of the cumulated execution time for each `Pgraph::Node`
Following decreasing order of the time consumed.
A summed time was also reported at the end.

Example:

![image](https://user-images.githubusercontent.com/10383186/64371182-f79d7100-cfed-11e9-80c1-3d8899b0acd1.png)

The `std::clock` time consumption used in the timer was estimated to be 0.5sec per 1M execution:

![image](https://user-images.githubusercontent.com/10383186/64371934-ca51c280-cfef-11e9-8a31-ac4228d4c7c5.png)

Code used in this test:
https://gist.github.com/HaiwangYu/31e6f2a2e6db811a76d781b8f1a5c96d


