### PR TITLE
move eigen utilities to WireCell::Array; warning fix

### DIFF
--- a/util/inc/WireCellUtil/Array.h
+++ b/util/inc/WireCellUtil/Array.h
@@ -116,6 +116,29 @@ namespace WireCell {
 	 */
 	array_xxf deconv(const array_xxf& arr, const array_xxc& filter);
 
+        /** downsample a 2D array along one axis by k
+         *  simple average of all numbers in a bin
+         *  e.g: MxN -> Mxfloor(N/k)
+         *  extra rows/cols are ignored
+         */
+        array_xxf downsample(const array_xxf &in, const unsigned int k, const int dim = 0);
+        
+        /** upsample a 2D array along one axis by k
+         *  e.g: MxN -> MxN*k
+         *  all numbers in a new bin are assigned with same value
+         */
+        array_xxf upsample(const array_xxf &in, const unsigned int k, const int dim = 0);
+                
+        /** put a mask on in
+         *  in and mask need to have same shape
+         *  values > th in mask are considered pass
+         */
+        array_xxf mask(const array_xxf &in, const array_xxf &mask, const float th = 0.5);
+                        
+        /** linear baseline subtraction along row direction
+         */
+        array_xxf baseline_subtraction(const array_xxf &in);
+
     }
 }
 

--- a/util/src/Array.cxx
+++ b/util/src/Array.cxx
@@ -1,4 +1,5 @@
 #include "WireCellUtil/Array.h"
+#include "WireCellUtil/Exceptions.h"
 
 #include <unsupported/Eigen/FFT>
 
@@ -221,3 +222,73 @@ WireCell::Array::deconv(const WireCell::Array::array_xxf& arr,
     return ret;
 }
 
+
+WireCell::Array::array_xxf WireCell::Array::downsample(const Array::array_xxf &in, const unsigned int k, const int dim) {
+  if(dim==0) {
+    Array::array_xxf out = Array::array_xxf::Zero(in.rows()/k, in.cols());
+    for(unsigned int i=0; i<in.rows(); ++i) {
+      out.row(i/k) = out.row(i/k) + in.row(i);
+    }
+    return out/k;
+  }
+  if(dim==1) {
+    Array::array_xxf out = Array::array_xxf::Zero(in.rows(), in.cols()/k);
+    for(unsigned int i=0; i<in.cols(); ++i) {
+      out.col(i/k) = out.col(i/k) + in.col(i);
+    }
+    return out/k;
+  }
+  THROW(ValueError() << errmsg{"dim should be 0 or 1"});
+}
+
+WireCell::Array::array_xxf WireCell::Array::upsample(
+  const Array::array_xxf &in,
+  const unsigned int k,
+  const int dim) {
+  if(dim==0) {
+    Array::array_xxf out = Array::array_xxf::Zero(in.rows()*k, in.cols());
+    for(unsigned int i=0; i<in.rows()*k; ++i) {
+      out.row(i) = in.row(i/k);
+    }
+    return out;
+  }
+  if(dim==1) {
+    Array::array_xxf out = Array::array_xxf::Zero(in.rows(), in.cols()*k);
+    for(unsigned int i=0; i<in.cols()*k; ++i) {
+      out.col(i) = in.col(i/k);
+    }
+    return out;
+  }
+  THROW(ValueError() << errmsg{"dim should be 0 or 1"});
+}
+
+WireCell::Array::array_xxf WireCell::Array::mask(const Array::array_xxf &in, const Array::array_xxf &mask, const float th) {
+  Array::array_xxf ret = Eigen::ArrayXXf::Zero(in.rows(),in.cols());
+  if(in.rows()!=mask.rows() || in.cols()!=mask.cols()) {
+    THROW(ValueError() << errmsg{"in.rows()!=mask.rows() || in.cols()!=mask.cols()"});
+  }
+  return (mask>th).select(in, ret);
+}
+
+WireCell::Array::array_xxf WireCell::Array::baseline_subtraction(
+  const Array::array_xxf &in
+) {
+  Array::array_xxf ret = Eigen::ArrayXXf::Zero(in.rows(),in.cols());
+  for(int ich=0; ich<in.cols(); ++ich) {
+    int sta = 0;
+    int end = 0;
+    for(int it=0; it<in.rows(); ++it) {
+      if(in(it,ich) == 0) {
+        if(sta < end){
+          for(int i=sta;i<end+1;++i) {
+            ret(i,ich) = in(i,ich)-(in(sta,ich)+(i-sta)*(in(end,ich)-in(sta,ich))/(end-sta));
+          }
+        }
+        sta = it+1; // first tick in ROI
+      } else {
+        end = it; // last tick in ROI
+      }
+    }
+  }
+  return ret;
+}


### PR DESCRIPTION
- moved some Eigen::Array utility functions from `DNNROIFinding` to WireCell::Array
- Fixed some warnings in `DNNROIFinding`

Results are validated by comparing decon_charge, ROI and sp charge:
![image](https://user-images.githubusercontent.com/10383186/74283909-c89fcf80-4cf0-11ea-91b0-2b6cce677211.png)
This comparison is used as a convoluted way to test the up/down sampling and baseline subtraction