### PR TITLE
implement BlobReframer

### DIFF
--- a/cfg/pgrapher/experiment/pdsp/img.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/img.jsonnet
@@ -109,5 +109,38 @@ local wc = import 'wirecell.jsonnet';
                       name="clusterdump-"+aname)
     }.ret,
 
+    // A function that reverts blobs to frames
+    reframing :: function(anode, aname) {
+        ret : g.pnode({
+            type: "BlobReframer",
+            name: "blobreframing-" + aname,
+            data: {
+                frame_tag: "reframe%d" %anode.data.ident,
+            }
+        }, nin=1, nout=1),
+    }.ret,
+
+    // fill ROOT histograms with frames
+    magnify :: function(anode, aname, frame_tag="orig") {
+        ret: g.pnode({
+          type: 'MagnifySink',
+          name: 'magnify-'+aname,
+          data: {
+            output_filename: "magnify-img.root",
+            root_file_mode: 'UPDATE',
+            frames: [frame_tag + anode.data.ident],
+            trace_has_tag: true,
+            anode: wc.tn(anode),
+          },
+        }, nin=1, nout=1),
+    }.ret,
+
+    // the end
+    dumpframes :: function(anode, aname) {
+        ret: g.pnode({
+            type: "DumpFrames",
+            name: "dumpframes-"+aname,
+        }, nin=1, nout=0),
+    }.ret,
 
 }

--- a/cfg/pgrapher/experiment/pdsp/wcls-sig-to-img.fcl
+++ b/cfg/pgrapher/experiment/pdsp/wcls-sig-to-img.fcl
@@ -21,7 +21,7 @@ physics :{
             logsinks: ["stderr:info", "wcls-sig-to-img.log:trace"]
             loglevels: ["trace", "raygrid:trace", "pgraph:info"]
 
-            plugins: ["WireCellGen", "WireCellImg", "WireCellPgraph", "WireCellSio", "WireCellLarsoft"]
+            plugins: ["WireCellGen", "WireCellImg", "WireCellPgraph", "WireCellSio", "WireCellRoot", "WireCellLarsoft"]
 
             inputers: ["wclsCookedFrameSource:sigs" ]
 
@@ -32,6 +32,9 @@ physics :{
             params : {
                // This locates the input raw::RawDigit collection in the art::Event 
                sig_input_label: "raw2sig:gauss"
+
+               // do the BlobReframer
+               use_blob_reframer: "false"
             }
          }
       }

--- a/cfg/pgrapher/experiment/pdsp/wcls-sig-to-img.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/wcls-sig-to-img.jsonnet
@@ -1,4 +1,5 @@
 local sig_input_label = std.extVar("sig_input_label");
+local use_blob_reframer = std.extVar("use_blob_reframer");
 
 local wc = import 'wirecell.jsonnet';
 local g = import 'pgraph.jsonnet';
