### PR TITLE
Individual static Eigen::FFT instance for each planner function

### DIFF
--- a/util/src/Array.cxx
+++ b/util/src/Array.cxx
@@ -8,7 +8,7 @@
 using namespace WireCell;
 using namespace WireCell::Array;
 
-thread_local static Eigen::FFT< float > gEigenFFT;
+thread_local static Eigen::FFT< float > gEigenFFT_dft;
 
 //http://stackoverflow.com/a/33636445
 
@@ -23,19 +23,20 @@ WireCell::Array::array_xxc WireCell::Array::dft(const WireCell::Array::array_xxf
         Eigen::VectorXcf fspec(ncols); // frequency spectrum 
 	// gEigenFFT wants vectors, also input arr is const
 	Eigen::VectorXf tmp = arr.row(irow);
-	gEigenFFT.fwd(fspec, tmp);
+	gEigenFFT_dft.fwd(fspec, tmp); //r2c
         matc.row(irow) = fspec;
     }
 
     for (int icol = 0; icol < ncols; ++icol) {
         Eigen::VectorXcf pspec(nrows); // periodicity spectrum
-        gEigenFFT.fwd(pspec, matc.col(icol));
+        gEigenFFT_dft.fwd(pspec, matc.col(icol)); //c2c
         matc.col(icol) = pspec;
     }
 
     return matc;
 }
 
+thread_local static Eigen::FFT< float > gEigenFFT_dft_rc;
 WireCell::Array::array_xxc WireCell::Array::dft_rc(const WireCell::Array::array_xxf& arr, int dim)
 {
     const int nrows = arr.rows();
@@ -47,7 +48,7 @@ WireCell::Array::array_xxc WireCell::Array::dft_rc(const WireCell::Array::array_
         for (int irow = 0; irow < nrows; ++irow) {
             Eigen::VectorXcf fspec(ncols);
             Eigen::VectorXf tmp = arr.row(irow);
-            gEigenFFT.fwd(fspec, tmp);
+            gEigenFFT_dft_rc.fwd(fspec, tmp); //r2c
             matc.row(irow) = fspec;
         }
     }
@@ -55,13 +56,14 @@ WireCell::Array::array_xxc WireCell::Array::dft_rc(const WireCell::Array::array_
         for (int icol = 0; icol < ncols; ++icol) {
             Eigen::VectorXcf fspec(nrows);
             Eigen::VectorXf tmp = arr.col(icol);
-            gEigenFFT.fwd(fspec, tmp);
+            gEigenFFT_dft_rc.fwd(fspec, tmp); //r2c
             matc.col(icol) = fspec;
         }
     }        
     return matc;
 }
 
