### PR TITLE
Tuning the DepoSplat with SimChannelSink

### DIFF
--- a/gen/inc/WireCellGen/DepoSplat.h
+++ b/gen/inc/WireCellGen/DepoSplat.h
@@ -22,6 +22,8 @@ namespace WireCell {
             virtual ITrace::vector process_face(IAnodeFace::pointer face,
                                                 const IDepo::vector& depos);
 
+            /// SPD logger
+            Log::logptr_t l;
 
         };
     }

--- a/gen/src/DepoSplat.cxx
+++ b/gen/src/DepoSplat.cxx
@@ -1,4 +1,5 @@
 #include "WireCellGen/DepoSplat.h"
+#include "WireCellGen/GaussianDiffusion.h"
 #include "WireCellIface/SimpleTrace.h"
 
 #include "WireCellUtil/Binning.h"
@@ -16,6 +17,7 @@ using namespace WireCell;
 
 Gen::DepoSplat::DepoSplat()
     : Ductor()
+    , l(Log::logger("sim"))
 {
 }
 
@@ -23,11 +25,15 @@ Gen::DepoSplat::~DepoSplat()
 {
 }
 
-                                  
+
 ITrace::vector Gen::DepoSplat::process_face(IAnodeFace::pointer face,
                                             const IDepo::vector& depos)
 
 {
+    const int time_offset = 2; // # of ticks
+    // const double difusion_scaler = 6.;
+    const double charge_scaler = 1.; //18.; 
+
     // channel-charge map
     std::unordered_map<int, std::vector<float> > chch;
 
@@ -56,32 +62,84 @@ ITrace::vector Gen::DepoSplat::process_face(IAnodeFace::pointer face,
         int idepo = 0;
         for (auto depo : depos) {
 
-            const double pwid = m_nsigma * depo->extent_tran();
+            // const double tsig = depo->extent_long() * difusion_scaler;
+            // const double psig = depo->extent_tran() * difusion_scaler;
+            
+            double sigma_L = depo->extent_long();
+            double sigma_T = depo->extent_tran();
+
+            // l->info("dirft: sigma_L: {} sigma_T: {}", sigma_L, sigma_T);
+
+            if (true) {
+              int nrebin=1;
+              double time_slice_width = nrebin * m_drift_speed * m_tick; // units::mm
+              double add_sigma_L = 1.428249  * time_slice_width / nrebin / (m_tick/units::us); // units::mm
+              sigma_L = sqrt( pow(depo->extent_long(),2) + pow(add_sigma_L,2) );// / time_slice_width;
+            }
+
+            if (true) {
+              double add_sigma_T = wbins.binsize();
+              if (iplane==0) add_sigma_T *= (0.402993*0.3);
+              else if (iplane==1) add_sigma_T *= (0.402993*0.5);
+              else if (iplane==2) add_sigma_T *= (0.188060*0.2);
+              sigma_T = sqrt( pow(depo->extent_tran(),2) + pow(add_sigma_T,2) ); // / wbins.binsize();
+            }
+
+            // l->info("final: sigma_L: {} sigma_T: {}", sigma_L, sigma_T);
+
+            const double tsig = sigma_L/m_drift_speed;
+            const double psig = sigma_T;
+
+            const double pwid = m_nsigma * psig;
             const double pcen = pimpos->distance(depo->pos());
 
-            const double twid = m_nsigma*depo->extent_long();
+            const double twid = m_nsigma * tsig;
             const double tcen = depo->time();
 
             const int pbeg = std::max(wbins.bin(pcen-pwid), 0);
             const int pend = std::min(wbins.bin(pcen+pwid)+1, (int)wires.size());
-            const int tbeg = tbins.bin(tcen-twid); // fixme what limits
-            const int tend = tbins.bin(tcen+twid)+1; //  to enforce here?
+            const int tbeg = std::max(tbins.bin(tcen-twid), 0); // fixme what limits
+            const int tend = std::min(tbins.bin(tcen+twid)+1, tbins.nbins()-1); //  to enforce here?
+
+            if(tbeg > tend) continue;
             
-            // if (idepo == 0) {
-            //     std::cerr << "splat: depo=" << depo->pos()/units::mm << "mm "
-            //               << "@" << depo->time()/units::ms<< " ms "
-            //               << "p=(" << pcen << "+-" << pwid << "), t=(" << tcen << "+=" << twid << ") "
-            //               << "pi=[" << pbeg << " " << pend << "], ti=[" << tbeg << " " << tend << "]\n";
-            // }
+            if(tbeg<0) continue;
+
+            Gen::GausDesc time_desc(tcen, tsig);
+            Gen::GausDesc pitch_desc(pcen, psig);
+
+            auto gd = std::make_shared<Gen::GaussianDiffusion>(depo, time_desc, pitch_desc);
+            gd->set_sampling(tbins, wbins, m_nsigma, 0, 1);
+            const auto patch = gd->patch();
+
+            // std::stringstream ss;
+            // ss << "splat: depo=" << depo->pos()/units::mm << "mm "
+            //           << "@" << depo->time()*m_drift_speed<< " mm "
+            //           << "p=(" << pcen << "+-" << pwid << "), t=(" << tcen << "+-" << twid << ") "
+            //           << "pi=[" << pbeg << " " << pend << "], ti=[" << tbeg << " " << tend << "]";
+            // l->info(ss.str());
+            // l->info("tsig: {} m_drift_speed: {} ", tsig, m_drift_speed);
+            // l->info("psig: {}", psig);
+            // l->info("tbins: ({},{}) nbin: {}", tbins.min(), tbins.max(), tbins.nbins() );
+            // l->info("wbins: ({},{}) nbin: {}", wbins.min(), wbins.max(), wbins.nbins() );
+            // l->info("tbin range: ({},{})", tbeg, tend );
+            // l->info("wbin range: ({},{})", pbeg, pend );
+            // l->info("gd->offset: {}, {}", gd->toffset_bin(), gd->poffset_bin());
+            // l->info("patch bins: {}, {}", patch.cols(), patch.rows());
+            // l->info("\n");
 
             for (int ip = pbeg; ip < pend; ++ip) {
+                auto irow = ip - gd->poffset_bin();
+                if (irow <0 or irow >= patch.rows()) continue;
                 auto iwire = wires[ip];
                 auto& charge = chch[iwire->channel()];
                 if ((int)charge.size() < tend) {
                     charge.resize(tend, 0.0);
                 }
                 for (int it = tbeg; it < tend; ++it) {
-                    charge[it] += std::abs(depo->charge());
+                    auto icol = it - gd->toffset_bin() + time_offset;
+                    if (icol <0 or icol >= patch.cols()) continue;
+                    charge[it] += std::abs(patch(irow, icol)*charge_scaler);
                 }
             }
             ++idepo;

--- a/gen/src/Ductor.cxx
+++ b/gen/src/Ductor.cxx
@@ -221,6 +221,13 @@ void Gen::Ductor::process(output_queue& frames)
     }
 
     auto frame = make_shared<SimpleFrame>(m_frame_count, m_start_time, traces, m_tick);
+    IFrame::trace_list_t indices(traces.size());
+    for (size_t ind=0; ind<traces.size(); ++ind) {
+        indices[ind] = ind;
+    }
+    std::string trace_tag("ductor");
+    frame->tag_traces(string("ductor")+std::to_string(m_anode->ident()),indices);
+    frame->tag_frame("ductor");
     frames.push_back(frame);
     l->debug("made frame: {} with {} traces @ {}ms",
              m_frame_count, traces.size(), m_start_time/units::ms);


### PR DESCRIPTION
Tuned the `DepoSplat` according to [`SimChannelSink`](https://cdcvs.fnal.gov/redmine/projects/larwirecell/repository/revisions/master/entry/larwirecell/Components/SimChannelSink.cxx)

- Charge distributed with `GaussianDiffusion`
- `extent_long` translated to time from space as it should
- empirical modification of sigmas borrowed from `SimChannelSink`

w/o this PR:
![image](https://user-images.githubusercontent.com/10383186/68336795-23e87300-00ad-11ea-8085-722335db76a3.png)

w/ this PR:
![image](https://user-images.githubusercontent.com/10383186/68337075-bbe65c80-00ad-11ea-8303-7bdedf167add.png)

related talks:
https://indico.bnl.gov/event/7004/contributions/32663/
https://indico.bnl.gov/event/7024/contributions/32779/
https://indico.bnl.gov/event/7058/contributions/32954/

In addition, tagged traces from the `Ductor` for later use