### PR TITLE
Quick fix: conditional compile hio; tbb with multiple events

### DIFF
--- a/tbb/src/TbbFlow.cxx
+++ b/tbb/src/TbbFlow.cxx
@@ -36,17 +36,8 @@ void TbbFlow::configure(const Configuration& cfg)
     m_dfp = Factory::lookup<IDataFlowGraph>(type, name);
 
     m_dfpgraph.configure(cfg["edges"]);
-    
-}
 
-void TbbFlow::execute()
-{
-    if (!m_dfp) {
-    l->critical("TbbFlow: not configured");
-	return;
-    }
-
-    l->info("TbbFlow::Execute");
+    l->info("TbbFlow::connect");
 
     for (auto thc : m_dfpgraph.connections()) {
 	auto tail_tn = get<0>(thc);
@@ -64,7 +55,15 @@ void TbbFlow::execute()
 
 	m_dfp->connect(tail_node, head_node, conn.tail, conn.head);
     }
+    
+}
 
+void TbbFlow::execute()
+{
+    if (!m_dfp) {
+    l->critical("TbbFlow: not configured");
+	return;
+    }
 
     l->info("TbbFlow: run: ");
     m_dfp->run();

--- a/wscript
+++ b/wscript
@@ -58,7 +58,7 @@ def configure(cfg):
         submodules.remove('dfp')
 
     # Remove WCT packages that happen to have same name as external name
-    for pkg,ext in [("root","ROOTSYS"), ("tbb","TBB"), ("tbb","FFTWTHREADS_LIB"), ("cuda","CUDA")]:
+    for pkg,ext in [("root","ROOTSYS"), ("tbb","TBB"), ("tbb","FFTWTHREADS_LIB"), ("cuda","CUDA"), ("hio", "H5CPP_ALL")]:
         have='HAVE_'+ext
         if have in cfg.env or have in cfg.env.define_key:
             continue


### PR DESCRIPTION
This PR contains two quick fixes:
 - conditional compile `hio` package when `hdf5` and `h5cpp` were available
 - re-arranged tbb making it runs with multiple events