### PR TITLE
deduce the sensitive volume from all planes in a tpc face

### DIFF
--- a/cfg/pgrapher/experiment/icarus/params.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/params.jsonnet
@@ -92,10 +92,10 @@ base {
                 ],
             } for n in std.range(0,3)],*/
 
-        local xanode = [-365.33*wc.cm, 0, 0, 365.33*wc.cm],
+        local xanode = [-369.33*wc.cm, -71.1*wc.cm, 71.1*wc.cm, 369.33*wc.cm],
         local offset_response = [if a%2==0 then +10*wc.cm else -10*wc.cm for a in std.range(0,3)],
         local xresponse = [xanode[a] + offset_response[a] for a in std.range(0,3)],
-        local xcathode = [-149.1*wc.cm, -149.1*wc.cm, 149.1*wc.cm, 149.1*wc.cm],
+        local xcathode = [-220.29*wc.cm, -220.29*wc.cm, 220.29*wc.cm, 220.29*wc.cm],
         volumes : [
             {
                 local world = 100,  // identify this geometry
@@ -191,7 +191,7 @@ base {
         // fixme: this is for microboone and probably bogus for
         // protodune because (at least) the span of MB wire lengths do
         // not cover pdsp's.
-        noise: "protodune-noise-spectra-v1.json.bz2",
+        noise: "t600-corr-noise-spectra.json.bz2",
 
 
         chresp: null,

--- a/util/inc/WireCellUtil/Point.h
+++ b/util/inc/WireCellUtil/Point.h
@@ -85,6 +85,8 @@ namespace WireCell {
      * at opposite corners. */
     double ray_volume(const Ray& ray);
 
+    /** Return the ray representing the intersection of two BoundingBox. */
+    Ray box_intersect(const Ray& r1, const Ray& r2);
 
     template<>
     inline			// fixme: ignores default

--- a/util/src/Point.cxx
+++ b/util/src/Point.cxx
@@ -104,3 +104,28 @@ double WireCell::ray_volume(const WireCell::Ray& ray)
     return diff.x() * diff.y() * diff.z();
 }
 
+// This returns the intersection between two unrotated(!)
+// box volumes, represented by a Ray.
+//       ________
+//      |    S2  |
+//  ____|___     |
+// |    |   |    |
+// |    |___|____|
+// | S1     |
+// |________|
+WireCell::Ray WireCell::box_intersect(const Ray& s1, const Ray& s2)
+{
+    Ray bb_ray;
+    for(size_t ind=0; ind<3; ind++) {
+        auto lb1 = s1.first[ind]; // left bound
+        auto rb1 = s1.second[ind]; // right bound
+        if (lb1 > rb1) std::swap(lb1, rb1); // let left < right
+        auto lb2 = s2.first[ind];
+        auto rb2 = s2.second[ind];
+        if (lb2 > rb2) std::swap(lb2, rb2);
+
+        bb_ray.first[ind] = std::max(lb1, lb2);
+        bb_ray.second[ind] = std::min(rb1, rb2);
+    }
+    return bb_ray;
+}


### PR DESCRIPTION
As suggested in this request (https://github.com/WireCell/wire-cell-toolkit/pull/32), the sensitive volume for a face/TPC now is calculated with an intersection of volumes from all planes. Below I simply printed out the sensitive volumes for microboone/pdsp/icarus **before** and **after** the change of the logic. No significant is observed, except that in ICARUS two adjacent "split" anodes are now correctly separated.

- microboone
-- default (sensitive volume from W plane only)
bounds: [(0 -1155.3 1) --> (2548 1174.7 10369)] 
-- new (sensitive volume from intersection of all planes)
bounds: [(0 -1155.1 1) --> (2548 1174.5 10369)]

The slight difference can be explained by the bounds of each plane
plane 0: [(0 -1155.1 0.352608) --> (2548 1174.5 10369.6)]
plane 1: [(0 -1155.1 0.352608) --> (2548 1174.5 10369.6)]
plane 2: [(0 -1155.3 1) --> (2548 1174.7 10369)]

- protodune
-- default (ignore empty face)
[(-3579.85 76.1 3.207) --> (-25.4 6060 2303.37)]
[(25.4 76.1 3.358) --> (3579.85 6060 2303.52)]
[(-3579.85 76.1 2323.81) --> (-25.4 6060 4623.97)] 
[(25.4 76.1 2323.96) --> (3579.85 6060 4624.12)] 
[(-3579.85 76.1 4644.41) --> (-25.4 6060 6944.57)] 
[(25.4 76.1 4644.56) --> (3579.85 6060 6944.72)] 
-- new
[(-3579.85 76.1 3.35) --> (-25.4 6060 2303.37)]
[(25.4 76.1 3.358) --> (3579.85 6060 2303.38)]
[(-3579.85 76.1 2323.95) --> (-25.4 6060 4623.97)]
[(25.4 76.1 2323.96) --> (3579.85 6060 4623.97)]
[(-3579.85 76.1 4644.55) --> (-25.4 6060 6944.57)]
[(25.4 76.1 4644.56) --> (3579.85 6060 6944.57)]

- icarus
-- default (we have 8 splits of anodes in total)
[(-3693.3 -1818.5 -8951.01) --> (-2202.9 1349.5 8951.01)] 
[(-3693.3 -1818.5 -8951.01) --> (-2202.9 1349.5 8951.01)] 
[(-2202.9 -1818.5 -8951.01) --> (-711 1349.5 8951.01)]
[(-2202.9 -1818.5 -8951.01) --> (-711 1349.5 8951.01)] 
[(711 -1818.5 -8951.01) --> (2202.9 1349.5 8951.01)] 
[(711 -1818.5 -8951.01) --> (2202.9 1349.5 8951.01)] 
[(2202.9 -1818.5 -8951.01) --> (3693.3 1349.5 8951.01)] 
[(2202.9 -1818.5 -8951.01) --> (3693.3 1349.5 8951.01)] 
-- new
[(-3693.3 -1818.5 -8949.51) --> (-2202.9 1349.5 0)] // see "split1" works
[(-3693.3 -1818.5 0) --> (-2202.9 1349.5 8949.51)] // also "split2" works
[(-2202.9 -1818.5 -8949.51) --> (-711 1349.5 0)]
[(-2202.9 -1818.5 0) --> (-711 1349.5 8949.51)]
[(711 -1818.5 -8949.51) --> (2202.9 1349.5 0)]
[(711 -1818.5 0) --> (2202.9 1349.5 8949.51)]
[(2202.9 -1818.5 -8949.51) --> (3693.3 1349.5 0)]
[(2202.9 -1818.5 0) --> (3693.3 1349.5 8949.51)]

