### PR TITLE
Introducing Plan Caching FFT

### DIFF
--- a/sigproc/inc/WireCellSigProc/Microboone.h
+++ b/sigproc/inc/WireCellSigProc/Microboone.h
@@ -29,8 +29,8 @@ namespace WireCell {
 	    bool RemoveFilterFlags(WireCell::Waveform::realseq_t& sig);
 	    bool NoisyFilterAlg(WireCell::Waveform::realseq_t& spec, float min_rms, float max_rms);
 
-	    std::vector< std::vector<int> > SignalProtection(WireCell::Waveform::realseq_t& sig, const WireCell::Waveform::compseq_t& respec, int res_offset, int pad_f, int pad_b, float upper_decon_limit = 0.02, float decon_lf_cutoff = 0.08, float upper_adc_limit = 15, float protection_factor = 5.0, float min_adc_limit = 50);
-	    bool Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& chansig, const WireCell::Waveform::realseq_t& medians, const WireCell::Waveform::compseq_t& respec, int res_offset, std::vector< std::vector<int> >& rois, float upper_decon_limit1=0.08, float roi_min_max_ratio=0.8, float rms_threshold=0.);
+	    std::vector< std::vector<int> > SignalProtection(WireCell::Waveform::FFT & fft, WireCell::Waveform::realseq_t& sig, const WireCell::Waveform::compseq_t& respec, int res_offset, int pad_f, int pad_b, float upper_decon_limit = 0.02, float decon_lf_cutoff = 0.08, float upper_adc_limit = 15, float protection_factor = 5.0, float min_adc_limit = 50);
+	    bool Subtract_WScaling(WireCell::Waveform::FFT & fft, WireCell::IChannelFilter::channel_signals_t& chansig, const WireCell::Waveform::realseq_t& medians, const WireCell::Waveform::compseq_t& respec, int res_offset, std::vector< std::vector<int> >& rois, float upper_decon_limit1=0.08, float roi_min_max_ratio=0.8, float rms_threshold=0.);
 
 
             // hold common config stuff
@@ -86,6 +86,7 @@ namespace WireCell {
 
             private:
         	float m_rms_threshold;
+            WireCell::Waveform::FFT fft;
 	    };
 
 

--- a/sigproc/inc/WireCellSigProc/Protodune.h
+++ b/sigproc/inc/WireCellSigProc/Protodune.h
@@ -20,9 +20,9 @@ namespace WireCell {
 	namespace Protodune {
 
 		bool LinearInterpSticky(WireCell::Waveform::realseq_t& signal, std::vector<std::pair<int,int> >& st_ranges, float stky_sig_like_val, float stky_sig_like_rms);
-		bool FftInterpSticky(WireCell::Waveform::realseq_t& signal, std::vector<std::pair<int,int> >& st_ranges);
+		bool FftInterpSticky(WireCell::Waveform::realseq_t& signal, std::vector<std::pair<int,int> >& st_ranges, WireCell::Waveform::FFT & fft);
 		bool FftShiftSticky(WireCell::Waveform::realseq_t& signal, double toffset, std::vector<std::pair<int,int> >& st_ranges);
-		bool FftScaling(WireCell::Waveform::realseq_t& signal, int nsamples);
+		bool FftScaling(WireCell::Waveform::realseq_t& signal, int nsamples, WireCell::Waveform::FFT & fft);
 
         // hold common config stuff
         class ConfigFilterBase : public WireCell::IConfigurable {
@@ -89,6 +89,8 @@ namespace WireCell {
 	    float m_stky_sig_like_val;
 	    float m_stky_sig_like_rms;
 	    int m_stky_max_len;
+
+        WireCell::Waveform::FFT fft;
                 
 	    };
 
@@ -113,6 +115,7 @@ namespace WireCell {
 		private:
 		Diagnostics::Partial m_check_partial; // at least need to expose them to configuration
 		std::map<int, int> m_resmp; // ch => orignal smp input
+        WireCell::Waveform::FFT fft;
 
 	    };
 

--- a/util/inc/WireCellUtil/Waveform.h
+++ b/util/inc/WireCellUtil/Waveform.h
@@ -9,6 +9,10 @@
 #include <algorithm>
 #include <string>
 
+// for FFT
+#include <Eigen/Core>
+#include <unsupported/Eigen/FFT>
+
 namespace WireCell {
 
 
@@ -231,6 +235,24 @@ namespace WireCell {
 
 	/// Return the smallest, most frequent value to appear in vector.
 	short most_frequent(const std::vector<short>& vals);
+
+    class FFT {
+        public:
+        FFT(){}
+        inline compseq_t dft(realseq_t wave) {
+            auto v = Eigen::Map<Eigen::VectorXf>(wave.data(), wave.size());
+            Eigen::VectorXcf ret = trans.fwd(v);
+            return compseq_t(ret.data(), ret.data()+ret.size());
+        }
+        inline realseq_t idft(compseq_t spec) {
+            auto v = Eigen::Map<Eigen::VectorXcf>(spec.data(), spec.size());
+            Eigen::VectorXf ret;
+            trans.inv(ret, v);
+            return realseq_t(ret.data(), ret.data()+ret.size());
+        }
+        private:
+        Eigen::FFT<Waveform::real_t> trans;
+    };
 
     }
 }


### PR DESCRIPTION
Exploit the "Plan Caching" feature in Eigen FFTW implementation.
In Noise Filtering, do FFT this way could reduce the total computing load also flatten the CPU usage when multi-threading.

Details in this talk:
https://indico.bnl.gov/event/7117/contributions/33176/

In this PR, this Plan Caching FFT was used in `pdStickyCodeMitig`, `pdOneChannelNoise` and `mbCoherentNoiseSub`. These are all filters with FFT used in the current NF.

CPU and Memory usage w/ and w/o Plan Caching  for NF chain:
![image](https://user-images.githubusercontent.com/10383186/69374568-516c1980-0c74-11ea-9532-120b48b40d96.png)


We did a integrated test with a nf-sp-ana chain, the CPU and memory usage w/ and w/o Plan Caching looks like this:
![image](https://user-images.githubusercontent.com/10383186/69374487-25509880-0c74-11ea-8bc6-bb4cc2ab4f5e.png)

The deconvoluted frames are identical:
![image](https://user-images.githubusercontent.com/10383186/69374662-7f515e00-0c74-11ea-89a4-6f6dd0ac5278.png)


