### PR TITLE
adjust bounding box for split schema

### DIFF
--- a/cfg/pgrapher/common/tools.jsonnet
+++ b/cfg/pgrapher/common/tools.jsonnet
@@ -124,6 +124,8 @@ function(params)
             nimpacts: params.sim.nimpacts,
             // The wire schema file
             wire_schema: wc.tn($.wires),
+            // split bounding box
+            split_bb: params.det.split_bb,
 
             faces : vol.faces,
         },

--- a/cfg/pgrapher/experiment/icarus/params.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/params.jsonnet
@@ -92,10 +92,10 @@ base {
                 ],
             } for n in std.range(0,3)],*/
 
-        local xanode = [-365.33*wc.cm, 0, 0, 365.33*wc.cm],
+        local xanode = [-369.33*wc.cm, -71.1*wc.cm, 71.1*wc.cm, 369.33*wc.cm],
         local offset_response = [if a%2==0 then +10*wc.cm else -10*wc.cm for a in std.range(0,3)],
         local xresponse = [xanode[a] + offset_response[a] for a in std.range(0,3)],
-        local xcathode = [-149.1*wc.cm, -149.1*wc.cm, 149.1*wc.cm, 149.1*wc.cm],
+        local xcathode = [-220.29*wc.cm, -220.29*wc.cm, 220.29*wc.cm, 220.29*wc.cm],
         volumes : [
             {
                 local world = 100,  // identify this geometry
@@ -117,6 +117,8 @@ base {
                 ],
             } for a in std.range(0,3) for s in std.range(1,2)
         ],
+
+        split_bb: true,
 
         // This describes some rough, overall bounding box.  It's not
         // directly needed but can be useful on the Jsonnet side, for
@@ -191,7 +193,8 @@ base {
         // fixme: this is for microboone and probably bogus for
         // protodune because (at least) the span of MB wire lengths do
         // not cover pdsp's.
-        noise: "protodune-noise-spectra-v1.json.bz2",
+        // noise: "protodune-noise-spectra-v1.json.bz2",
+        noise: "t600-corr-noise-spectra.json.bz2",
 
 
         chresp: null,


### PR DESCRIPTION
When testing the icarus simualtion with wriecell, I found that the BoundingBoxs for two splits are identical. For example, I printed out the sensitive volumes for two splits in the DepoTransform.cxx
> [DepoTransform:bb] (2202.9 -1818.5 -8951.01) (3693.3 1349.5 8951.01)
> [DepoTransform:bb] (2202.9 -1818.5 -8951.01) (3693.3 1349.5 8951.01)

The reason is that in the AnodePlane.cxx, the bounding box is created for each face with the bounding box from the last plane

> // AnodePlane.cxx
>             // Last iteration, use W plane to define volume
>             if (iplane == nplanes-1) { 
>                 const double mean_pitch = (pitchmax - pitchmin) / (nwires-1);
>                 BoundingBox sensvol;
>                 if (sensitive_face) {
>                     auto v1 = bb_ray.first;
>                     auto v2 = bb_ray.second;
>                     // Enlarge to anode/cathode planes in X and by 1/2 pitch in Z.
>                     Point p1(  anode_x, v1.y(), std::min(v1.z(), v2.z()) - 0.5*mean_pitch);
>                     sensvol(p1);
>                     Point p2(cathode_x, v2.y(), std::max(v1.z(), v2.z()) + 0.5*mean_pitch);
>                     sensvol(p2);
>                 }
>                ...
>                 m_faces[iface] = make_shared<AnodeFace>(ws_face.ident, planes, sensvol);
>             }

As a result, I got two identical tracks in two splits after DepoTransform because the same track has been considered within the BoundingBox for both splits of anodes.
![image](https://user-images.githubusercontent.com/10663117/73303610-c44dbf80-41e4-11ea-8140-e4d6526afe2a.png)

The solution is to add an option `split_bb` when the AnodePlane is created, and the overlap of three planes in Z-direction will be used to declare the BoundingBox of a face. Below is the new result for the two bounding boxes mentioned at the beginning. One can see that the border is now splitted at +/-1.5, which is one half of the wire pitch (3mm).

> [DepoTransform:bb] (2202.9 -1818.5 -8951.01) (3693.3 1349.5 1.5)
> [DepoTransform:bb] (2202.9 -1818.5 -1.5) (3693.3 1349.5 8951.01)

Here is the waveform after this update. One can see only one track now.
![image](https://user-images.githubusercontent.com/10663117/73303548-ada76880-41e4-11ea-97a3-72b038b17599.png)

