### PR TITLE
Wrapped adjacency

### DIFF
--- a/cfg/pgrapher/experiment/pdsp/sp.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/sp.jsonnet
@@ -60,7 +60,7 @@ function(params, tools, override = {}) {
       shrink_roi_tag: 'shrink_roi%d' % anode.data.ident,
       extend_roi_tag: 'extend_roi%d' % anode.data.ident,
 
-      isWarped: false,
+      isWraped: true,
 
     } + override,
   }, nin=1, nout=1, uses=[anode, tools.field] + pc.uses + spfilt),

--- a/cfg/pgrapher/experiment/pdsp/sp.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/sp.jsonnet
@@ -60,6 +60,8 @@ function(params, tools, override = {}) {
       shrink_roi_tag: 'shrink_roi%d' % anode.data.ident,
       extend_roi_tag: 'extend_roi%d' % anode.data.ident,
 
+      isWarped: false,
+
     } + override,
   }, nin=1, nout=1, uses=[anode, tools.field] + pc.uses + spfilt),
 

--- a/cfg/pgrapher/experiment/pdsp/sp.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/sp.jsonnet
@@ -60,7 +60,7 @@ function(params, tools, override = {}) {
       shrink_roi_tag: 'shrink_roi%d' % anode.data.ident,
       extend_roi_tag: 'extend_roi%d' % anode.data.ident,
 
-      isWraped: true,
+      isWraped: false,
 
     } + override,
   }, nin=1, nout=1, uses=[anode, tools.field] + pc.uses + spfilt),

--- a/cfg/pgrapher/experiment/pdsp/sp.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/sp.jsonnet
@@ -60,7 +60,7 @@ function(params, tools, override = {}) {
       shrink_roi_tag: 'shrink_roi%d' % anode.data.ident,
       extend_roi_tag: 'extend_roi%d' % anode.data.ident,
 
-      isWraped: false,
+      isWrapped: false,
 
     } + override,
   }, nin=1, nout=1, uses=[anode, tools.field] + pc.uses + spfilt),

