### PR TITLE
Using static Eigen::FFT

### DIFF
--- a/sigproc/inc/WireCellSigProc/Microboone.h
+++ b/sigproc/inc/WireCellSigProc/Microboone.h
@@ -29,8 +29,8 @@ namespace WireCell {
 	    bool RemoveFilterFlags(WireCell::Waveform::realseq_t& sig);
 	    bool NoisyFilterAlg(WireCell::Waveform::realseq_t& spec, float min_rms, float max_rms);
 
-	    std::vector< std::vector<int> > SignalProtection(WireCell::Waveform::FFT & fft, WireCell::Waveform::realseq_t& sig, const WireCell::Waveform::compseq_t& respec, int res_offset, int pad_f, int pad_b, float upper_decon_limit = 0.02, float decon_lf_cutoff = 0.08, float upper_adc_limit = 15, float protection_factor = 5.0, float min_adc_limit = 50);
-	    bool Subtract_WScaling(WireCell::Waveform::FFT & fft, WireCell::IChannelFilter::channel_signals_t& chansig, const WireCell::Waveform::realseq_t& medians, const WireCell::Waveform::compseq_t& respec, int res_offset, std::vector< std::vector<int> >& rois, float upper_decon_limit1=0.08, float roi_min_max_ratio=0.8, float rms_threshold=0.);
+	    std::vector< std::vector<int> > SignalProtection(WireCell::Waveform::realseq_t& sig, const WireCell::Waveform::compseq_t& respec, int res_offset, int pad_f, int pad_b, float upper_decon_limit = 0.02, float decon_lf_cutoff = 0.08, float upper_adc_limit = 15, float protection_factor = 5.0, float min_adc_limit = 50);
+	    bool Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& chansig, const WireCell::Waveform::realseq_t& medians, const WireCell::Waveform::compseq_t& respec, int res_offset, std::vector< std::vector<int> >& rois, float upper_decon_limit1=0.08, float roi_min_max_ratio=0.8, float rms_threshold=0.);
 
 
             // hold common config stuff
@@ -86,7 +86,6 @@ namespace WireCell {
 
             private:
         	float m_rms_threshold;
-            WireCell::Waveform::FFT fft;
 	    };
 
 

