### PR TITLE
Add interfaces to export Multi-Plane ROI information

### DIFF
--- a/cfg/pgrapher/experiment/pdsp/sp.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/sp.jsonnet
@@ -61,7 +61,8 @@ function(params, tools, override = {}) {
       extend_roi_tag: 'extend_roi%d' % anode.data.ident,
 
       use_multi_plane_protection: false,
-      mp_roi_tag: 'mp_roi%d' % anode.data.ident,
+      mp3_roi_tag: 'mp3_roi%d' % anode.data.ident,
+      mp2_roi_tag: 'mp2_roi%d' % anode.data.ident,
       
       isWrapped: false,
 

--- a/cfg/pgrapher/experiment/pdsp/sp.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/sp.jsonnet
@@ -60,6 +60,9 @@ function(params, tools, override = {}) {
       shrink_roi_tag: 'shrink_roi%d' % anode.data.ident,
       extend_roi_tag: 'extend_roi%d' % anode.data.ident,
 
+      use_multi_plane_protection: false,
+      mp_roi_tag: 'mp_roi%d' % anode.data.ident,
+
     } + override,
   }, nin=1, nout=1, uses=[anode, tools.field] + pc.uses + spfilt),
 

--- a/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
@@ -60,7 +60,8 @@ namespace WireCell {
                      const std::string& break_roi_loop2_tag = "break_roi_2nd",
                      const std::string& shrink_roi_tag = "shrink_roi",
                      const std::string& extend_roi_tag = "extend_roi",
-                     const std::string& mp_roi_tag = "mp_roi" );
+                     const std::string& mp3_roi_tag = "mp3_roi",
+                     const std::string& mp2_roi_tag = "mp2_roi" );
       virtual ~OmnibusSigProc();
       
       virtual bool operator()(const input_pointer& in, output_pointer& out);
@@ -231,7 +232,8 @@ namespace WireCell {
       std::string m_extend_roi_tag;
 
       bool m_use_multi_plane_protection;
-      std::string m_mp_roi_tag;
+      std::string m_mp3_roi_tag;
+      std::string m_mp2_roi_tag;
       
       bool m_isWrapped;
 

--- a/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
@@ -59,7 +59,8 @@ namespace WireCell {
                      const std::string& break_roi_loop1_tag = "break_roi_1st",
                      const std::string& break_roi_loop2_tag = "break_roi_2nd",
                      const std::string& shrink_roi_tag = "shrink_roi",
-                     const std::string& extend_roi_tag = "extend_roi" );
+                     const std::string& extend_roi_tag = "extend_roi",
+                     const std::string& mp_roi_tag = "mp_roi" );
       virtual ~OmnibusSigProc();
       
       virtual bool operator()(const input_pointer& in, output_pointer& out);
