### PR TITLE
[cfg] add basic nf in icarus data processing

### DIFF
--- a/cfg/pgrapher/experiment/icarus/chndb-base.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/chndb-base.jsonnet
@@ -4,6 +4,7 @@
 
 local handmade = import 'chndb-resp.jsonnet';
 local wc = import 'wirecell.jsonnet';
+local util = import 'pgrapher/experiment/icarus/funcs.jsonnet';
 
 function(params, anode, field, n, rms_cuts=[])
   {
@@ -20,14 +21,14 @@ function(params, anode, field, n, rms_cuts=[])
     // For MicroBooNE, channel groups is a 2D list.  Each element is
     // one group of channels which should be considered together for
     // coherent noise filtering.
-    // groups: [std.range(g*48, (g+1)*48-1) for g in std.range(0,171)],
-    groups: [std.range(n * 2560 + u * 40, n * 2560 + (u + 1) * 40 - 1) for u in std.range(0, 19)]
-            + [std.range(n * 2560 + 800 + v * 40, n * 2560 + 800 + (v + 1) * 40 - 1) for v in std.range(0, 19)]
-            + [std.range(n * 2560 + 1600 + w * 48, n * 2560 + 1600 + (w + 1) * 48 - 1) for w in std.range(0, 19)],
+    groups: [std.range(g*64, (g+1)*64-1) for g in std.range(0,171)],
+    // groups: [std.range(n * 2560 + u * 40, n * 2560 + (u + 1) * 40 - 1) for u in std.range(0, 19)]
+    //         + [std.range(n * 2560 + 800 + v * 40, n * 2560 + 800 + (v + 1) * 40 - 1) for v in std.range(0, 19)]
+    //         + [std.range(n * 2560 + 1600 + w * 48, n * 2560 + 1600 + (w + 1) * 48 - 1) for w in std.range(0, 19)],
 
 
     // Externally determined "bad" channels.
-    bad: [1, 2, 4, 200, 202, 204, 206, 208, 400, 401, 800, 801, 876, 991, 993, 995, 997, 999, 1200, 1632, 1719, 1829, 1831, 1833, 1835, 1837, 1839, 2169, 2961, 3541, 3543, 3661, 3663, 4061, 4063, 4141, 4143, 4377, 4379, 4381, 4383, 4385, 4387, 4410, 4411, 4412, 4521, 4523, 4525, 4527, 4529, 4531, 4652, 4654, 4656, 4658, 4658, 4660, 4748, 4750, 4752, 4754, 4756, 4758, 5125, 5321, 5361, 5363, 6132, 7058, 7190, 7194, 7295, 7551, 7680, 7681, 7918, 8080, 8328, 8480, 8501, 8503, 8821, 8823, 9261, 9263, 9282, 9283, 9305, 9307, 9309, 9311, 9313, 9315, 9689, 9691, 9693, 9695, 9697, 9699, 9736, 9772, 9774, 9776, 9778, 9780, 9782, 9854, 9990, 10102, 10189, 10697, 10800, 10907, 11024, 11203, 11270, 11457, 11459, 11463, 11469, 11517, 11669, 11679, 11842, 11902, 12324, 12333, 12744, 12756, 12801, 13001, 13081, 13363],
+    bad: [],
 
     // Overide defaults for specific channels.  If an info is
     // mentioned for a particular channel in multiple objects in this
@@ -40,7 +41,7 @@ function(params, anode, field, n, rms_cuts=[])
       // repeat values found here in subsequent entries unless you
       // wish to change them.
       {
-        channels: std.range(n * 2560, (n + 1) * 2560 - 1),
+        channels: util.anode_channels(n),
         nominal_baseline: 2048.0,  // adc count
         gain_correction: 1.0,  // unitless
         response_offset: 0.0,  // ticks?
@@ -66,58 +67,6 @@ function(params, anode, field, n, rms_cuts=[])
         // field response waveform to make "response" spectrum.
         response: {},
 
-      },
-
-      {
-        //channels: { wpid: wc.WirePlaneId(wc.Ulayer) },
-	channels: std.range(n * 2560, n * 2560 + 800- 1),
-	freqmasks: [
-          { value: 1.0, lobin: 0, hibin: $.nsamples - 1 },
-          { value: 0.0, lobin: 169, hibin: 173 },
-          { value: 0.0, lobin: 513, hibin: 516 },
-        ],
-        /// this will use an average calculated from the anode
-        // response: { wpid: wc.WirePlaneId(wc.Ulayer) },
-        /// this uses hard-coded waveform.
-        response: { waveform: handmade.u_resp, waveformid: wc.Ulayer },
-        response_offset: 120, // offset of the negative peak
-        pad_window_front: 20,
-        decon_limit: 0.02,
-        decon_limit1: 0.07,
-        roi_min_max_ratio: 3.0,
-      },
-
-      {
-        //channels: { wpid: wc.WirePlaneId(wc.Vlayer) },
-	channels: std.range(n * 2560 + 800, n * 2560 + 1600- 1),
-        freqmasks: [
-          { value: 1.0, lobin: 0, hibin: $.nsamples - 1 },
-          { value: 0.0, lobin: 169, hibin: 173 },
-          { value: 0.0, lobin: 513, hibin: 516 },
-        ],
-        /// this will use an average calculated from the anode
-        // response: { wpid: wc.WirePlaneId(wc.Vlayer) },
-        /// this uses hard-coded waveform.
-        response: { waveform: handmade.v_resp, waveformid: wc.Vlayer },
-        response_offset: 124,
-        decon_limit: 0.01,
-        decon_limit1: 0.08,
-        roi_min_max_ratio: 1.5,
-      },
-
-      local freqbinner = wc.freqbinner(params.daq.tick, params.nf.nsamples);
-      local harmonic_freqs = [f*wc.kilohertz for f in
-        // [51.5, 102.8, 154.2, 205.5, 256.8, 308.2, 359.2, 410.5, 461.8, 513.2, 564.5, 615.8]
-        [51.5, 77.2, 102.8, 128.5, 154.2, 180.0, 205.5, 231.5, 256.8, 282.8, 308.2, 334.0, 359.2, 385.5, 410.5, 461.8, 513.2, 564.5, 615.8, 625.0]
-      ];
-      
-      {
-        //channels: { wpid: wc.WirePlaneId(wc.Wlayer) },
-	channels: std.range(n * 2560 + 1600, n * 2560 + 2560- 1),
-        nominal_baseline: 400.0,
-        decon_limit: 0.05,
-        decon_limit1: 0.08,
-        freqmasks: freqbinner.freqmasks(harmonic_freqs, 5.0*wc.kilohertz),
       },
 
     ] + rms_cuts,

