### PR TITLE
optional method for Coherent removal

### DIFF
--- a/cfg/pgrapher/experiment/pdsp/chndb-base.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/chndb-base.jsonnet
@@ -48,6 +48,7 @@ function(params, anode, field, n, rms_cuts=[])
         pad_window_back: 10,  // ticks?
         decon_limit: 0.02,
         decon_limit1: 0.09,
+        rms_threshold: 0.0,
         adc_limit: 15,
         roi_min_max_ratio: 0.8, // default 0.8
         min_rms_cut: 1.0,  // units???

--- a/cfg/pgrapher/experiment/pdsp/wcls-sp.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/wcls-sp.jsonnet
@@ -202,13 +202,13 @@ local chsel_pipes = [
 local nfsp_pipes = [
   g.pipeline([
                chsel_pipes[n],
-               //magnify_pipes[n],
+               magnify_pipes[n],
                nf_pipes[n],
-               //magnify_pipes2[n],
+               magnify_pipes2[n],
                sp_pipes[n],
-               //magnify_pipes3[n],
-               //magnify_pipes4[n],
-               //magnify_pipes5[n],
+               magnify_pipes3[n],
+               magnify_pipes4[n],
+               magnify_pipes5[n],
              ],
              'nfsp_pipe_%d' % n)
   for n in std.range(0, std.length(tools.anodes) - 1)

--- a/iface/inc/WireCellIface/IChannelNoiseDatabase.h
+++ b/iface/inc/WireCellIface/IChannelNoiseDatabase.h
@@ -51,6 +51,7 @@ namespace WireCell {
 	virtual float coherent_nf_decon_lf_cutoff(int channel) const = 0;
 	virtual float coherent_nf_adc_limit(int channel) const = 0;
 	virtual float coherent_nf_decon_limit1(int channel) const = 0;
+	virtual float coherent_nf_rms_threshold(int channel) const = 0;
 	virtual float coherent_nf_protection_factor(int channel) const = 0;
 	virtual float coherent_nf_min_adc_limit(int channel) const = 0;
 	virtual float coherent_nf_roi_min_max_ratio(int channel) const = 0;

--- a/sigproc/inc/WireCellSigProc/Microboone.h
+++ b/sigproc/inc/WireCellSigProc/Microboone.h
@@ -30,7 +30,7 @@ namespace WireCell {
 	    bool NoisyFilterAlg(WireCell::Waveform::realseq_t& spec, float min_rms, float max_rms);
 
 	    std::vector< std::vector<int> > SignalProtection(WireCell::Waveform::realseq_t& sig, const WireCell::Waveform::compseq_t& respec, int res_offset, int pad_f, int pad_b, float upper_decon_limit = 0.02, float decon_lf_cutoff = 0.08, float upper_adc_limit = 15, float protection_factor = 5.0, float min_adc_limit = 50);
-	    bool Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& chansig, const WireCell::Waveform::realseq_t& medians, const WireCell::Waveform::compseq_t& respec, int res_offset, std::vector< std::vector<int> >& rois, float upper_decon_limit1=0.08, float roi_min_max_ratio=0.8);
+	    bool Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& chansig, const WireCell::Waveform::realseq_t& medians, const WireCell::Waveform::compseq_t& respec, int res_offset, std::vector< std::vector<int> >& rois, float upper_decon_limit1=0.08, float roi_min_max_ratio=0.8, float rms_threshold=0.);
 
 
             // hold common config stuff

--- a/sigproc/inc/WireCellSigProc/OmniChannelNoiseDB.h
+++ b/sigproc/inc/WireCellSigProc/OmniChannelNoiseDB.h
@@ -50,6 +50,7 @@ namespace WireCell {
 	    virtual float coherent_nf_decon_limit(int channel) const;
 	    virtual float coherent_nf_decon_lf_cutoff(int channel) const;
 	    virtual float coherent_nf_decon_limit1(int channel) const;
+	    virtual float coherent_nf_rms_threshold(int channel) const;
 	    virtual float coherent_nf_adc_limit(int channel) const;
 	    virtual float coherent_nf_protection_factor(int channel) const;
 	    virtual float coherent_nf_min_adc_limit(int channel) const;
@@ -119,6 +120,7 @@ namespace WireCell {
 		float decon_lf_cutoff;
 		float adc_limit;
 		float decon_limit1;
+		float rms_threshold;
 		float protection_factor;
 		float min_adc_limit;
 		float roi_min_max_ratio;

--- a/sigproc/inc/WireCellSigProc/SimpleChannelNoiseDB.h
+++ b/sigproc/inc/WireCellSigProc/SimpleChannelNoiseDB.h
@@ -35,6 +35,7 @@ namespace WireCell {
 	    virtual float coherent_nf_decon_limit(int channel) const;
 	    virtual float coherent_nf_decon_lf_cutoff(int channel) const;
 	    virtual float coherent_nf_decon_limit1(int channel) const;
+	    virtual float coherent_nf_rms_threshold(int channel) const;
 	    virtual float coherent_nf_adc_limit(int channel) const;
 	    virtual float coherent_nf_protection_factor(int channel) const;
 	    virtual float coherent_nf_min_adc_limit(int channel) const;
@@ -86,6 +87,7 @@ namespace WireCell {
 	    void set_coherent_nf_decon_limit(const std::vector<int>& channels, float decon_limit);
 	    void set_coherent_nf_decon_lf_cutoff(const std::vector<int>& channels, float decon_lf_cutoff);
 	    void set_coherent_nf_decon_limit1(const std::vector<int>& channels, float decon_limit);
+	    void set_coherent_nf_rms_threshold(const std::vector<int>& channels, float rms_threshold);
 	    void set_coherent_nf_adc_limit(const std::vector<int>& channels, float adc_limit);
 	    void set_coherent_nf_protection_factor(const std::vector<int>& channels, float protection_factor);
 	    void set_coherent_nf_min_adc_limit(const std::vector<int>& channels, float min_adc_limit);
@@ -134,11 +136,11 @@ namespace WireCell {
 	    double m_default_baseline, m_default_gain, m_default_offset;
 	    double m_default_min_rms, m_default_max_rms;
 	    int m_default_pad_f, m_default_pad_b;
-	    float m_default_decon_limit, m_default_decon_lf_cutoff, m_default_adc_limit, m_default_decon_limit1, m_default_protection_factor, m_default_min_adc_limit, m_default_roi_min_max_ratio;
+	    float m_default_decon_limit, m_default_decon_lf_cutoff, m_default_adc_limit, m_default_decon_limit1, m_default_rms_threshold, m_default_protection_factor, m_default_min_adc_limit, m_default_roi_min_max_ratio;
 
 	    std::vector<double> m_baseline, m_gain, m_offset, m_min_rms, m_max_rms;
 	    std::vector<int> m_pad_f, m_pad_b;
-	    std::vector<float> m_decon_limit, m_decon_lf_cutoff, m_adc_limit, m_decon_limit1, m_protection_factor, m_min_adc_limit, m_roi_min_max_ratio;
+	    std::vector<float> m_decon_limit, m_decon_lf_cutoff, m_adc_limit, m_decon_limit1, m_rms_threshold, m_protection_factor, m_min_adc_limit, m_roi_min_max_ratio;
 
 
 	    typedef std::shared_ptr<filter_t> shared_filter_t;

--- a/sigproc/src/Microboone.cxx
+++ b/sigproc/src/Microboone.cxx
@@ -124,19 +124,19 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 
 	if (respec.size() > 0 && (respec.at(0).real()!=1 || respec.at(0).imag()!=0) && res_offset!=0){
 	    int nbin = signal.size();
-	    // WireCell::Waveform::realseq_t signal_roi(nbin,0);
-	 //    for (auto roi: rois){
-		// const int bin0 = std::max(roi.front()-1, 0);
-		// const int binf = std::min(roi.back()+1, nbin-1);
-		// const double m0 = signal[bin0];
-		// const double mf = signal[binf];
-		// const double roi_run = binf - bin0;
-		// const double roi_rise = mf - m0;
-		// for (auto bin : roi) {
-		//     const double m = m0 + (bin - bin0)/roi_run*roi_rise;
-		//     signal_roi.at(bin) = signal.at(bin) - m;
-		// }
-	 //    }
+	    WireCell::Waveform::realseq_t signal_roi(nbin,0);
+	    for (auto roi: rois){
+		const int bin0 = std::max(roi.front()-1, 0);
+		const int binf = std::min(roi.back()+1, nbin-1);
+		const double m0 = signal[bin0];
+		const double mf = signal[binf];
+		const double roi_run = binf - bin0;
+		const double roi_rise = mf - m0;
+		for (auto bin : roi) {
+		    const double m = m0 + (bin - bin0)/roi_run*roi_rise;
+		    signal_roi.at(bin) = signal.at(bin) - m;
+		}
+	    }
 
 	    // do the deconvolution with a very loose low-frequency filter
 	    // WireCell::Waveform::compseq_t signal_roi_freq = WireCell::Waveform::dft(signal_roi);
@@ -213,7 +213,7 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 		}
 	    }
 	    
-	    if (ch==93) {
+	    if (ch==8331) {
 		std::cout << "[Jujube] dbg_info_ch" << ch << " mean    " << mean << std::endl;
 		std::cout << "[Jujube] dbg_info_ch" << ch << " rms     " << rms << std::endl;
 		std::cout << "[Jujube] dbg_info_ch" << ch << " scaling " << scaling << std::endl;

--- a/sigproc/src/Microboone.cxx
+++ b/sigproc/src/Microboone.cxx
@@ -213,26 +213,26 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 		}
 	    }
 	    
-	 //    if (ch==8331) {
-		// std::cout << "[Jujube] dbg_info_ch" << ch << " mean    " << mean << std::endl;
-		// std::cout << "[Jujube] dbg_info_ch" << ch << " rms     " << rms << std::endl;
-		// std::cout << "[Jujube] dbg_info_ch" << ch << " scaling " << scaling << std::endl;
-		// for (auto roi : rois) {
-		//     std::cout << "[Jujube] dbg_info_ch" << ch << " roi     " 
-		//               << roi.front() << " " << roi.back() << " " << flag_replace[roi.front()] << std::endl;
-		// }
-		// for (int j=0;j!=nbin;j++){
-	 // 	    int time_bin = j-res_offset;
-	 // 	    if (time_bin <0) time_bin += nbin;
-		//     if (time_bin >=nbin) time_bin -= nbin;
-		//     std::cout << "[Jujube] dbg_spec_ch" << ch << "\t"
-		//               << signal.at(j) << "\t"
-		//               << medians.at(j) << "\t"
-		//               << signal_roi_decon.at(time_bin) << "\t"
-		//               << temp_medians.at(j) << "\t"
-		//               << std::endl;
-		// }
-	 //    }
+	    if (ch==460) {
+		std::cout << "[Jujube] dbg_info_ch" << ch << " mean    " << mean << std::endl;
+		std::cout << "[Jujube] dbg_info_ch" << ch << " rms     " << rms << std::endl;
+		std::cout << "[Jujube] dbg_info_ch" << ch << " scaling " << scaling << std::endl;
+		for (auto roi : rois) {
+		    std::cout << "[Jujube] dbg_info_ch" << ch << " roi     " 
+		              << roi.front() << " " << roi.back() << " " << flag_replace[roi.front()] << std::endl;
+		}
+		for (int j=0;j!=nbin;j++){
+	 	    int time_bin = j-res_offset;
+	 	    if (time_bin <0) time_bin += nbin;
+		    if (time_bin >=nbin) time_bin -= nbin;
+		    std::cout << "[Jujube] dbg_spec_ch" << ch << "\t"
+		              << signal.at(j) << "\t"
+		              << medians.at(j) << "\t"
+		              << signal_roi_decon.at(time_bin) << "\t"
+		              << temp_medians.at(j) << "\t"
+		              << std::endl;
+		}
+	    }
 
 	    // collection plane, directly subtracti ... 
 	    for (int i=0;i!=nbin;i++){

--- a/sigproc/src/Microboone.cxx
+++ b/sigproc/src/Microboone.cxx
@@ -213,7 +213,7 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 		}
 	    }
 	    
-	    if (ch==460) {
+	    if (ch==26) {
 		std::cout << "[Jujube] dbg_info_ch" << ch << " mean    " << mean << std::endl;
 		std::cout << "[Jujube] dbg_info_ch" << ch << " rms     " << rms << std::endl;
 		std::cout << "[Jujube] dbg_info_ch" << ch << " scaling " << scaling << std::endl;

--- a/sigproc/src/Microboone.cxx
+++ b/sigproc/src/Microboone.cxx
@@ -158,7 +158,7 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 	    std::pair<double,double> temp = Derivations::CalcRMS(signal_roi_decon);
 	    double mean = temp.first;
 	    double rms = temp.second;
-
+	    // std::cout << "[Jujube] dfg_rms_ch" << ch << "\t" << rms << std::endl;
 	    for (size_t i=0;i!=signal_roi_freq.size();i++){
 		signal_roi_decon.at(i) -= mean;
 	    }
@@ -213,7 +213,7 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 		}
 	    }
 	    
-	    if (ch==26) {
+	    if (ch==500) {
 		std::cout << "[Jujube] dbg_info_ch" << ch << " mean    " << mean << std::endl;
 		std::cout << "[Jujube] dbg_info_ch" << ch << " rms     " << rms << std::endl;
 		std::cout << "[Jujube] dbg_info_ch" << ch << " scaling " << scaling << std::endl;

--- a/sigproc/src/Microboone.cxx
+++ b/sigproc/src/Microboone.cxx
@@ -139,8 +139,8 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 	    }
 
 	    // do the deconvolution with a very loose low-frequency filter
-	    // WireCell::Waveform::compseq_t signal_roi_freq = WireCell::Waveform::dft(signal_roi);
-	    WireCell::Waveform::compseq_t signal_roi_freq = WireCell::Waveform::dft(signal);
+	    WireCell::Waveform::compseq_t signal_roi_freq = WireCell::Waveform::dft(signal_roi);
+	    // WireCell::Waveform::compseq_t signal_roi_freq = WireCell::Waveform::dft(signal);
 	    WireCell::Waveform::shrink(signal_roi_freq,respec);
 	    for (size_t i=0;i!=signal_roi_freq.size();i++){
 		double freq;
@@ -155,14 +155,14 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 	    }
 	    WireCell::Waveform::realseq_t signal_roi_decon = WireCell::Waveform::idft(signal_roi_freq);
 
-	    std::pair<double,double> temp = Derivations::CalcRMS(signal_roi_decon);
-	    double mean = temp.first;
-	    double rms = temp.second;
-	    // std::cout << "[Jujube] dfg_rms_ch" << ch << "\t" << rms << std::endl;
-	    for (size_t i=0;i!=signal_roi_freq.size();i++){
-		signal_roi_decon.at(i) -= mean;
-	    }
-	    decon_limit1 = 3.*rms;
+	 //    std::pair<double,double> temp = Derivations::CalcRMS(signal_roi_decon);
+	 //    double mean = temp.first;
+	 //    double rms = temp.second;
+	 //    // std::cout << "[Jujube] dfg_rms_ch" << ch << "\t" << rms << std::endl;
+	 //    for (size_t i=0;i!=signal_roi_freq.size();i++){
+		// signal_roi_decon.at(i) -= mean;
+	 //    }
+	 //    decon_limit1 = 3.*rms;
 	    
 	    std::map<int, bool> flag_replace;
 	    for (auto roi: rois){
@@ -213,9 +213,9 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 		}
 	    }
 	    
-	    if (ch==500) {
-		std::cout << "[Jujube] dbg_info_ch" << ch << " mean    " << mean << std::endl;
-		std::cout << "[Jujube] dbg_info_ch" << ch << " rms     " << rms << std::endl;
+	    if (ch==580) {
+		// std::cout << "[Jujube] dbg_info_ch" << ch << " mean    " << mean << std::endl;
+		// std::cout << "[Jujube] dbg_info_ch" << ch << " rms     " << rms << std::endl;
 		std::cout << "[Jujube] dbg_info_ch" << ch << " scaling " << scaling << std::endl;
 		for (auto roi : rois) {
 		    std::cout << "[Jujube] dbg_info_ch" << ch << " roi     " 

--- a/sigproc/src/Microboone.cxx
+++ b/sigproc/src/Microboone.cxx
@@ -213,26 +213,26 @@ bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& 
 		}
 	    }
 	    
-	    if (ch==8331) {
-		std::cout << "[Jujube] dbg_info_ch" << ch << " mean    " << mean << std::endl;
-		std::cout << "[Jujube] dbg_info_ch" << ch << " rms     " << rms << std::endl;
-		std::cout << "[Jujube] dbg_info_ch" << ch << " scaling " << scaling << std::endl;
-		for (auto roi : rois) {
-		    std::cout << "[Jujube] dbg_info_ch" << ch << " roi     " 
-		              << roi.front() << " " << roi.back() << " " << flag_replace[roi.front()] << std::endl;
-		}
-		for (int j=0;j!=nbin;j++){
-	 	    int time_bin = j-res_offset;
-	 	    if (time_bin <0) time_bin += nbin;
-		    if (time_bin >=nbin) time_bin -= nbin;
-		    std::cout << "[Jujube] dbg_spec_ch" << ch << "\t"
-		              << signal.at(j) << "\t"
-		              << medians.at(j) << "\t"
-		              << signal_roi_decon.at(time_bin) << "\t"
-		              << temp_medians.at(j) << "\t"
-		              << std::endl;
-		}
-	    }
+	 //    if (ch==8331) {
+		// std::cout << "[Jujube] dbg_info_ch" << ch << " mean    " << mean << std::endl;
+		// std::cout << "[Jujube] dbg_info_ch" << ch << " rms     " << rms << std::endl;
+		// std::cout << "[Jujube] dbg_info_ch" << ch << " scaling " << scaling << std::endl;
+		// for (auto roi : rois) {
+		//     std::cout << "[Jujube] dbg_info_ch" << ch << " roi     " 
+		//               << roi.front() << " " << roi.back() << " " << flag_replace[roi.front()] << std::endl;
+		// }
+		// for (int j=0;j!=nbin;j++){
+	 // 	    int time_bin = j-res_offset;
+	 // 	    if (time_bin <0) time_bin += nbin;
+		//     if (time_bin >=nbin) time_bin -= nbin;
+		//     std::cout << "[Jujube] dbg_spec_ch" << ch << "\t"
+		//               << signal.at(j) << "\t"
+		//               << medians.at(j) << "\t"
+		//               << signal_roi_decon.at(time_bin) << "\t"
+		//               << temp_medians.at(j) << "\t"
+		//               << std::endl;
+		// }
+	 //    }
 
 	    // collection plane, directly subtracti ... 
 	    for (int i=0;i!=nbin;i++){

--- a/sigproc/src/OmniChannelNoiseDB.cxx
+++ b/sigproc/src/OmniChannelNoiseDB.cxx
@@ -40,6 +40,7 @@ OmniChannelNoiseDB::ChannelInfo::ChannelInfo()
     , decon_lf_cutoff(0.08)
     , adc_limit(0.0)
     , decon_limit1(0.08)
+    , rms_threshold(0.0)
     , protection_factor(5.0)
     , min_adc_limit(50)
     , roi_min_max_ratio(0.8)
@@ -493,6 +494,14 @@ void OmniChannelNoiseDB::update_channels(Json::Value cfg)
             //dbget(ch).decon_limit1 = val;
             get_ci(ch).decon_limit1 = val;
         }
+    }    if (cfg.isMember("rms_threshold")) {
+        float val = cfg["rms_threshold"].asDouble();
+        dump_cfg("rmsthreshold", chans, val);
+        for (int ch : chans) {
+            //m_db.at(ch).rms_threshold = val;
+            //dbget(ch).rms_threshold = val;
+            get_ci(ch).rms_threshold = val;
+        }
     }
     if (cfg.isMember("adc_limit")) {
         float val = cfg["adc_limit"].asDouble();
@@ -696,6 +705,11 @@ float OmniChannelNoiseDB::coherent_nf_decon_lf_cutoff(int channel) const
 float OmniChannelNoiseDB::coherent_nf_decon_limit1(int channel) const
 {
     return dbget(channel).decon_limit1;
+}
+
+float OmniChannelNoiseDB::coherent_nf_rms_threshold(int channel) const
+{
+    return dbget(channel).rms_threshold;
 }
 
 float OmniChannelNoiseDB::coherent_nf_adc_limit(int channel) const

--- a/sigproc/src/SimpleChannelNoiseDB.cxx
+++ b/sigproc/src/SimpleChannelNoiseDB.cxx
@@ -26,6 +26,7 @@ SimpleChannelNoiseDB::SimpleChannelNoiseDB(double tick, int nsamples)
     , m_default_decon_lf_cutoff(0.08)
     , m_default_adc_limit(15.0)
     , m_default_decon_limit1(0.08)
+    , m_default_rms_threshold(0.0)
     , m_default_protection_factor(5.0)
     , m_default_min_adc_limit(50)
     , m_default_roi_min_max_ratio(0.8)
@@ -131,6 +132,15 @@ float SimpleChannelNoiseDB::coherent_nf_decon_limit1(int channel) const
 	return m_decon_limit1[ind];
     }
     return m_default_decon_limit1;
+}
+
+float SimpleChannelNoiseDB::coherent_nf_rms_threshold(int channel) const
+{
+    const int ind = chind(channel);
+    if (0 <= ind && ind < (int)m_rms_threshold.size()) {
+    return m_rms_threshold[ind];
+    }
+    return m_default_rms_threshold;
 }
 
 float SimpleChannelNoiseDB::coherent_nf_adc_limit(int channel) const
@@ -427,6 +437,15 @@ void SimpleChannelNoiseDB::set_coherent_nf_decon_limit1(const std::vector<int>& 
     for (auto ch : channels) {
 	int ind = chind(ch);
 	set_one(ind, decon_limit1, m_decon_limit1, m_default_decon_limit1);
+    }
+}
+
+void SimpleChannelNoiseDB::set_coherent_nf_rms_threshold(const std::vector<int>& channels, float rms_threshold)
+{
+    //std::cerr << "SimpleChannelNoiseDB: set pad window back on " << channels.size() << " channels: " << pad_b << std::endl;
+    for (auto ch : channels) {
+    int ind = chind(ch);
+    set_one(ind, rms_threshold, m_rms_threshold, m_default_rms_threshold);
     }
 }
 


### PR DESCRIPTION
- Decon the whole signal instead of only within median ROI region

- Judgement of good signal is still performed within median ROI region

- rms_threshold in cfg/pgrapher/experiment/pdsp/chndb-base.jsonnet serves not only as value but also as boolen (switch)