--- a/sigproc/inc/WireCellSigProc/Protodune.h
+++ b/sigproc/inc/WireCellSigProc/Protodune.h
@@ -20,9 +20,9 @@ namespace WireCell {
 	namespace Protodune {
 
 		bool LinearInterpSticky(WireCell::Waveform::realseq_t& signal, std::vector<std::pair<int,int> >& st_ranges, float stky_sig_like_val, float stky_sig_like_rms);
-		bool FftInterpSticky(WireCell::Waveform::realseq_t& signal, std::vector<std::pair<int,int> >& st_ranges, WireCell::Waveform::FFT & fft);
+		bool FftInterpSticky(WireCell::Waveform::realseq_t& signal, std::vector<std::pair<int,int> >& st_ranges);
 		bool FftShiftSticky(WireCell::Waveform::realseq_t& signal, double toffset, std::vector<std::pair<int,int> >& st_ranges);
-		bool FftScaling(WireCell::Waveform::realseq_t& signal, int nsamples, WireCell::Waveform::FFT & fft);
+		bool FftScaling(WireCell::Waveform::realseq_t& signal, int nsamples);
 
         // hold common config stuff
         class ConfigFilterBase : public WireCell::IConfigurable {
@@ -89,8 +89,6 @@ namespace WireCell {
 	    float m_stky_sig_like_val;
 	    float m_stky_sig_like_rms;
 	    int m_stky_max_len;
-
-        WireCell::Waveform::FFT fft;
                 
 	    };
 
@@ -115,7 +113,6 @@ namespace WireCell {
 		private:
 		Diagnostics::Partial m_check_partial; // at least need to expose them to configuration
 		std::map<int, int> m_resmp; // ch => orignal smp input
-        WireCell::Waveform::FFT fft;
 
 	    };
 

--- a/sigproc/src/Microboone.cxx
+++ b/sigproc/src/Microboone.cxx
@@ -52,7 +52,7 @@ double filter_low_loose(double freq){
 }
 
 
-bool Microboone::Subtract_WScaling(WireCell::Waveform::FFT & fft, WireCell::IChannelFilter::channel_signals_t& chansig,
+bool Microboone::Subtract_WScaling(WireCell::IChannelFilter::channel_signals_t& chansig,
 				   const WireCell::Waveform::realseq_t& medians,
 				   const WireCell::Waveform::compseq_t& respec,
 				   int res_offset,
@@ -144,7 +144,7 @@ bool Microboone::Subtract_WScaling(WireCell::Waveform::FFT & fft, WireCell::ICha
 	    }
 
 	    // do the deconvolution with a very loose low-frequency filter
-	    WireCell::Waveform::compseq_t signal_roi_freq = fft.dft(signal_roi);
+	    WireCell::Waveform::compseq_t signal_roi_freq = WireCell::Waveform::dft(signal_roi);
 	    WireCell::Waveform::shrink(signal_roi_freq,respec);
 	    for (size_t i=0;i!=signal_roi_freq.size();i++){
 		double freq;
@@ -157,7 +157,7 @@ bool Microboone::Subtract_WScaling(WireCell::Waveform::FFT & fft, WireCell::ICha
 		std::complex<float> factor = filter_time(freq)*filter_low_loose(freq);
 		signal_roi_freq.at(i) = signal_roi_freq.at(i) * factor;
 	    }
-	    WireCell::Waveform::realseq_t signal_roi_decon = fft.idft(signal_roi_freq);
+	    WireCell::Waveform::realseq_t signal_roi_decon = WireCell::Waveform::idft(signal_roi_freq);
 
 	    if (rms_threshold) {
 		std::pair<double,double> temp = Derivations::CalcRMS(signal_roi_decon);
@@ -275,7 +275,7 @@ bool Microboone::Subtract_WScaling(WireCell::Waveform::FFT & fft, WireCell::ICha
     return true;
 }
 
-std::vector< std::vector<int> > Microboone::SignalProtection(WireCell::Waveform::FFT & fft, WireCell::Waveform::realseq_t& medians, const WireCell::Waveform::compseq_t& respec, int res_offset, int pad_f, int pad_b, float upper_decon_limit, float decon_lf_cutoff, float upper_adc_limit, float protection_factor, float min_adc_limit)
+std::vector< std::vector<int> > Microboone::SignalProtection(WireCell::Waveform::realseq_t& medians, const WireCell::Waveform::compseq_t& respec, int res_offset, int pad_f, int pad_b, float upper_decon_limit, float decon_lf_cutoff, float upper_adc_limit, float protection_factor, float min_adc_limit)
 {
    
   
@@ -349,7 +349,7 @@ std::vector< std::vector<int> > Microboone::SignalProtection(WireCell::Waveform:
     if (respec.size() > 0 && (respec.at(0).real()!=1 || respec.at(0).imag()!=0) && res_offset!=0){
 	//std::cout << nbin << std::endl;
 
-     	WireCell::Waveform::compseq_t medians_freq =fft.dft(medians);
+     	WireCell::Waveform::compseq_t medians_freq =WireCell::Waveform::dft(medians);
      	WireCell::Waveform::shrink(medians_freq,respec);
 	
     	for (size_t i=0;i!=medians_freq.size();i++){
@@ -363,7 +363,7 @@ std::vector< std::vector<int> > Microboone::SignalProtection(WireCell::Waveform:
     	    std::complex<float> factor = filter_time(freq)*filter_low(freq, decon_lf_cutoff);
     	    medians_freq.at(i) = medians_freq.at(i) * factor;
     	}
-    	WireCell::Waveform::realseq_t medians_decon = fft.idft(medians_freq);
+    	WireCell::Waveform::realseq_t medians_decon = WireCell::Waveform::idft(medians_freq);
 	
     	temp = Derivations::CalcRMS(medians_decon);
     	mean = temp.first;
@@ -960,7 +960,7 @@ Microboone::CoherentNoiseSub::apply(channel_signals_t& chansig) const
     //std::cout << achannel << std::endl;
 
     // do the signal protection and adaptive baseline
-    std::vector< std::vector<int> > rois = Microboone::SignalProtection(const_cast<WireCell::Waveform::FFT&>(fft),medians,respec,res_offset,pad_f,pad_b,decon_limit, decon_lf_cutoff, adc_limit, protection_factor, min_adc_limit);
+    std::vector< std::vector<int> > rois = Microboone::SignalProtection(medians,respec,res_offset,pad_f,pad_b,decon_limit, decon_lf_cutoff, adc_limit, protection_factor, min_adc_limit);
 
     // if (achannel == 3840){
     // 	std::cout << "Xin1: " << rois.size() << std::endl;
@@ -972,7 +972,7 @@ Microboone::CoherentNoiseSub::apply(channel_signals_t& chansig) const
     //std::cerr <<"\tSigprotection done: " << chansig.size() << " " << medians.size() << " " << medians.at(100) << " " << medians.at(101) << std::endl;
 
     // calculate the scaling coefficient and subtract
-    Microboone::Subtract_WScaling(const_cast<WireCell::Waveform::FFT&>(fft),chansig, medians, respec, res_offset, rois, decon_limit1, roi_min_max_ratio, m_rms_threshold);
+    Microboone::Subtract_WScaling(chansig, medians, respec, res_offset, rois, decon_limit1, roi_min_max_ratio, m_rms_threshold);
 
     
     // WireCell::IChannelFilter::signal_t& signal = chansig.begin()->second;

--- a/util/src/Waveform.cxx
+++ b/util/src/Waveform.cxx
@@ -138,20 +138,20 @@ std::pair<int, int> WireCell::Waveform::edge(const realseq_t& wave)
 }
 
 
+thread_local static Eigen::FFT<Waveform::real_t> gEigenFFT;
+
 Waveform::compseq_t WireCell::Waveform::dft(realseq_t wave)
 {
     auto v = Eigen::Map<Eigen::VectorXf>(wave.data(), wave.size());
-    Eigen::FFT<Waveform::real_t> trans;
-    Eigen::VectorXcf ret = trans.fwd(v);
+    Eigen::VectorXcf ret = gEigenFFT.fwd(v);
     return compseq_t(ret.data(), ret.data()+ret.size());
 }
 
 Waveform::realseq_t WireCell::Waveform::idft(compseq_t spec)
 {
-    Eigen::FFT<Waveform::real_t> trans;
     auto v = Eigen::Map<Eigen::VectorXcf>(spec.data(), spec.size());
     Eigen::VectorXf ret;
-    trans.inv(ret, v);
+    gEigenFFT.inv(ret, v);
     return realseq_t(ret.data(), ret.data()+ret.size());
 }
 


### PR DESCRIPTION
@brettviren and I checked the possibility of using `static Eigen::FFT` instead of a `FFT` class holding `Eigen::FFT` for each node.
This should in principle increase the reusing of the cached plans in the `Eigen::FFT`. Such reduce memory and CPU usage.

Right now, I am not 100% convinced that this `static Eigen::FFT` is thread safe. Even some initial tests didn't show any issues.

For now I just put a `thread_local` specifier to be safe:
https://en.cppreference.com/w/cpp/language/storage_duration
We could remove that in the future.

Changes include FFT used in `Array.cxx` and `Waveform.cxx`
Filters in `Protodune` and `Microboone` are reverted to use the function form FFT.

CPU and memory profiling based on nf-sp-ana chain showed similar performance compared with #17 
![image](https://user-images.githubusercontent.com/10383186/69579484-9491f980-0fa0-11ea-9898-e5077be7e410.png)

![image](https://user-images.githubusercontent.com/10383186/69579465-880da100-0fa0-11ea-8a86-87e649802735.png)


SP results are identical with #17 and are omitted here.
