### PR TITLE
add optional plane for signal processing

### DIFF
--- a/cfg/pgrapher/experiment/pdsp/sp.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/sp.jsonnet
@@ -65,6 +65,7 @@ function(params, tools, override = {}) {
       mp2_roi_tag: 'mp2_roi%d' % anode.data.ident,
       
       isWrapped: false,
+      // process_planes: [0, 2],
 
     } + override,
   }, nin=1, nout=1, uses=[anode, tools.field] + pc.uses + spfilt),

--- a/cfg/pgrapher/experiment/pdsp/wct-sim-check.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/wct-sim-check.jsonnet
@@ -49,14 +49,8 @@ local tracklist = [
 
   {
     time: 0 * wc.us, 
-    charge: -2500, // 5000 e/mm
-    ray: parallel,
-  },
-
-  {
-    time: 0 * wc.us,
-    charge: -2500, // 5000 e/mm
-    ray: cathpier,
+    charge: -5000, // 5000 e/mm
+    ray: params.det.bounds,
   },
 
 ];
@@ -65,7 +59,7 @@ local output = 'wct-sim-ideal-sig.npz';
 
 //local depos = g.join_sources(g.pnode({type:"DepoMerger", name:"BlipTrackJoiner"}, nin=2, nout=1),
 //                             [sim.ar39(), sim.tracks(tracklist)]);
-local depos = sim.tracks(tracklist, step=0.5 * wc.mm);
+local depos = sim.tracks(tracklist, step=1.0 * wc.mm);
 
 
 //local deposio = io.numpy.depos(output);

--- a/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
+++ b/sigproc/inc/WireCellSigProc/OmnibusSigProc.h
@@ -48,6 +48,7 @@ namespace WireCell {
                      int r_max_npeaks = 200,
                      double r_sigma = 2.0,
                      double r_th_percent = 0.1,
+                     std::vector<int> process_planes = {0, 1, 2},
                      int charge_ch_offset = 10000,
                      const std::string& wiener_tag = "wiener",
                      const std::string& wiener_threshold_tag = "threshold",
@@ -174,6 +175,9 @@ namespace WireCell {
       int m_r_max_npeaks;
       double m_r_sigma;
       double m_r_th_percent;
+
+      // specify the planes to process
+      std::vector<int> m_process_planes;
 
       // fixme: this is apparently not used:
       // channel offset


### PR DESCRIPTION
A user can specify the plane number for signal processing (see pdsp/sp.jsonnet). Otherwise, the default value for process_planes is {0,1,2}.