@@ -56,8 +57,16 @@ local perapa_pipelines = [
         img.tiling(anode, anode.name),
         //img.solving(anode, anode.name),
         img.clustering(anode, anode.name),
+      ]
+
+      + if use_blob_reframer=="true" then [
+        img.reframing(anode, anode.name),
+        img.magnify(anode, anode.name, "reframe"),
+        img.dumpframes(anode, anode.name),
+      ] else [
         img.dump(anode, anode.name, params.lar.drift_speed),
-    ], "img-" + anode.name) for anode in tools.anodes];
+      ], 
+      "img-" + anode.name) for anode in tools.anodes];
 
 local graph = g.intern(innodes=[input],
                        centernodes = [fansel] + perapa_pipelines,

--- a/img/inc/WireCellImg/BlobReframer.h
+++ b/img/inc/WireCellImg/BlobReframer.h
@@ -12,6 +12,7 @@
 
 #include "WireCellIface/IConfigurable.h"
 #include "WireCellIface/IClusterFramer.h"
+#include "WireCellUtil/Logging.h"
 
 namespace WireCell {
 
@@ -20,7 +21,7 @@ namespace WireCell {
         class BlobReframer : public IClusterFramer, public IConfigurable {
         public:
 
-            BlobReframer();
+            BlobReframer(const std::string& frame_tag="reframe");
             virtual ~BlobReframer();
 
             virtual void configure(const WireCell::Configuration& cfg);
@@ -28,6 +29,12 @@ namespace WireCell {
 
             virtual bool operator()(const input_pointer& in, output_pointer& out);
 
+        private:
+            int m_nticks;
+            double m_period;
+            std::string m_frame_tag;
+
+            Log::logptr_t log;
         };
     }
 }

--- a/img/src/BlobReframer.cxx
+++ b/img/src/BlobReframer.cxx
@@ -8,6 +8,8 @@
 
 #include "WireCellImg/BlobReframer.h"
 #include "WireCellUtil/NamedFactory.h"
+#include "WireCellIface/SimpleFrame.h"
+#include "WireCellIface/SimpleTrace.h"
 
 
 WIRECELL_FACTORY(BlobReframer, WireCell::Img::BlobReframer,
@@ -16,7 +18,11 @@ WIRECELL_FACTORY(BlobReframer, WireCell::Img::BlobReframer,
 
 using namespace WireCell;
 
-Img::BlobReframer::BlobReframer()
+Img::BlobReframer::BlobReframer(const std::string& frame_tag)
+: m_nticks(0)
+, m_period(0)
+, m_frame_tag(frame_tag)
+, log(Log::logger("reframe"))
 {
 }
 
@@ -26,11 +32,15 @@ Img::BlobReframer::~BlobReframer()
 
 void Img::BlobReframer::configure(const WireCell::Configuration& cfg)
 {
+  // m_nticks = get(cfg, "nticks", m_nticks);
+  m_frame_tag = get(cfg,"frame_tag",m_frame_tag);
 }
 
 WireCell::Configuration Img::BlobReframer::default_configuration() const
 {
     Configuration cfg;
+    // cfg["nticks"] = m_nticks;
+    cfg["frame_tag"] = m_frame_tag;
     return cfg;
 }
 
@@ -44,10 +54,62 @@ bool Img::BlobReframer::operator()(const input_pointer& in, output_pointer& out)
 
     cluster_indexed_graph_t grind(in->graph());
 
+    WireCell::IFrame::pointer iframe;
+    std::unordered_map<int, ITrace::ChargeSequence> map_charges;
     for (auto iblob : oftype<IBlob::pointer>(grind)) {
-        // to be continued.
+
+        auto islice = iblob->slice();
+        if (!iframe) {
+          // typical values for protoDUNE
+          // period: 0.5us, nticks: 6000
+          iframe = islice->frame();
+          m_period = iframe->tick();
+          {
+            std::vector<int> tbins;
+            for (auto trace : *iframe->traces()) {
+              const int tbin = trace->tbin();
+              const int nbins = trace->charge().size();
+              tbins.push_back(tbin);
+              tbins.push_back(tbin+nbins);
+            }
+            auto mme = std::minmax_element(tbins.begin(), tbins.end());
+            int tbinmin = *mme.first;
+            int tbinmax = *mme.second;
+            m_nticks = tbinmax-tbinmin;
+            log->debug("BlobReframer: nticks={} tbinmin={} tbinmax={}",
+                        m_nticks, tbinmin, tbinmax);     
+          }
+        }
+        int itick = islice->start()/m_period;
+        int nspan = islice->span()/m_period;
+
+        for (auto const& act : islice->activity()) {
+          auto ichan = act.first;
+          if (map_charges.find(ichan->ident()) == map_charges.end()){
+            map_charges.insert(std::make_pair(ichan->ident(), ITrace::ChargeSequence(m_nticks,0.0)));
+          }
+          float q = act.second;
+          for (int ns=0; ns<nspan; ns++) {
+            map_charges.at(ichan->ident()).at(itick+ ns) += q/(float)nspan;
+          }
+        }
+
     }
 
+    ITrace::vector* itraces = new ITrace::vector; // will become shared_ptr.
+    for (auto const& it : map_charges) {
+      int ident = it.first;
+      auto charge = it.second;
+      // Save the waveform densely, including zeros.
+      SimpleTrace *trace = new SimpleTrace(ident, 0, charge);
+      itraces->push_back(ITrace::pointer(trace));      
+    }
+
+    SimpleFrame* sframe = new SimpleFrame(iframe->ident(), iframe->time(),
+                                          ITrace::shared_vector(itraces),
+                                          iframe->tick());
+    sframe->tag_frame(m_frame_tag);
+    out = IFrame::pointer(sframe);
     
     return true;
 }


### PR DESCRIPTION
I start to work on the BlobReframer. To use it, one can open the option in `wcls-sig-to-img.fcl` with `use_blob_reframer: "true"`. Here is the performance (gauss frame vs the reframed version).

![image](https://user-images.githubusercontent.com/10663117/67581866-bd5f6e80-f716-11e9-91f7-a4038ba313d4.png)

There is some issue in scale, I will look into more about the ISlice::activity(). But I would like to push this piece of code into master now.

