### PR TITLE
rebin the Pimpos

### DIFF
--- a/util/inc/WireCellUtil/Pimpos.h
+++ b/util/inc/WireCellUtil/Pimpos.h
@@ -77,7 +77,7 @@ namespace WireCell {
 
         /// Trivial accessor
         int nimpbins_per_wire() const { return m_nimpbins_per_wire; }
-
+        void set_nimpbins_per_wire(int nbins);
 
         //// Geometry related:
 
@@ -136,6 +136,7 @@ namespace WireCell {
 	
 
     private:
+        int m_nwires;
         int m_nimpbins_per_wire;
 	Point m_origin;
 	Vector m_axis[3];

--- a/util/src/Pimpos.cxx
+++ b/util/src/Pimpos.cxx
@@ -7,7 +7,8 @@ Pimpos::Pimpos(int nwires, double minwirepitch, double maxwirepitch,
                const Vector& pitch,
                const Point& origin,
 	       int nbins)       // default=10
-    : m_nimpbins_per_wire(nbins)
+    : m_nwires(nwires)
+    , m_nimpbins_per_wire(nbins)
     , m_origin(origin)
     , m_axis{Vector(0,0,0), wire.norm(), pitch.norm()}
 {
@@ -29,6 +30,12 @@ Pimpos::Pimpos(int nwires, double minwirepitch, double maxwirepitch,
 
     // Impact binning.  Impact *positions* are bin-edges.
     m_impactbins.set(nimpstot, pmin, pmax);
+}
+
+void Pimpos::set_nimpbins_per_wire(int nbins)
+{
+    const int nimpstot = m_nwires * nbins;
+    m_impactbins.set(nimpstot, m_impactbins.min(), m_impactbins.max());
 }
 
 std::pair<int, int> Pimpos::closest(double pitch) const


### PR DESCRIPTION
We want to make the larwirecell::SimChannelSink more generic so that it can be used on any experiment  (uboone, pdsp, etc.) So the that `Pimpos` is not hardcoded or configured from jsonnet, instead it is from the wirecell geometry.  

I found that the `Pimpos` from `plane->pimpos()` is originally created with 10 bins per wire pitch. Therefore, I would like to add a method `set_nimpbins_per_wire(int nbins)`. As the `nbins` is only used in computing `m_impactbins`, it can be changed anytime. However, users are NOT suggested to use it directly on a `Pimpos` pointer, while it is suggested to *make a copy* of that `Pimpos` object and then change the binning.

Here is the dumped "SimChannel" from a uboone simulation (wcls-sim-drift-simchannel.fcl) and retrieved with Brooke's CheckWires module in uboonecode. The new result with the above `set_nimpbins_per_wire()` method looks very similar.

![image](https://user-images.githubusercontent.com/10663117/64649537-11bec100-d3eb-11e9-9eee-8dfc952e3028.png)

A direct subtraction of the two 2D histograms shows a slight difference. This could be from the slight difference of `Pimpos` between the hardcoded one and the one retrieved from wirecell geometry infrastructure.

![image](https://user-images.githubusercontent.com/10663117/64649719-74b05800-d3eb-11e9-82cc-83e4151fa405.png)