+thread_local static Eigen::FFT< float > gEigenFFT_dft_cc;
 WireCell::Array::array_xxc WireCell::Array::dft_cc(const WireCell::Array::array_xxc& arr, int dim)
 {
     const int nrows = arr.rows();
@@ -74,14 +76,14 @@ WireCell::Array::array_xxc WireCell::Array::dft_cc(const WireCell::Array::array_
     if (dim == 0) {
         for (int irow = 0; irow < nrows; ++irow) {
             Eigen::VectorXcf pspec(ncols);
-            gEigenFFT.fwd(pspec,matc.row(irow));
+            gEigenFFT_dft_cc.fwd(pspec,matc.row(irow)); //c2c
             matc.row(irow) = pspec;
         }
     }
     else {
         for (int icol = 0; icol < ncols; ++icol) {
             Eigen::VectorXcf pspec(nrows);
-            gEigenFFT.fwd(pspec, matc.col(icol));
+            gEigenFFT_dft_cc.fwd(pspec, matc.col(icol)); //c2c
             matc.col(icol) = pspec;
         }
     }
@@ -90,6 +92,7 @@ WireCell::Array::array_xxc WireCell::Array::dft_cc(const WireCell::Array::array_
 
 
 
+thread_local static Eigen::FFT< float > gEigenFFT_idft;
 WireCell::Array::array_xxf WireCell::Array::idft(const WireCell::Array::array_xxc& arr)
 {
     const int nrows = arr.rows();
@@ -101,7 +104,7 @@ WireCell::Array::array_xxf WireCell::Array::idft(const WireCell::Array::array_xx
 
     for (int icol = 0; icol < ncols; ++icol) {
         Eigen::VectorXcf pspec(nrows); // wire spectrum
-        gEigenFFT.inv(pspec, partial.col(icol));
+        gEigenFFT_idft.inv(pspec, partial.col(icol)); //c2c
         partial.col(icol) = pspec;
     }
 
@@ -110,13 +113,14 @@ WireCell::Array::array_xxf WireCell::Array::idft(const WireCell::Array::array_xx
 
     for (int irow = 0; irow < nrows; ++irow) {
         Eigen::VectorXf wave(ncols); // back to real-valued time series
-        gEigenFFT.inv(wave, partial.row(irow));
+        gEigenFFT_idft.inv(wave, partial.row(irow)); //c2r
         ret.row(irow) = wave;
     }
 
     return ret;
 }
 
+thread_local static Eigen::FFT< float > gEigenFFT_idft_cc;
 WireCell::Array::array_xxc WireCell::Array::idft_cc(const WireCell::Array::array_xxc& arr, int dim)
 {
     const int nrows = arr.rows();
@@ -129,20 +133,21 @@ WireCell::Array::array_xxc WireCell::Array::idft_cc(const WireCell::Array::array
     if (dim == 1) {
         for (int icol = 0; icol < ncols; ++icol) {
             Eigen::VectorXcf pspec(nrows);
-            gEigenFFT.inv(pspec, ret.col(icol));
+            gEigenFFT_idft_cc.inv(pspec, ret.col(icol)); //c2c
             ret.col(icol) = pspec;
         }
     }
     else if (dim == 0) {
         for (int irow = 0; irow < nrows; ++irow) {
             Eigen::VectorXcf pspec(ncols);
-            gEigenFFT.inv(pspec, ret.row(irow));
+            gEigenFFT_idft_cc.inv(pspec, ret.row(irow)); //c2c
             ret.row(irow) = pspec;
         }
     }
     return ret;
 }
 
+thread_local static Eigen::FFT< float > gEigenFFT_idft_cr;
 WireCell::Array::array_xxf WireCell::Array::idft_cr(const WireCell::Array::array_xxc& arr, int dim)
 {
     const int nrows = arr.rows();
@@ -157,14 +162,14 @@ WireCell::Array::array_xxf WireCell::Array::idft_cr(const WireCell::Array::array
     if (dim == 0) {
         for (int irow = 0; irow < nrows; ++irow) {
             Eigen::VectorXf wave(ncols); // back to real-valued time series
-            gEigenFFT.inv(wave, partial.row(irow));
+            gEigenFFT_idft_cr.inv(wave, partial.row(irow)); //c2r
             ret.row(irow) = wave;
         }
     }
     else if (dim == 1) {
         for (int icol = 0; icol < ncols; ++icol) {
             Eigen::VectorXf wave(nrows);
-            gEigenFFT.inv(wave, partial.col(icol));
+            gEigenFFT_idft_cr.inv(wave, partial.col(icol)); //c2r
             ret.col(icol) = wave;
         }
     }
@@ -173,6 +178,7 @@ WireCell::Array::array_xxf WireCell::Array::idft_cr(const WireCell::Array::array
 
 
 
+thread_local static Eigen::FFT< float > gEigenFFT_deconv;
 // this is a cut-and-paste mashup of dft() and idft() in order to avoid temporaries.
 WireCell::Array::array_xxf
 WireCell::Array::deconv(const WireCell::Array::array_xxf& arr,
@@ -186,13 +192,13 @@ WireCell::Array::deconv(const WireCell::Array::array_xxf& arr,
 	Eigen::VectorXcf fspec(ncols); // frequency spectrum 
 	// gEigenFFT wants vectors, also input arr is const
 	Eigen::VectorXf tmp = arr.row(irow);
-	gEigenFFT.fwd(fspec, tmp);
+	gEigenFFT_deconv.fwd(fspec, tmp); //r2c
 	matc.row(irow) = fspec;
     }
     
     for (int icol = 0; icol < ncols; ++icol) {
 	Eigen::VectorXcf pspec(nrows); // periodicity spectrum
-	gEigenFFT.fwd(pspec, matc.col(icol));
+	gEigenFFT_deconv.fwd(pspec, matc.col(icol)); //c2c
 	matc.col(icol) = pspec;
     }
 
@@ -201,7 +207,7 @@ WireCell::Array::deconv(const WireCell::Array::array_xxf& arr,
 
     for (int icol = 0; icol < ncols; ++icol) {
         Eigen::VectorXcf pspec(nrows); // wire spectrum
-        gEigenFFT.inv(pspec, filt.col(icol));
+        gEigenFFT_deconv.inv(pspec, filt.col(icol)); //c2c
         filt.col(icol) = pspec;
     }
 
@@ -209,7 +215,7 @@ WireCell::Array::deconv(const WireCell::Array::array_xxf& arr,
 
     for (int irow = 0; irow < nrows; ++irow) {
         Eigen::VectorXf wave(ncols); // back to real-valued time series
-        gEigenFFT.inv(wave, filt.row(irow));
+        gEigenFFT_deconv.inv(wave, filt.row(irow)); //c2r
         ret.row(irow) = wave;
     }
 


### PR DESCRIPTION
Observed crashing using current version of `Array.cxx` when running jobs including 'sim-nf-sp'.
In tests in #18 , simulation was not included in the test.

Possible reason is that there are 3 versions (c2c, c2r, r2c) of plan making functions for 1D fft:
https://eigen.tuxfamily.org/dox/unsupported/ei__fftw__impl_8h_source.html
But they may not yield identical plans for a given key used in the caching.

In this fix, 3 static Eigen::FFT instances were made for each planner function.
After this fix, the 'sim-nf-sp' chain stopped crashing.

And the data 'nf-sp' chain yields identical results as in #18 .

It would be great if @goowenq could do some extra tests with this PR. Thanks!