--- a/cfg/pgrapher/experiment/icarus/funcs.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/funcs.jsonnet
@@ -3,6 +3,10 @@
 local g = import 'pgraph.jsonnet';
 
 {
+    //  Return a list of channel by anode index [1-8]
+    anode_channels(n):: std.range(1056 * (n % 2) + 13312 * (n - n % 2) / 2, 1056 * (n % 2 + 1) - 1 + 13312 * (n - n % 2) / 2) + std.range(1056 * 2 + 13312 * (n - n % 2) / 2, 13312 - 1 + 13312 * (n - n % 2) / 2),
+
+
     //  Build a depofanout-[signal]-[framesummer]-[pipelines]-fanin graph.
     //  FrameSummer add up the two "split" anodes into one frame.
     //  Each branch of the pipelines operates on the summed signal frame.

--- a/cfg/pgrapher/experiment/icarus/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/magnify-sinks.jsonnet
@@ -32,12 +32,12 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        frames: ['raw%d' % n],
+        frames: ['raw%d' % tools.anodes[n].data.ident],
         trace_has_tag: true,
-        cmmtree: [["noisy", "T_noisy%d"%n],
-                  ["sticky", "T_stky%d"%n],
-                  ["ledge", "T_ldg%d"%n],
-                  ["harmonic", "T_hm%d"%n] ], // maskmap in nf.jsonnet 
+//        cmmtree: [["noisy", "T_noisy%d"%n],
+//                  ["sticky", "T_stky%d"%n],
+//                  ["ledge", "T_ldg%d"%n],
+//                  ["harmonic", "T_hm%d"%n] ], // maskmap in nf.jsonnet 
         anode: wc.tn(tools.anodes[n]),
       },
     }, nin=1, nout=1)