@@ -91,6 +92,11 @@ namespace WireCell {
       // save ROI into the out frame (set use_roi_debug_mode=true)
       void save_roi(ITrace::vector& itraces, IFrame::trace_list_t& indices, int plane,
                     std::vector<std::list<SignalROI*> >& roi_channel_list);
+      
+      // save Multi-Plane ROI into the out frame (set use_roi_debug_mode=true)
+      // mp_rois: osp-chid, start -> start, end
+      void save_mproi(ITrace::vector& itraces, IFrame::trace_list_t& indices, int plane,
+                    std::multimap<std::pair<int, int>, std::pair<int, int> > mp_rois);
 
       // initialize the overall response function ...
       void init_overall_response(IFrame::pointer frame);
@@ -222,6 +228,7 @@ namespace WireCell {
       std::string m_extend_roi_tag;
 
       bool m_use_multi_plane_protection;
+      std::string m_mp_roi_tag;
 
       // If true, safe output as a sparse frame.  Traces will only
       // cover segments of waveforms which have non-zero signal

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -637,7 +637,6 @@ void OmnibusSigProc::save_mproi(
     ITrace::vector &itraces, IFrame::trace_list_t &indices, int plane,
     std::multimap<std::pair<int, int>, std::pair<int, int>> mp_rois) {
 
-  log->debug("[yuhw] mp_roi.size(): {}", mp_rois.size());
   // reuse this temporary vector to hold charge for a channel.
   ITrace::ChargeSequence charge(m_nticks, 0.0);
 
@@ -1443,7 +1442,6 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
                roi_refine.get_rois_by_plane(iplane));
     }
 
-    log->debug("[yuhw] m_use_multi_plane_protection {}", m_use_multi_plane_protection);
     if (m_use_multi_plane_protection) {
       roi_refine.MultiPlaneProtection(iplane, m_anode, m_roi_ch_ch_ident, roi_form, 1000,
                                       m_anode->ident() % 2);

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -119,11 +119,8 @@ OmnibusSigProc::OmnibusSigProc(const std::string& anode_tn,
   , m_shrink_roi_tag(shrink_roi_tag)
   , m_extend_roi_tag(extend_roi_tag)
   , m_use_multi_plane_protection(false)
-<<<<<<< HEAD
   , m_mp_roi_tag(mp_roi_tag)
-=======
   , m_isWrapped(false)
->>>>>>> d5ab7c394f4d9dc122bc2ced574b1344f39bba76
   , m_sparse(false)
   , log(Log::logger("sigproc"))
 {
@@ -215,11 +212,9 @@ void OmnibusSigProc::configure(const WireCell::Configuration& config)
   m_extend_roi_tag = get(config,"extend_roi_tag",m_extend_roi_tag);
 
   m_use_multi_plane_protection =  get<bool>(config, "use_multi_plane_protection", m_use_multi_plane_protection);
-<<<<<<< HEAD
   m_mp_roi_tag = get(config,"mp_roi_tag",m_mp_roi_tag);
-=======
+  
   m_isWrapped =  get<bool>(config, "isWrapped", m_isWrapped);
->>>>>>> d5ab7c394f4d9dc122bc2ced574b1344f39bba76
 
   // this throws if not found
   m_anode = Factory::find_tn<IAnodePlane>(m_anode_tn);
@@ -335,11 +330,9 @@ WireCell::Configuration OmnibusSigProc::default_configuration() const
   cfg["extend_roi_tag"] = m_extend_roi_tag;
 
   cfg["use_multi_plane_protection"] = m_use_multi_plane_protection; // default false
-<<<<<<< HEAD
   cfg["mp_roi_tag"] = m_mp_roi_tag;
-=======
+  
   cfg["isWarped"] = m_isWrapped; // default false
->>>>>>> d5ab7c394f4d9dc122bc2ced574b1344f39bba76
   
   cfg["sparse"] = false;
 

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -2695,12 +2695,6 @@ void ROI_refinement::MultiPlaneROI(const int target_plane,
   for (auto r2a : map_roichid_anodechid) {
     map_anodechid_roichid[r2a.second] = r2a.first;
   }
-
-  log->debug("[yuhw] ROI chid -> Anode chid {} {}", map_roichid_anodechid.begin()->first, map_roichid_anodechid.begin()->second);
-  log->debug("[yuhw] ROI chid -> Anode chid {} {}", map_roichid_anodechid.rbegin()->first, map_roichid_anodechid.rbegin()->second);
-
-  log->debug("[yuhw] Anode chid -> ROI chid {} {}", map_anodechid_roichid.begin()->first, map_anodechid_roichid.begin()->second);
-  log->debug("[yuhw] Anode chid -> ROI chid {} {}", map_anodechid_roichid.rbegin()->first, map_anodechid_roichid.rbegin()->second);
  
   std::map<int, int> map_wireid_roichid[3];
   for(auto chident : anode->channels()) { // Anode chiid
@@ -2713,11 +2707,6 @@ void ROI_refinement::MultiPlaneROI(const int target_plane,
       auto wireid = wire->index();
       map_wireid_roichid[iplane][wireid] = roichid;
     }
-  }
-
-  for(int iplane = 0; iplane < 3; ++iplane) {
-    log->debug("[yuhw] wireid -> roichid {} {}", map_wireid_roichid[iplane].begin()->first, map_wireid_roichid[iplane].begin()->second);
-    log->debug("[yuhw] wireid -> roichid {} {}", map_wireid_roichid[iplane].rbegin()->first, map_wireid_roichid[iplane].rbegin()->second);
   }
 
   if (target_plane == 2)

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -2674,7 +2674,171 @@ void ROI_refinement::refine_data_debug_mode(int plane, ROI_formation& roi_form, 
     }
 #endif
   }
+}
+
+void ROI_refinement::MultiPlaneROI(const int target_plane,
+                                       const IAnodePlane::pointer anode,
+                                       const std::map<int, int> &map_roichid_anodechid, //ROI chid -> Anode chid
+                                       ROI_formation& roi_form,
+                                       const double threshold,
+                                       const int faceid,
+                                       const int tick_resolution,
+                                       const int wire_resolution,
+                                       const int nbounds_layers) {
+  log->info("ROI_refinement::MultiPlaneROI:");
+  const double th2 = 500;
+  LogDebug("th1: " << threshold << ", th2: " << th2);
+  std::set<int> print_chids = {1441, 875};
+  
+  // reverse map
+  std::map<int, int> map_anodechid_roichid;
+  for (auto r2a : map_roichid_anodechid) {
+    map_anodechid_roichid[r2a.second] = r2a.first;
+  }
+
+  log->debug("[yuhw] ROI chid -> Anode chid {} {}", map_roichid_anodechid.begin()->first, map_roichid_anodechid.begin()->second);
+  log->debug("[yuhw] ROI chid -> Anode chid {} {}", map_roichid_anodechid.rbegin()->first, map_roichid_anodechid.rbegin()->second);
+
+  log->debug("[yuhw] Anode chid -> ROI chid {} {}", map_anodechid_roichid.begin()->first, map_anodechid_roichid.begin()->second);
+  log->debug("[yuhw] Anode chid -> ROI chid {} {}", map_anodechid_roichid.rbegin()->first, map_anodechid_roichid.rbegin()->second);
+ 
+  std::map<int, int> map_wireid_roichid[3];
+  for(auto chident : anode->channels()) { // Anode chiid
+    auto iplane = anode->resolve(chident).index();
+    auto roichid = map_anodechid_roichid[chident];
+    auto ch = anode->channel(chident);
+    auto wires = ch->wires();
+    for (auto wire : wires) {
+      if(faceid != wire->planeid().face()) continue;
+      auto wireid = wire->index();
+      map_wireid_roichid[iplane][wireid] = roichid;
+    }
+  }
+
+  for(int iplane = 0; iplane < 3; ++iplane) {
+    log->debug("[yuhw] wireid -> roichid {} {}", map_wireid_roichid[iplane].begin()->first, map_wireid_roichid[iplane].begin()->second);
+    log->debug("[yuhw] wireid -> roichid {} {}", map_wireid_roichid[iplane].rbegin()->first, map_wireid_roichid[iplane].rbegin()->second);
+  }
+
+  if (target_plane == 2)
+    return;
+  int ref_planes[2] = {0, 2};
+  if (target_plane == 0) ref_planes[0] = 1;
+
+  std::map<int, std::vector<WireCell::RayGrid::coordinate_t>> map_tick_coord[3];
+  std::map<int, std::map<int, SignalROI *>> map_tick_pitch_roi[3];
+
+  for (int iplane = 0; iplane < 3; ++iplane) {
+    auto rois_chan = get_rois_by_plane(iplane);
+    for (auto rois : rois_chan) {
+      for (auto roi : rois) {
+        auto chid = map_roichid_anodechid.at(roi->get_chid());
+        WireCell::RayGrid::coordinate_t coord;
+        auto ch = anode->channel(chid);
+        auto wires = ch->wires();
+        for (auto wire : wires) {
+          if(faceid != wire->planeid().face()) continue;
+          auto pit_id = wire->index();
+          coord.grid = pit_id;
+          coord.layer = iplane + nbounds_layers;
+          for (int tick = roi->get_start_bin() / tick_resolution;
+               tick < roi->get_end_bin() / tick_resolution; ++tick) {
+            int content_id = tick * tick_resolution - roi->get_start_bin();
+            if (content_id < 0)
+              content_id = 0;
+            if (content_id >= (int)roi->get_contents().size())
+              content_id = roi->get_contents().size() - 1;
+
+            //  if (print_chids.find(chid)!=print_chids.end())
+            LogDebug(tick * tick_resolution
+                     << ", " << chid << " : {" << roi->get_chid() << ", "
+                     << roi->get_start_bin()
+                     << " } : " << roi->get_contents().at(content_id));
+
+            if (roi->get_contents().at(content_id) < th2)
+              continue;
+
+            if (map_tick_pitch_roi[iplane].find(tick) ==
+                map_tick_pitch_roi[iplane].end()) {
+              std::map<int, SignalROI *> mtmp;
+              mtmp[pit_id] = roi;
+              map_tick_pitch_roi[iplane][tick] = mtmp;
+            } else {
+              map_tick_pitch_roi[iplane][tick][pit_id] = roi;
+            }
+
+           //  LogDebug(iplane << ", " << tick*tick_resolution << ", " << pit_id);
+            
+            if (roi->get_contents().at(content_id) <
+               //  threshold * roi_form.get_rms_by_plane(iplane).at(roi->get_chid())
+               threshold
+               )
+              continue;
+            
+           //  LogDebug(iplane << ", " << tick*tick_resolution << ", " << coord.grid);
+
+            if (map_tick_coord[iplane].find(tick) ==
+                map_tick_coord[iplane].end()) {
+              std::vector<WireCell::RayGrid::coordinate_t> vtmp;
+              vtmp.push_back(coord);
+              map_tick_coord[iplane][tick] = vtmp;
+            } else {
+              map_tick_coord[iplane][tick].push_back(coord);
+            }
+
+          }
+        }
+      }
+    }
+
+   //  std::cout << " map_tick_coord:     " << map_tick_coord[iplane].size()
+   //            << " map_tick_pitch_roi: " << map_tick_pitch_roi[iplane].size()
+   //            << std::endl;
+  }
+
+  auto face = anode->face(faceid);
+  WireCell::RayGrid::layer_index_t layer = target_plane+nbounds_layers;
+  for (auto tc1 : map_tick_coord[ref_planes[0]]) {
+    for (auto tc2 : map_tick_coord[ref_planes[1]]) {
+      if (tc2.first != tc1.first)
+        continue;
+      auto tick = tc1.first;
+      for (auto c1 : tc1.second) {
+        for (auto c2 : tc2.second) {
+          auto pitch = face->raygrid().pitch_location(c1, c2, layer);
+          auto index = face->raygrid().pitch_index(pitch, layer);
+          // LogDebug(tick*tick_resolution << ", " << c1.grid << ", " << c2.grid);
+
+          for (auto pitch_target = index - wire_resolution+1;
+          pitch_target < index + wire_resolution; ++ pitch_target) {
+            std::pair<int, int> key = {map_wireid_roichid[target_plane][pitch_target],0};
+            int sta = tick * tick_resolution;
+            int end = sta + tick_resolution;
+            mp_rois.insert({key,{sta, end}});
+          }
+        }
+      }
+    }
+  }
+
+ {
+   LogDebug(" total rois:          " << get_rois_by_plane(target_plane).size()
+             << " at target_plane " << target_plane
+             << " protected_rois:      " << mp_rois.size());
+   std::multimap<int, std::pair<std::pair<int, int>, std::pair<int, int>>> tmp;
+   for (auto roi : mp_rois) {
+     tmp.insert({map_roichid_anodechid.at(roi.first.first), roi});
+   }
+#ifdef __DEBUG__
+   for (auto ch : tmp) {
+     LogDebug(ch.first << " : {" << ch.second.first.first << ", "
+                       << ch.second.first.second << "} : {"
+                       << ch.second.second.first << ", "
+                       << ch.second.second.second << "}, ");
+   }
+#endif
  }
+}
 
  void ROI_refinement::TestROIs() {
 

--- a/sigproc/src/ROI_refinement.h
+++ b/sigproc/src/ROI_refinement.h
@@ -39,8 +39,19 @@ namespace WireCell{
                                 const int wire_resolution = 2,
                                 const int nbounds_layers = 2);
 
+      void MultiPlaneROI(const int plane,
+                                const IAnodePlane::pointer anode,
+                                const std::map<int, int> &map_ch,
+                                ROI_formation& roi_form,
+                                const double threshold = 0.,
+                                const int faceid = 1,
+                                const int tick_resolution = 10,
+                                const int wire_resolution = 2,
+                                const int nbounds_layers = 2);
+
       typedef std::multimap<std::pair<int, int>, std::pair<int, int> > MapMPROI;
-      MapMPROI get_mp_rois() const { return proteced_rois;}
+      MapMPROI get_mp2_rois() const { return mp_rois;}
+      MapMPROI get_mp3_rois() const { return proteced_rois;}
 
       void CleanUpROIs(int plane);
       void generate_merge_ROIs(int plane);
@@ -101,6 +112,7 @@ namespace WireCell{
       SignalROIChList rois_v_loose;
 
       MapMPROI proteced_rois; //using chid and start_bin as id
+      MapMPROI mp_rois; //using chid and start_bin as id
    
     
       SignalROIMap front_rois;

--- a/sigproc/src/ROI_refinement.h
+++ b/sigproc/src/ROI_refinement.h
@@ -39,6 +39,9 @@ namespace WireCell{
                                 const int wire_resolution = 2,
                                 const int nbounds_layers = 2);
 
+      typedef std::multimap<std::pair<int, int>, std::pair<int, int> > MapMPROI;
+      MapMPROI get_mp_rois() const { return proteced_rois;}
+
       void CleanUpROIs(int plane);
       void generate_merge_ROIs(int plane);
       void CheckROIs(int plane, ROI_formation& roi_form);
@@ -97,7 +100,7 @@ namespace WireCell{
       SignalROIChList rois_u_loose;
       SignalROIChList rois_v_loose;
 
-      std::multimap<std::pair<int, int>, std::pair<int, int> > proteced_rois; //using chid and start_bin as id
+      MapMPROI proteced_rois; //using chid and start_bin as id
    
     
       SignalROIMap front_rois;

--- a/util/src/Array.cxx
+++ b/util/src/Array.cxx
@@ -8,7 +8,7 @@
 using namespace WireCell;
 using namespace WireCell::Array;
 
-thread_local static Eigen::FFT< float > gEigenFFT;
+thread_local static Eigen::FFT< float > gEigenFFT_dft;
 
 //http://stackoverflow.com/a/33636445
 
@@ -23,19 +23,20 @@ WireCell::Array::array_xxc WireCell::Array::dft(const WireCell::Array::array_xxf
         Eigen::VectorXcf fspec(ncols); // frequency spectrum 
 	// gEigenFFT wants vectors, also input arr is const
 	Eigen::VectorXf tmp = arr.row(irow);
-	gEigenFFT.fwd(fspec, tmp);
+	gEigenFFT_dft.fwd(fspec, tmp); //r2c
         matc.row(irow) = fspec;
     }
 
     for (int icol = 0; icol < ncols; ++icol) {
         Eigen::VectorXcf pspec(nrows); // periodicity spectrum
-        gEigenFFT.fwd(pspec, matc.col(icol));
+        gEigenFFT_dft.fwd(pspec, matc.col(icol)); //c2c
         matc.col(icol) = pspec;
     }
 
     return matc;
 }
 
+thread_local static Eigen::FFT< float > gEigenFFT_dft_rc;
 WireCell::Array::array_xxc WireCell::Array::dft_rc(const WireCell::Array::array_xxf& arr, int dim)
 {
     const int nrows = arr.rows();
@@ -47,7 +48,7 @@ WireCell::Array::array_xxc WireCell::Array::dft_rc(const WireCell::Array::array_
         for (int irow = 0; irow < nrows; ++irow) {
             Eigen::VectorXcf fspec(ncols);
             Eigen::VectorXf tmp = arr.row(irow);
-            gEigenFFT.fwd(fspec, tmp);
+            gEigenFFT_dft_rc.fwd(fspec, tmp); //r2c
             matc.row(irow) = fspec;
         }
     }
@@ -55,13 +56,14 @@ WireCell::Array::array_xxc WireCell::Array::dft_rc(const WireCell::Array::array_
         for (int icol = 0; icol < ncols; ++icol) {
             Eigen::VectorXcf fspec(nrows);
             Eigen::VectorXf tmp = arr.col(icol);
-            gEigenFFT.fwd(fspec, tmp);
+            gEigenFFT_dft_rc.fwd(fspec, tmp); //r2c
             matc.col(icol) = fspec;
         }
     }        
     return matc;
 }
 
+thread_local static Eigen::FFT< float > gEigenFFT_dft_cc;
 WireCell::Array::array_xxc WireCell::Array::dft_cc(const WireCell::Array::array_xxc& arr, int dim)
 {
     const int nrows = arr.rows();
@@ -74,14 +76,14 @@ WireCell::Array::array_xxc WireCell::Array::dft_cc(const WireCell::Array::array_
     if (dim == 0) {
         for (int irow = 0; irow < nrows; ++irow) {
             Eigen::VectorXcf pspec(ncols);
-            gEigenFFT.fwd(pspec,matc.row(irow));
+            gEigenFFT_dft_cc.fwd(pspec,matc.row(irow)); //c2c
             matc.row(irow) = pspec;
         }
     }
     else {
         for (int icol = 0; icol < ncols; ++icol) {
             Eigen::VectorXcf pspec(nrows);
-            gEigenFFT.fwd(pspec, matc.col(icol));
+            gEigenFFT_dft_cc.fwd(pspec, matc.col(icol)); //c2c
             matc.col(icol) = pspec;
         }
     }
@@ -90,6 +92,7 @@ WireCell::Array::array_xxc WireCell::Array::dft_cc(const WireCell::Array::array_
 
 
 
+thread_local static Eigen::FFT< float > gEigenFFT_idft;
 WireCell::Array::array_xxf WireCell::Array::idft(const WireCell::Array::array_xxc& arr)
 {
     const int nrows = arr.rows();
@@ -101,7 +104,7 @@ WireCell::Array::array_xxf WireCell::Array::idft(const WireCell::Array::array_xx
 
     for (int icol = 0; icol < ncols; ++icol) {
         Eigen::VectorXcf pspec(nrows); // wire spectrum
-        gEigenFFT.inv(pspec, partial.col(icol));
+        gEigenFFT_idft.inv(pspec, partial.col(icol)); //c2c
         partial.col(icol) = pspec;
     }
 
@@ -110,13 +113,14 @@ WireCell::Array::array_xxf WireCell::Array::idft(const WireCell::Array::array_xx
 
     for (int irow = 0; irow < nrows; ++irow) {
         Eigen::VectorXf wave(ncols); // back to real-valued time series
-        gEigenFFT.inv(wave, partial.row(irow));
+        gEigenFFT_idft.inv(wave, partial.row(irow)); //c2r
         ret.row(irow) = wave;
     }
 
     return ret;
 }
 
+thread_local static Eigen::FFT< float > gEigenFFT_idft_cc;
 WireCell::Array::array_xxc WireCell::Array::idft_cc(const WireCell::Array::array_xxc& arr, int dim)
 {
     const int nrows = arr.rows();
@@ -129,20 +133,21 @@ WireCell::Array::array_xxc WireCell::Array::idft_cc(const WireCell::Array::array
     if (dim == 1) {
         for (int icol = 0; icol < ncols; ++icol) {
             Eigen::VectorXcf pspec(nrows);
-            gEigenFFT.inv(pspec, ret.col(icol));
+            gEigenFFT_idft_cc.inv(pspec, ret.col(icol)); //c2c
             ret.col(icol) = pspec;
         }
     }
     else if (dim == 0) {
         for (int irow = 0; irow < nrows; ++irow) {
             Eigen::VectorXcf pspec(ncols);
-            gEigenFFT.inv(pspec, ret.row(irow));
+            gEigenFFT_idft_cc.inv(pspec, ret.row(irow)); //c2c
             ret.row(irow) = pspec;
         }
     }
     return ret;
 }
 
+thread_local static Eigen::FFT< float > gEigenFFT_idft_cr;
 WireCell::Array::array_xxf WireCell::Array::idft_cr(const WireCell::Array::array_xxc& arr, int dim)
 {
     const int nrows = arr.rows();
@@ -157,14 +162,14 @@ WireCell::Array::array_xxf WireCell::Array::idft_cr(const WireCell::Array::array
     if (dim == 0) {
         for (int irow = 0; irow < nrows; ++irow) {
             Eigen::VectorXf wave(ncols); // back to real-valued time series
-            gEigenFFT.inv(wave, partial.row(irow));
+            gEigenFFT_idft_cr.inv(wave, partial.row(irow)); //c2r
             ret.row(irow) = wave;
         }
     }
     else if (dim == 1) {
         for (int icol = 0; icol < ncols; ++icol) {
             Eigen::VectorXf wave(nrows);
-            gEigenFFT.inv(wave, partial.col(icol));
+            gEigenFFT_idft_cr.inv(wave, partial.col(icol)); //c2r
             ret.col(icol) = wave;
         }
     }
@@ -173,6 +178,7 @@ WireCell::Array::array_xxf WireCell::Array::idft_cr(const WireCell::Array::array
 
 
 
+thread_local static Eigen::FFT< float > gEigenFFT_deconv;
 // this is a cut-and-paste mashup of dft() and idft() in order to avoid temporaries.
 WireCell::Array::array_xxf
 WireCell::Array::deconv(const WireCell::Array::array_xxf& arr,
@@ -186,13 +192,13 @@ WireCell::Array::deconv(const WireCell::Array::array_xxf& arr,
 	Eigen::VectorXcf fspec(ncols); // frequency spectrum 
 	// gEigenFFT wants vectors, also input arr is const
 	Eigen::VectorXf tmp = arr.row(irow);
-	gEigenFFT.fwd(fspec, tmp);
+	gEigenFFT_deconv.fwd(fspec, tmp); //r2c
 	matc.row(irow) = fspec;
     }
     
     for (int icol = 0; icol < ncols; ++icol) {
 	Eigen::VectorXcf pspec(nrows); // periodicity spectrum
-	gEigenFFT.fwd(pspec, matc.col(icol));
+	gEigenFFT_deconv.fwd(pspec, matc.col(icol)); //c2c
 	matc.col(icol) = pspec;
     }
 
@@ -201,7 +207,7 @@ WireCell::Array::deconv(const WireCell::Array::array_xxf& arr,
 
     for (int icol = 0; icol < ncols; ++icol) {
         Eigen::VectorXcf pspec(nrows); // wire spectrum
-        gEigenFFT.inv(pspec, filt.col(icol));
+        gEigenFFT_deconv.inv(pspec, filt.col(icol)); //c2c
         filt.col(icol) = pspec;
     }
 
@@ -209,7 +215,7 @@ WireCell::Array::deconv(const WireCell::Array::array_xxf& arr,
 
     for (int irow = 0; irow < nrows; ++irow) {
         Eigen::VectorXf wave(ncols); // back to real-valued time series
-        gEigenFFT.inv(wave, filt.row(irow));
+        gEigenFFT_deconv.inv(wave, filt.row(irow)); //c2r
         ret.row(irow) = wave;
     }
 


### PR DESCRIPTION
The Multi-Plane information could be used in external applications like  in a Machine Learning session.

Related talks:
3-Plane MP ROI: https://indico.bnl.gov/event/7168/contributions/33380/
2-Plane MP ROI: https://indico.bnl.gov/event/7204/contributions/33529/

Analysis macros:
https://github.com/HaiwangYu/wct-analysis/tree/master/ml-sp