--- a/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
@@ -222,6 +222,7 @@ namespace WireCell {
       std::string m_extend_roi_tag;
 
       bool m_use_multi_plane_protection;
+      bool m_isWraped;
 
       // If true, safe output as a sparse frame.  Traces will only
       // cover segments of waveforms which have non-zero signal

--- a/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
@@ -222,7 +222,7 @@ namespace WireCell {
       std::string m_extend_roi_tag;
 
       bool m_use_multi_plane_protection;
-      bool m_isWraped;
+      bool m_isWrapped;
 
       // If true, safe output as a sparse frame.  Traces will only
       // cover segments of waveforms which have non-zero signal

--- a/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
@@ -91,6 +91,8 @@ namespace WireCell {
       // save ROI into the out frame (set use_roi_debug_mode=true)
       void save_roi(ITrace::vector& itraces, IFrame::trace_list_t& indices, int plane,
                     std::vector<std::list<SignalROI*> >& roi_channel_list);
+      void save_ext_roi(ITrace::vector& itraces, IFrame::trace_list_t& indices, int plane,
+                        std::vector<std::list<SignalROI*> >& roi_channel_list);
 
       // initialize the overall response function ...
       void init_overall_response(IFrame::pointer frame);

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -118,7 +118,7 @@ OmnibusSigProc::OmnibusSigProc(const std::string& anode_tn,
   , m_shrink_roi_tag(shrink_roi_tag)
   , m_extend_roi_tag(extend_roi_tag)
   , m_use_multi_plane_protection(false)
-  , m_isWraped(false)
+  , m_isWrapped(false)
   , m_sparse(false)
   , log(Log::logger("sigproc"))
 {
@@ -210,7 +210,7 @@ void OmnibusSigProc::configure(const WireCell::Configuration& config)
   m_extend_roi_tag = get(config,"extend_roi_tag",m_extend_roi_tag);
 
   m_use_multi_plane_protection =  get<bool>(config, "use_multi_plane_protection", m_use_multi_plane_protection);
-  m_isWraped =  get<bool>(config, "isWraped", m_isWraped);
+  m_isWrapped =  get<bool>(config, "isWrapped", m_isWrapped);
 
   // this throws if not found
   m_anode = Factory::find_tn<IAnodePlane>(m_anode_tn);
@@ -326,7 +326,7 @@ WireCell::Configuration OmnibusSigProc::default_configuration() const
   cfg["extend_roi_tag"] = m_extend_roi_tag;
 
   cfg["use_multi_plane_protection"] = m_use_multi_plane_protection; // default false
-  cfg["isWarped"] = m_isWraped; // default false
+  cfg["isWarped"] = m_isWrapped; // default false
   
   cfg["sparse"] = false;
 
@@ -1220,7 +1220,7 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
 
   // create a class for ROIs ... 
   ROI_formation roi_form(m_cmm, m_nwires[0], m_nwires[1], m_nwires[2], m_nticks, m_th_factor_ind, m_th_factor_col, m_pad, m_asy, m_rebin, m_l_factor, m_l_max_th, m_l_factor1, m_l_short_length, m_l_jump_one_bin);
-  ROI_refinement roi_refine(m_cmm, m_nwires[0], m_nwires[1], m_nwires[2],m_r_th_factor,m_r_fake_signal_low_th,m_r_fake_signal_high_th,m_r_fake_signal_low_th_ind_factor,m_r_fake_signal_high_th_ind_factor,m_r_pad,m_r_break_roi_loop,m_r_th_peak,m_r_sep_peak,m_r_low_peak_sep_threshold_pre,m_r_max_npeaks,m_r_sigma,m_r_th_percent,m_isWraped);//
+  ROI_refinement roi_refine(m_cmm, m_nwires[0], m_nwires[1], m_nwires[2],m_r_th_factor,m_r_fake_signal_low_th,m_r_fake_signal_high_th,m_r_fake_signal_low_th_ind_factor,m_r_fake_signal_high_th_ind_factor,m_r_pad,m_r_break_roi_loop,m_r_th_peak,m_r_sep_peak,m_r_low_peak_sep_threshold_pre,m_r_max_npeaks,m_r_sigma,m_r_th_percent,m_isWrapped);//
 
   
   const std::vector<float>* perplane_thresholds[3] = {

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -118,6 +118,7 @@ OmnibusSigProc::OmnibusSigProc(const std::string& anode_tn,
   , m_shrink_roi_tag(shrink_roi_tag)
   , m_extend_roi_tag(extend_roi_tag)
   , m_use_multi_plane_protection(false)
+  , m_isWraped(false)
   , m_sparse(false)
   , log(Log::logger("sigproc"))
 {
@@ -209,6 +210,7 @@ void OmnibusSigProc::configure(const WireCell::Configuration& config)
   m_extend_roi_tag = get(config,"extend_roi_tag",m_extend_roi_tag);
 
   m_use_multi_plane_protection =  get<bool>(config, "use_multi_plane_protection", m_use_multi_plane_protection);
+  m_isWraped =  get<bool>(config, "use_multi_plane_protection", m_isWraped);
 
   // this throws if not found
   m_anode = Factory::find_tn<IAnodePlane>(m_anode_tn);
@@ -323,6 +325,7 @@ WireCell::Configuration OmnibusSigProc::default_configuration() const
   cfg["extend_roi_tag"] = m_extend_roi_tag;
 
   cfg["use_multi_plane_protection"] = m_use_multi_plane_protection; // default false
+  cfg["isWarped"] = m_isWraped; // default false
   
   cfg["sparse"] = false;
 
@@ -1216,7 +1219,7 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
 
   // create a class for ROIs ... 
   ROI_formation roi_form(m_cmm, m_nwires[0], m_nwires[1], m_nwires[2], m_nticks, m_th_factor_ind, m_th_factor_col, m_pad, m_asy, m_rebin, m_l_factor, m_l_max_th, m_l_factor1, m_l_short_length, m_l_jump_one_bin);
-  ROI_refinement roi_refine(m_cmm, m_nwires[0], m_nwires[1], m_nwires[2],m_r_th_factor,m_r_fake_signal_low_th,m_r_fake_signal_high_th,m_r_fake_signal_low_th_ind_factor,m_r_fake_signal_high_th_ind_factor,m_r_pad,m_r_break_roi_loop,m_r_th_peak,m_r_sep_peak,m_r_low_peak_sep_threshold_pre,m_r_max_npeaks,m_r_sigma,m_r_th_percent);//
+  ROI_refinement roi_refine(m_cmm, m_nwires[0], m_nwires[1], m_nwires[2],m_r_th_factor,m_r_fake_signal_low_th,m_r_fake_signal_high_th,m_r_fake_signal_low_th_ind_factor,m_r_fake_signal_high_th_ind_factor,m_r_pad,m_r_break_roi_loop,m_r_th_peak,m_r_sep_peak,m_r_low_peak_sep_threshold_pre,m_r_max_npeaks,m_r_sigma,m_r_th_percent,m_isWraped);//
 
   
   const std::vector<float>* perplane_thresholds[3] = {

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -253,7 +253,7 @@ void OmnibusSigProc::configure(const WireCell::Configuration& config)
     for (auto ichan : plane_channels[iplane]) {
       const int wct_chan_ident = ichan->ident();
       OspChan och(osp_channel_number, osp_wire_number, iplane, wct_chan_ident);
-      std::cout << "[hyu1]chmap: " << wct_chan_ident << " " << iplane << " " << osp_channel_number << " " << osp_wire_number << std::endl;
+      // std::cout << "[hyu1]chmap: " << wct_chan_ident << " " << iplane << " " << osp_channel_number << " " << osp_wire_number << std::endl;
       m_roi_ch_ch_ident[osp_channel_number] = wct_chan_ident;
       m_channel_map[wct_chan_ident] = och; // we could save some space by storing
       m_channel_range[iplane].push_back(och);// wct ident here instead of a whole och.

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -1323,7 +1323,7 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
     } else {
       roi_refine.CleanUpInductionROIs(iplane);
     }
-    roi_refine.ExtendROIs();
+    roi_refine.ExtendROIs(iplane);
 
     if (m_use_roi_debug_mode) {
       save_roi(*itraces, extend_roi_traces, iplane,

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -210,7 +210,7 @@ void OmnibusSigProc::configure(const WireCell::Configuration& config)
   m_extend_roi_tag = get(config,"extend_roi_tag",m_extend_roi_tag);
 
   m_use_multi_plane_protection =  get<bool>(config, "use_multi_plane_protection", m_use_multi_plane_protection);
-  m_isWraped =  get<bool>(config, "use_multi_plane_protection", m_isWraped);
+  m_isWraped =  get<bool>(config, "isWraped", m_isWraped);
 
   // this throws if not found
   m_anode = Factory::find_tn<IAnodePlane>(m_anode_tn);
@@ -253,6 +253,7 @@ void OmnibusSigProc::configure(const WireCell::Configuration& config)
     for (auto ichan : plane_channels[iplane]) {
       const int wct_chan_ident = ichan->ident();
       OspChan och(osp_channel_number, osp_wire_number, iplane, wct_chan_ident);
+      std::cout << "[hyu1]chmap: " << wct_chan_ident << " " << iplane << " " << osp_channel_number << " " << osp_wire_number << std::endl;
       m_roi_ch_ch_ident[osp_channel_number] = wct_chan_ident;
       m_channel_map[wct_chan_ident] = och; // we could save some space by storing
       m_channel_range[iplane].push_back(och);// wct ident here instead of a whole och.

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -524,7 +524,7 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
 	 //  }
 	  
 	  // CHANGE(S): Hongzhao added the code to include wrapped adjacency
-	  // CHANGE(S): "create the connectivity map for channel N & N+1" will be called once for the LAST & FIRST channel in a plane
+	  // CHANGE(S): connect the LAST & FIRST osp_wire_number in an Induction plane
 	  if (chid==nwire_u-1 && isWrapped){
 	    //form connectivity map
 	    for (auto it=rois_u_loose[0].begin();it!=rois_u_loose[0].end();it++){
@@ -617,7 +617,7 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
 	 //  }
 	  
 	  // CHANGE(S): Hongzhao added the code to include wrapped adjacency
-	  // CHANGE(S): "create the connectivity map for channel N & N+1" will be called once for the LAST & FIRST channel in a plane
+	  // CHANGE(S): connect the LAST & FIRST osp_wire_number in an Induction plane
 	  if (chid==nwire_u+nwire_v-1 && isWrapped){
 	    //form connectivity map
 	    for (auto it = rois_v_loose[0].begin();it!=rois_v_loose[0].end();it++){

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -404,6 +404,9 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
 	
       	if (chid>nwire_u+nwire_v){
       	  //form connectivity map
+      	  // [Hongzhao] should avoid fake adjacency in Collection Plane for warped-up configuration
+      	  // CHANGE(S): Hongzhao added protection to skip fake adjacency
+      	  if (chid!=nwire_u+nwire_v+nwire_w/2. || !isWraped) { // additional judgement to skip fake adjacency
       	  for (auto it = rois_w_tight[chid-nwire_u-nwire_v-1].begin();it!=rois_w_tight[chid-nwire_u-nwire_v-1].end();it++){
       	    SignalROI *prev_roi = *it;
       	    if (tight_roi->overlap(prev_roi)){
@@ -422,6 +425,7 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
       		back_rois[tight_roi].push_back(prev_roi);
       	      }
       	    }
+      	  }
       	  }
       	}
 
@@ -453,32 +457,6 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
  //      	    }
  //      	  }
  //      	}
- //      }
-
-  // CHANGE(S): Hongzhao added the code to include warp-up adjacency
-  // CHANGE(S): "create the connectivity map for channel N & N+1" will be called once for the LAST & FIRST channel in a plane
-	if (chid==nwire_u+nwire_v+nwire_w-1  && isWraped){
-      	  //form connectivity map
-      	  for (auto it = rois_w_tight[0].begin();it!=rois_w_tight[0].end();it++){
-      	    SignalROI *next_roi = *it;
-      	    if (tight_roi->overlap(next_roi)){
-      	      if (back_rois.find(next_roi) == back_rois.end()){
-      		SignalROISelection temp_rois;
-      		temp_rois.push_back(tight_roi);
-      		back_rois[next_roi] = temp_rois;
-      	      }else{
-      		back_rois[next_roi].push_back(tight_roi);
-      	      }
-      	      if (front_rois.find(tight_roi) == front_rois.end()){
-      		SignalROISelection temp_rois;
-      		temp_rois.push_back(next_roi);
-      		front_rois[tight_roi] = temp_rois;
-      	      }else{
-      		front_rois[tight_roi].push_back(next_roi);
-      	      }
-      	    }
-      	  }
-      	}
       }
 
       

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -523,7 +523,7 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
 	 //    }
 	 //  }
 	  
-	  // CHANGE(S): Hongzhao added the code to include warp-up adjacency
+	  // CHANGE(S): Hongzhao added the code to include wrapped adjacency
 	  // CHANGE(S): "create the connectivity map for channel N & N+1" will be called once for the LAST & FIRST channel in a plane
 	  if (chid==nwire_u-1 && isWrapped){
 	    //form connectivity map
@@ -616,7 +616,7 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
 	 //    }
 	 //  }
 	  
-	  // CHANGE(S): Hongzhao added the code to include warp-up adjacency
+	  // CHANGE(S): Hongzhao added the code to include wrapped adjacency
 	  // CHANGE(S): "create the connectivity map for channel N & N+1" will be called once for the LAST & FIRST channel in a plane
 	  if (chid==nwire_u+nwire_v-1 && isWrapped){
 	    //form connectivity map
@@ -898,7 +898,7 @@ void ROI_refinement::generate_merge_ROIs(int plane){
 	    
 	  }
 	}
-	// CHANGE(S): Hongzhao added the code to include warp-up adjacency
+	// CHANGE(S): Hongzhao added the code to include wrapped adjacency
 	if (i == nwire_u-1 && isWrapped){
 	  for (auto it1 = rois_u_loose.at(0).begin(); it1!=rois_u_loose.at(0).end(); it1++){
 	    SignalROI *next_roi = *it1;
@@ -945,7 +945,7 @@ void ROI_refinement::generate_merge_ROIs(int plane){
 	    }
 	  }
 	}
-	// CHANGE(S): Hongzhao added the code to include warp-up adjacency
+	// CHANGE(S): Hongzhao added the code to include wrapped adjacency
 	if (i == 0 && isWrapped){
 	  for (auto it1 = rois_u_loose.at(nwire_u-1).begin(); it1!=rois_u_loose.at(nwire_u-1).end(); it1++){
 	    SignalROI *prev_roi = *it1;
@@ -1030,7 +1030,7 @@ void ROI_refinement::generate_merge_ROIs(int plane){
 	    
 	  }
 	}
-	// CHANGE(S): Hongzhao added the code to include warp-up adjacency
+	// CHANGE(S): Hongzhao added the code to include wrapped adjacency
 	if (i == nwire_v-1 && isWrapped){
 	  for (auto it1 = rois_v_loose.at(0).begin(); it1!=rois_v_loose.at(0).end(); it1++){
 	    SignalROI *next_roi = *it1;
@@ -1077,7 +1077,7 @@ void ROI_refinement::generate_merge_ROIs(int plane){
 	    }
 	  }
 	}
-	// CHANGE(S): Hongzhao added the code to include warp-up adjacency
+	// CHANGE(S): Hongzhao added the code to include wrapped adjacency
 	if (i == 0 && isWrapped){
 	  for (auto it1 = rois_v_loose.at(nwire_v-1).begin(); it1!=rois_v_loose.at(nwire_v-1).end(); it1++){
 	    SignalROI *prev_roi = *it1;

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -404,7 +404,7 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
 	
       	if (chid>nwire_u+nwire_v){
       	  //form connectivity map
-      	  // [Hongzhao] should avoid fake adjacency in Collection Plane for warped-up configuration
+      	  // [Hongzhao] should avoid fake adjacency in Collection Plane for wrapped configuration
       	  // CHANGE(S): Hongzhao added protection to skip fake adjacency
       	  if (chid!=nwire_u+nwire_v+nwire_w/2. || !isWrapped) { // additional judgement to skip fake adjacency
       	  for (auto it = rois_w_tight[chid-nwire_u-nwire_v-1].begin();it!=rois_w_tight[chid-nwire_u-nwire_v-1].end();it++){

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -1252,7 +1252,7 @@ void ROI_refinement::CleanUpCollectionROIs(){
 	  SignalROI* roi1 = next_rois.at(i);
 	  if (Good_ROIs.find(roi1)!=Good_ROIs.end()) {
 	    flag_qx = 1;
-	    continue;
+	    break; // continue;
 	  }
 	}
 	if (flag_qx == 1) continue;
@@ -1265,7 +1265,7 @@ void ROI_refinement::CleanUpCollectionROIs(){
 	  SignalROI* roi1 = next_rois.at(i);
 	  if (Good_ROIs.find(roi1)!=Good_ROIs.end()) {
 	    flag_qx = 1;
-	    continue;
+	    break; // continue;
 	  }
 	}
 	if (flag_qx == 1) continue;
@@ -1316,85 +1316,87 @@ void ROI_refinement::CleanUpInductionROIs(int plane){
   threshold *= fake_signal_high_th_ind_factor;
   
   std::list<SignalROI*> Bad_ROIs;
-  if (plane==0){
-    for (int i=0;i!=nwire_u;i++){
-      for (auto it = rois_u_loose.at(i).begin();it!=rois_u_loose.at(i).end();it++){
-	SignalROI* roi = *it;
-	//std::cout << "Xin: " << roi->get_max_height() << " " << roi->get_average_heights() << std::endl;
-	if (front_rois.find(roi)==front_rois.end() && back_rois.find(roi)==back_rois.end()){
-	  if (roi->get_above_threshold(threshold).size()==0 && roi->get_average_heights() < mean_threshold)
-	    Bad_ROIs.push_back(roi);
-	}
-      }
-    }
-    for (auto it = Bad_ROIs.begin(); it!=Bad_ROIs.end(); it ++){
-      SignalROI* roi = *it;
-      int chid = roi->get_chid();
-      auto it1 = find(rois_u_loose.at(chid).begin(), rois_u_loose.at(chid).end(),roi);
-      if (it1 != rois_u_loose.at(chid).end())
-	rois_u_loose.at(chid).erase(it1);
 
-      if (front_rois.find(roi)!=front_rois.end()){
-	SignalROISelection next_rois = front_rois[roi];
-	for (size_t i=0;i!=next_rois.size();i++){
-	  //unlink the current roi
-	  unlink(roi,next_rois.at(i));
-	}
-	front_rois.erase(roi);
-      }
-      
-      if (back_rois.find(roi)!=back_rois.end()){
-	SignalROISelection prev_rois = back_rois[roi];
-	for (size_t i=0;i!=prev_rois.size();i++){
-	  //unlink the current roi
-	  unlink(prev_rois.at(i),roi);
-	}
-	back_rois.erase(roi);
-      }
-      
-      delete roi;
-    }
-    Bad_ROIs.clear();
-  }else if (plane==1){
-    for (int i=0;i!=nwire_v;i++){
-      for (auto it = rois_v_loose.at(i).begin();it!=rois_v_loose.at(i).end();it++){
-	SignalROI* roi = *it;
-	//	std::cout << "Xin: " << roi->get_max_height() << " " << roi->get_average_heights() << std::endl;
-	if (front_rois.find(roi)==front_rois.end() && back_rois.find(roi)==back_rois.end()){
-	  if (roi->get_above_threshold(threshold).size()==0 && roi->get_average_heights() < mean_threshold)
-	    Bad_ROIs.push_back(roi);
-	}
-      }
-    }
-    for (auto it = Bad_ROIs.begin(); it!=Bad_ROIs.end(); it ++){
-      SignalROI* roi = *it;
-      int chid = roi->get_chid()-nwire_u;
-      auto it1 = find(rois_v_loose.at(chid).begin(), rois_v_loose.at(chid).end(),roi);
-      if (it1 != rois_v_loose.at(chid).end())
-	rois_v_loose.at(chid).erase(it1);
+  // Hongzhao: bad ROIs without good neighbors will be removed by next step
+ //  if (plane==0){
+ //    for (int i=0;i!=nwire_u;i++){
+ //      for (auto it = rois_u_loose.at(i).begin();it!=rois_u_loose.at(i).end();it++){
+	// SignalROI* roi = *it;
+	// //std::cout << "Xin: " << roi->get_max_height() << " " << roi->get_average_heights() << std::endl;
+	// if (front_rois.find(roi)==front_rois.end() && back_rois.find(roi)==back_rois.end()){
+	//   if (roi->get_above_threshold(threshold).size()==0 && roi->get_average_heights() < mean_threshold)
+	//     Bad_ROIs.push_back(roi);
+	// }
+ //      }
+ //    }
+ //    for (auto it = Bad_ROIs.begin(); it!=Bad_ROIs.end(); it ++){
+ //      SignalROI* roi = *it;
+ //      int chid = roi->get_chid();
+ //      auto it1 = find(rois_u_loose.at(chid).begin(), rois_u_loose.at(chid).end(),roi);
+ //      if (it1 != rois_u_loose.at(chid).end())
+	// rois_u_loose.at(chid).erase(it1);
 
-      if (front_rois.find(roi)!=front_rois.end()){
-	SignalROISelection next_rois = front_rois[roi];
-	for (size_t i=0;i!=next_rois.size();i++){
-	  //unlink the current roi
-	  unlink(roi,next_rois.at(i));
-	}
-	front_rois.erase(roi);
-      }
+ //      if (front_rois.find(roi)!=front_rois.end()){
+	// SignalROISelection next_rois = front_rois[roi];
+	// for (size_t i=0;i!=next_rois.size();i++){
+	//   //unlink the current roi
+	//   unlink(roi,next_rois.at(i));
+	// }
+	// front_rois.erase(roi);
+ //      }
       
-      if (back_rois.find(roi)!=back_rois.end()){
-	SignalROISelection prev_rois = back_rois[roi];
-	for (size_t i=0;i!=prev_rois.size();i++){
-	  //unlink the current roi
-	  unlink(prev_rois.at(i),roi);
-	}
-	back_rois.erase(roi);
-      }
+ //      if (back_rois.find(roi)!=back_rois.end()){
+	// SignalROISelection prev_rois = back_rois[roi];
+	// for (size_t i=0;i!=prev_rois.size();i++){
+	//   //unlink the current roi
+	//   unlink(prev_rois.at(i),roi);
+	// }
+	// back_rois.erase(roi);
+ //      }
+      
+ //      delete roi;
+ //    }
+ //    Bad_ROIs.clear();
+ //  }else if (plane==1){
+ //    for (int i=0;i!=nwire_v;i++){
+ //      for (auto it = rois_v_loose.at(i).begin();it!=rois_v_loose.at(i).end();it++){
+	// SignalROI* roi = *it;
+	// //	std::cout << "Xin: " << roi->get_max_height() << " " << roi->get_average_heights() << std::endl;
+	// if (front_rois.find(roi)==front_rois.end() && back_rois.find(roi)==back_rois.end()){
+	//   if (roi->get_above_threshold(threshold).size()==0 && roi->get_average_heights() < mean_threshold)
+	//     Bad_ROIs.push_back(roi);
+	// }
+ //      }
+ //    }
+ //    for (auto it = Bad_ROIs.begin(); it!=Bad_ROIs.end(); it ++){
+ //      SignalROI* roi = *it;
+ //      int chid = roi->get_chid()-nwire_u;
+ //      auto it1 = find(rois_v_loose.at(chid).begin(), rois_v_loose.at(chid).end(),roi);
+ //      if (it1 != rois_v_loose.at(chid).end())
+	// rois_v_loose.at(chid).erase(it1);
+
+ //      if (front_rois.find(roi)!=front_rois.end()){
+	// SignalROISelection next_rois = front_rois[roi];
+	// for (size_t i=0;i!=next_rois.size();i++){
+	//   //unlink the current roi
+	//   unlink(roi,next_rois.at(i));
+	// }
+	// front_rois.erase(roi);
+ //      }
+      
+ //      if (back_rois.find(roi)!=back_rois.end()){
+	// SignalROISelection prev_rois = back_rois[roi];
+	// for (size_t i=0;i!=prev_rois.size();i++){
+	//   //unlink the current roi
+	//   unlink(prev_rois.at(i),roi);
+	// }
+	// back_rois.erase(roi);
+ //      }
       
       
-      delete roi;
-    }
-  }
+ //      delete roi;
+ //    }
+ //  }
 
 
   // threshold = fake_signal_low_th;

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -12,7 +12,7 @@ using namespace WireCell::SigProc;
 #else
 #define LogDebug(x)
 #endif
-ROI_refinement::ROI_refinement(Waveform::ChannelMaskMap& cmm,int nwire_u, int nwire_v, int nwire_w, float th_factor, float fake_signal_low_th, float fake_signal_high_th, float fake_signal_low_th_ind_factor, float fake_signal_high_th_ind_factor, int pad, int break_roi_loop, float th_peak, float sep_peak, float low_peak_sep_threshold_pre, int max_npeaks, float sigma, float th_percent, bool isWraped)
+ROI_refinement::ROI_refinement(Waveform::ChannelMaskMap& cmm,int nwire_u, int nwire_v, int nwire_w, float th_factor, float fake_signal_low_th, float fake_signal_high_th, float fake_signal_low_th_ind_factor, float fake_signal_high_th_ind_factor, int pad, int break_roi_loop, float th_peak, float sep_peak, float low_peak_sep_threshold_pre, int max_npeaks, float sigma, float th_percent, bool isWrapped)
   : nwire_u(nwire_u)
   , nwire_v(nwire_v)
   , nwire_w(nwire_w)
@@ -30,7 +30,7 @@ ROI_refinement::ROI_refinement(Waveform::ChannelMaskMap& cmm,int nwire_u, int nw
   , sigma(sigma)
   , th_percent(th_percent)
   , log(Log::logger("sigproc"))
-  , isWraped(isWraped)
+  , isWrapped(isWrapped)
 {
   rois_u_tight.resize(nwire_u);
   rois_u_loose.resize(nwire_u);
@@ -406,7 +406,7 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
       	  //form connectivity map
       	  // [Hongzhao] should avoid fake adjacency in Collection Plane for warped-up configuration
       	  // CHANGE(S): Hongzhao added protection to skip fake adjacency
-      	  if (chid!=nwire_u+nwire_v+nwire_w/2. || !isWraped) { // additional judgement to skip fake adjacency
+      	  if (chid!=nwire_u+nwire_v+nwire_w/2. || !isWrapped) { // additional judgement to skip fake adjacency
       	  for (auto it = rois_w_tight[chid-nwire_u-nwire_v-1].begin();it!=rois_w_tight[chid-nwire_u-nwire_v-1].end();it++){
       	    SignalROI *prev_roi = *it;
       	    if (tight_roi->overlap(prev_roi)){
@@ -525,7 +525,7 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
 	  
 	  // CHANGE(S): Hongzhao added the code to include warp-up adjacency
 	  // CHANGE(S): "create the connectivity map for channel N & N+1" will be called once for the LAST & FIRST channel in a plane
-	  if (chid==nwire_u-1 && isWraped){
+	  if (chid==nwire_u-1 && isWrapped){
 	    //form connectivity map
 	    for (auto it=rois_u_loose[0].begin();it!=rois_u_loose[0].end();it++){
 	      SignalROI *next_roi = *it;
@@ -618,7 +618,7 @@ void ROI_refinement::load_data(int plane, const Array::array_xxf& r_data, ROI_fo
 	  
 	  // CHANGE(S): Hongzhao added the code to include warp-up adjacency
 	  // CHANGE(S): "create the connectivity map for channel N & N+1" will be called once for the LAST & FIRST channel in a plane
-	  if (chid==nwire_u+nwire_v-1 && isWraped){
+	  if (chid==nwire_u+nwire_v-1 && isWrapped){
 	    //form connectivity map
 	    for (auto it = rois_v_loose[0].begin();it!=rois_v_loose[0].end();it++){
 	      SignalROI *next_roi = *it;
@@ -899,7 +899,7 @@ void ROI_refinement::generate_merge_ROIs(int plane){
 	  }
 	}
 	// CHANGE(S): Hongzhao added the code to include warp-up adjacency
-	if (i == nwire_u-1 && isWraped){
+	if (i == nwire_u-1 && isWrapped){
 	  for (auto it1 = rois_u_loose.at(0).begin(); it1!=rois_u_loose.at(0).end(); it1++){
 	    SignalROI *next_roi = *it1;
 	    
@@ -946,7 +946,7 @@ void ROI_refinement::generate_merge_ROIs(int plane){
 	  }
 	}
 	// CHANGE(S): Hongzhao added the code to include warp-up adjacency
-	if (i == 0 && isWraped){
+	if (i == 0 && isWrapped){
 	  for (auto it1 = rois_u_loose.at(nwire_u-1).begin(); it1!=rois_u_loose.at(nwire_u-1).end(); it1++){
 	    SignalROI *prev_roi = *it1;
 	    if (loose_roi->overlap(prev_roi)){
@@ -1031,7 +1031,7 @@ void ROI_refinement::generate_merge_ROIs(int plane){
 	  }
 	}
 	// CHANGE(S): Hongzhao added the code to include warp-up adjacency
-	if (i == nwire_v-1 && isWraped){
+	if (i == nwire_v-1 && isWrapped){
 	  for (auto it1 = rois_v_loose.at(0).begin(); it1!=rois_v_loose.at(0).end(); it1++){
 	    SignalROI *next_roi = *it1;
 	    
@@ -1078,7 +1078,7 @@ void ROI_refinement::generate_merge_ROIs(int plane){
 	  }
 	}
 	// CHANGE(S): Hongzhao added the code to include warp-up adjacency
-	if (i == 0 && isWraped){
+	if (i == 0 && isWrapped){
 	  for (auto it1 = rois_v_loose.at(nwire_v-1).begin(); it1!=rois_v_loose.at(nwire_v-1).end(); it1++){
 	    SignalROI *prev_roi = *it1;
 	    if (loose_roi->overlap(prev_roi)){

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -1420,7 +1420,7 @@ void ROI_refinement::CleanUpInductionROIs(int plane){
 	    SignalROI* roi1 = next_rois.at(i);
 	    if (Good_ROIs.find(roi1)!=Good_ROIs.end()) {
 	      flag_qx = 1;
-	      continue;
+	      break; // continue;
 	    }
 	  }
 	  if (flag_qx == 1) continue;
@@ -1433,7 +1433,7 @@ void ROI_refinement::CleanUpInductionROIs(int plane){
 	    SignalROI* roi1 = next_rois.at(i);
 	    if (Good_ROIs.find(roi1)!=Good_ROIs.end()) {
 	      flag_qx = 1;
-	      continue;
+	      break; // continue;
 	    }
 	  }
 	  if (flag_qx == 1) continue;
@@ -1492,7 +1492,7 @@ void ROI_refinement::CleanUpInductionROIs(int plane){
 	    SignalROI* roi1 = next_rois.at(i);
 	    if (Good_ROIs.find(roi1)!=Good_ROIs.end()) {
 	      flag_qx = 1;
-	      continue;
+	      break; // continue;
 	    }
 	  }
 	  if (flag_qx == 1) continue;
@@ -1505,7 +1505,7 @@ void ROI_refinement::CleanUpInductionROIs(int plane){
 	    SignalROI* roi1 = next_rois.at(i);
 	    if (Good_ROIs.find(roi1)!=Good_ROIs.end()) {
 	      flag_qx = 1;
-	      continue;
+	      break; // continue;
 	    }
 	  }
 	  if (flag_qx == 1) continue;

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -2447,7 +2447,7 @@ void ROI_refinement::refine_data(int plane, ROI_formation& roi_form){
     CleanUpInductionROIs(plane);
   }
 
-  ExtendROIs();
+  ExtendROIs(plane);
   //TestROIs();
   //if (plane==2)  std::cout << "Xin: " << rois_w_tight.at(69).size() << " " << std::endl;
 }
@@ -2488,7 +2488,7 @@ void ROI_refinement::refine_data_debug_mode(int plane, ROI_formation& roi_form, 
       CleanUpInductionROIs(plane);
     }
 
-    ExtendROIs();
+    ExtendROIs(plane);
     //TestROIs();
   }
 
@@ -2745,10 +2745,10 @@ void ROI_refinement::refine_data_debug_mode(int plane, ROI_formation& roi_form, 
 }
 
 
-void ROI_refinement::ExtendROIs(){
+void ROI_refinement::ExtendROIs(int plane){
 
   bool flag = true;
-  
+  if (plane==0) {
   // U plane ... 
   for (int chid = 0; chid != nwire_u; chid ++){
     rois_u_loose.at(chid).sort(CompareRois());
@@ -2804,6 +2804,7 @@ void ROI_refinement::ExtendROIs(){
     //   std::cout << chid << " " << roi->get_ext_start_bin() << " " << roi->get_ext_end_bin() << std::endl;
     // }
   }
+  } else if (plane==1) { 
   // V plane
   for (int chid = 0; chid != nwire_v; chid ++){
     rois_v_loose.at(chid).sort(CompareRois());
@@ -2859,7 +2860,7 @@ void ROI_refinement::ExtendROIs(){
     //   std::cout << chid << " " << roi->get_ext_start_bin() << " " << roi->get_ext_end_bin() << std::endl;
     // }
   }
-
+  } else {
   // W plane
   for (int chid = 0; chid != nwire_w; chid ++){
     rois_w_tight.at(chid).sort(CompareRois());
@@ -2914,6 +2915,7 @@ void ROI_refinement::ExtendROIs(){
       //   SignalROI *roi =  *it;
       //   std::cout << chid << " " << roi->get_ext_start_bin() << " " << roi->get_ext_end_bin() << std::endl;
       // }
+  }
   }
 }
 

--- a/sigproc/src/ROI_refinement.h
+++ b/sigproc/src/ROI_refinement.h
@@ -19,7 +19,7 @@ namespace WireCell{
     
     class ROI_refinement{
     public:
-      ROI_refinement(Waveform::ChannelMaskMap& cmm,int nwire_u, int nwire_v, int nwire_w, float th_factor = 3.0, float fake_signal_low_th = 500, float fake_signal_high_th = 1000, float fake_signal_low_th_ind_factor=1.0, float fake_signal_high_th_ind_factor=1.0, int pad = 5, int break_roi_loop = 2, float th_peak = 3.0, float sep_peak = 6.0, float low_peak_sep_threshold_pre = 1200, int max_npeaks = 200, float sigma = 2, float th_percent = 0.1, bool isWraped = false); 
+      ROI_refinement(Waveform::ChannelMaskMap& cmm,int nwire_u, int nwire_v, int nwire_w, float th_factor = 3.0, float fake_signal_low_th = 500, float fake_signal_high_th = 1000, float fake_signal_low_th_ind_factor=1.0, float fake_signal_high_th_ind_factor=1.0, int pad = 5, int break_roi_loop = 2, float th_peak = 3.0, float sep_peak = 6.0, float low_peak_sep_threshold_pre = 1200, int max_npeaks = 200, float sigma = 2, float th_percent = 0.1, bool isWrapped = false); 
       ~ROI_refinement();
 
       void Clear();
@@ -106,7 +106,7 @@ namespace WireCell{
       
       Log::logptr_t log;
 
-      bool isWraped;
+      bool isWrapped;
     };
   }
 }

--- a/sigproc/src/ROI_refinement.h
+++ b/sigproc/src/ROI_refinement.h
@@ -19,7 +19,7 @@ namespace WireCell{
     
     class ROI_refinement{
     public:
-      ROI_refinement(Waveform::ChannelMaskMap& cmm,int nwire_u, int nwire_v, int nwire_w, float th_factor = 3.0, float fake_signal_low_th = 500, float fake_signal_high_th = 1000, float fake_signal_low_th_ind_factor=1.0, float fake_signal_high_th_ind_factor=1.0, int pad = 5, int break_roi_loop = 2, float th_peak = 3.0, float sep_peak = 6.0, float low_peak_sep_threshold_pre = 1200, int max_npeaks = 200, float sigma = 2, float th_percent = 0.1); 
+      ROI_refinement(Waveform::ChannelMaskMap& cmm,int nwire_u, int nwire_v, int nwire_w, float th_factor = 3.0, float fake_signal_low_th = 500, float fake_signal_high_th = 1000, float fake_signal_low_th_ind_factor=1.0, float fake_signal_high_th_ind_factor=1.0, int pad = 5, int break_roi_loop = 2, float th_peak = 3.0, float sep_peak = 6.0, float low_peak_sep_threshold_pre = 1200, int max_npeaks = 200, float sigma = 2, float th_percent = 0.1, bool isWraped = false); 
       ~ROI_refinement();
 
       void Clear();
@@ -105,6 +105,8 @@ namespace WireCell{
       SignalROIMap contained_rois;
       
       Log::logptr_t log;
+
+      bool isWraped;
     };
   }
 }

--- a/sigproc/src/ROI_refinement.h
+++ b/sigproc/src/ROI_refinement.h
@@ -52,7 +52,7 @@ namespace WireCell{
       void BreakROI(SignalROI *roi, float rms);
       void BreakROI1(SignalROI *roi);
       
-      void ExtendROIs();
+      void ExtendROIs(int plane);
 
       void TestROIs();
 


### PR DESCRIPTION
1. consider wrapped adjacency for ROI_refinement::Extend_ROIs()
- In the decon stage, each CHANNEL in induction plane has 2-sided neighbours.
**channel-wire relationship is inrelevant in this problem**
- Minor differences for 2 channels per plane

2. comment out some unnecessary code
- cancel connectivity map for tight_ROIs for induction planes in ROI_refinement::load_data()
- remove first step in ROI_refinement:CleanUpInductionROIs()
- remove the step to connect N & N+1 (still connect N-1 & N)
- no impact on final result

3. some minor updates
- add OmniBusSigProc::save_ext_roi() for Wenqiang's debug mode
- pass "iplane" to ROI_refinement::Extend_ROIs()