--- a/cfg/pgrapher/experiment/icarus/nf.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/nf.jsonnet
@@ -7,38 +7,17 @@ local gainmap = import 'pgrapher/experiment/pdsp/chndb-rel-gain.jsonnet';
 function(params, anode, chndbobj, n, name='')
   {
 
-//    local bitshift = {
-//        type: "mbADCBitShift",
-//        name:name,
-//        data: {
-//            Number_of_ADC_bits: params.adc.resolution,
-//            Exam_number_of_ticks_test: 500,
-//            Threshold_sigma_test: 7.5,
-//            Threshold_fix: 0.8,
-//        },
-//    },
-//    local status = {
-//      type: 'mbOneChannelStatus',
-//      name: name,
-//      data: {
-//        Threshold: 3.5,
-//        Window: 5,
-//        Nbins: 250,
-//        Cut: 14,
-//        anode: wc.tn(anode),
-//      },
-//    },
     local single = {
       type: 'pdOneChannelNoise',
       name: name,
       data: {
         noisedb: wc.tn(chndbobj),
         anode: wc.tn(anode),
-        resmp: [
-          {channels: std.range(2128, 2175), sample_from: 5996},
-          {channels: std.range(1520, 1559), sample_from: 5996},
-          {channels: std.range( 440,  479), sample_from: 5996},
-        ],
+//        resmp: [
+//          {channels: std.range(2128, 2175), sample_from: 5996},
+//          {channels: std.range(1520, 1559), sample_from: 5996},
+//          {channels: std.range( 440,  479), sample_from: 5996},
+//        ],
       },
     },
     local grouped = {
@@ -91,11 +70,11 @@ function(params, anode, chndbobj, n, name='')
 
         // channel bin ranges are ignored
         // only when the channelmask is merged to `bad`
-        maskmap: {sticky: "bad", ledge: "bad", noisy: "bad"},
+        // maskmap: {sticky: "bad", ledge: "bad", noisy: "bad"},
         channel_filters: [
-          wc.tn(sticky),
+          // wc.tn(sticky),
           wc.tn(single),
-          wc.tn(gaincalib),
+          // wc.tn(gaincalib),
         ],
         grouped_filters: [
           wc.tn(grouped),
@@ -103,8 +82,8 @@ function(params, anode, chndbobj, n, name='')
         channel_status_filters: [
         ],
         noisedb: wc.tn(chndbobj),
-        intraces: 'orig%d' % n,  // frame tag get all traces
-        outtraces: 'raw%d' % n,
+        intraces: 'orig%d' % anode.data.ident,  // frame tag get all traces
+        outtraces: 'raw%d' % anode.data.ident,
       },
       //}, uses=[chndbobj, anode, single, grouped, bitshift, status], nin=1, nout=1),
       //}, uses=[chndbobj, anode, single, grouped, status], nin=1, nout=1),

--- a/cfg/pgrapher/experiment/icarus/wcls-decode-to-sig.fcl
+++ b/cfg/pgrapher/experiment/icarus/wcls-decode-to-sig.fcl
@@ -27,7 +27,7 @@ physics :{
             apps: ["Pgrapher"]
 
             logsinks: ["stdout"]
-            loglevels: ["debug", "pgraph:info"]
+            loglevels: ["debug", "pgraph:info", "glue:debug", "sigproc:debug"]
 
             // Libraries in which to look for WCT components
             plugins: ["WireCellGen", "WireCellSigProc", "WireCellRoot", "WireCellPgraph", "WireCellLarsoft"]


### PR DESCRIPTION
Some configuration update for ICARUS minicrate dataset. The MicroBooNE style coherent noise removal is configured in the ICARUS environment. It looks good at first glance (see figures below for 2D waveform before and after noise filtering). More investigations like the power spectrum before and after noise removal will be added.

![image](https://user-images.githubusercontent.com/10663117/74675266-2e70d900-5181-11ea-96f3-712b2bef3af5.png)

To reproduce this result, simply run `lar -n1 -c pgrapher/experiment/icarus/wcls-decode-to-sig.fcl data_dl1_run822_201_20200109T010140_dl3_decoded_root`. The decoded data is available [here](https://www.phy.bnl.gov/~wgu/icarus/data_dl1_run822_201_20200109T010140_dl3_decoded_root).