### PR TITLE
Init Torch Script Wrapper

### DIFF
--- a/pytorch/inc/WireCellPytorch/DNNROIFinding.h
+++ b/pytorch/inc/WireCellPytorch/DNNROIFinding.h
@@ -12,6 +12,8 @@
 #include "WireCellUtil/Array.h"
 #include "WireCellUtil/Logging.h"
 
+#include "WireCellPytorch/ITorchScript.h"
+
 #include <torch/script.h> // One-stop header.
 
 namespace WireCell {
@@ -38,6 +40,8 @@ private:
 
   Configuration m_cfg; /// copy of configuration
   IAnodePlane::pointer m_anode; /// pointer to some APA, needed to associate chnnel ID to planes
+
+  ITorchScript::pointer m_torch; ///
 
   torch::jit::script::Module module;
 

--- a/pytorch/inc/WireCellPytorch/DNNROIFinding.h
+++ b/pytorch/inc/WireCellPytorch/DNNROIFinding.h
@@ -41,9 +41,7 @@ private:
   Configuration m_cfg; /// copy of configuration
   IAnodePlane::pointer m_anode; /// pointer to some APA, needed to associate chnnel ID to planes
 
-  ITorchScript::pointer m_torch; ///
-
-  torch::jit::script::Module module;
+  ITorchScript::pointer m_torch; /// pointer to a TorchScript wrapper
 
   int m_save_count;   // count frames saved
   

--- a/pytorch/inc/WireCellPytorch/ITorchScript.h
+++ b/pytorch/inc/WireCellPytorch/ITorchScript.h
@@ -1,0 +1,25 @@
+/** A wrapper for pytorch torchscript
+ */
+
+#ifndef WIRECELLPYTORCH_ITORCHSCRIPT
+#define WIRECELLPYTORCH_ITORCHSCRIPT
+
+#include "WireCellUtil/IComponent.h"
+
+#include <torch/script.h> // One-stop header.
+
+namespace WireCell {
+namespace Pytorch {
+class ITorchScript : public IComponent<ITorchScript> {
+public:
+  virtual ~ITorchScript() {}
+  /// Return the ident number
+  virtual int ident() const = 0;
+
+  /// wrapper of the torch script forward function
+  virtual torch::IValue forward(const std::vector<torch::IValue> &inputs) = 0;
+};
+} // namespace Pytorch
+} // namespace WireCell
+
+#endif // WIRECELLPYTORCH_ITORCHSCRIPT

--- a/pytorch/inc/WireCellPytorch/ITorchScript.h
+++ b/pytorch/inc/WireCellPytorch/ITorchScript.h
@@ -13,8 +13,12 @@ namespace Pytorch {
 class ITorchScript : public IComponent<ITorchScript> {
 public:
   virtual ~ITorchScript() {}
+
   /// Return the ident number
   virtual int ident() const = 0;
+
+  /// gpu model or not
+  virtual bool gpu() const = 0;
 
   /// wrapper of the torch script forward function
   virtual torch::IValue forward(const std::vector<torch::IValue> &inputs) = 0;

--- a/pytorch/inc/WireCellPytorch/TorchScript.h
+++ b/pytorch/inc/WireCellPytorch/TorchScript.h
@@ -1,0 +1,40 @@
+/** A wrapper for pytorch torchscript
+ */
+
+#ifndef WIRECELLPYTORCH_TORCHSCRIPT
+#define WIRECELLPYTORCH_TORCHSCRIPT
+
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellPytorch/ITorchScript.h"
+#include "WireCellUtil/Logging.h"
+
+#include <torch/script.h> // One-stop header.
+
+namespace WireCell {
+namespace Pytorch {
+class TorchScript : public ITorchScript, public IConfigurable {
+public:
+  TorchScript();
+  virtual ~TorchScript() {}
+
+  // IConfigurable interface
+  virtual void configure(const WireCell::Configuration &config);
+  virtual WireCell::Configuration default_configuration() const;
+
+  // ITorchScript interface
+  virtual int ident() const { return m_ident; }
+  virtual torch::IValue forward(const std::vector<torch::IValue> &inputs);
+
+private:
+  int m_ident;
+  Log::logptr_t l;
+  Configuration m_cfg; /// copy of configuration
+
+  torch::jit::script::Module m_module;
+
+  std::unordered_map<std::string, float> m_timers;
+};
+} // namespace Pytorch
+} // namespace WireCell
+
+#endif // WIRECELLPYTORCH_TORCHSCRIPT

--- a/pytorch/inc/WireCellPytorch/TorchScript.h
+++ b/pytorch/inc/WireCellPytorch/TorchScript.h
@@ -33,6 +33,7 @@ private:
   torch::jit::script::Module m_module;
 
   std::unordered_map<std::string, float> m_timers;
+
 };
 } // namespace Pytorch
 } // namespace WireCell

--- a/pytorch/inc/WireCellPytorch/TorchScript.h
+++ b/pytorch/inc/WireCellPytorch/TorchScript.h
@@ -23,6 +23,7 @@ public:
 
   // ITorchScript interface
   virtual int ident() const { return m_ident; }
+  virtual bool gpu() const {return get<bool>(m_cfg, "gpu", false);}
   virtual torch::IValue forward(const std::vector<torch::IValue> &inputs);
 
 private:

--- a/pytorch/src/DNNROIFinding.cxx
+++ b/pytorch/src/DNNROIFinding.cxx
@@ -325,7 +325,7 @@ bool Pytorch::DNNROIFinding::operator()(const IFrame::pointer &inframe,
   //eigen to frame
   ITrace::vector* itraces = new ITrace::vector;
   IFrame::trace_list_t trace_index;
-  eigen_to_traces(sp_charge, *itraces, trace_index, m_cfg["cbeg"].asInt(), m_cfg["nticks"].asInt(), false);
+  eigen_to_traces(sp_charge, *itraces, trace_index, m_anode->channels().front()+m_cfg["cbeg"].asInt(), m_cfg["nticks"].asInt(), false);
 
   SimpleFrame* sframe = new SimpleFrame(inframe->ident(), inframe->time(),
                                         ITrace::shared_vector(itraces),

--- a/pytorch/src/DNNROIFinding.cxx
+++ b/pytorch/src/DNNROIFinding.cxx
@@ -27,14 +27,10 @@ Pytorch::DNNROIFinding::~DNNROIFinding() {}
 
 void Pytorch::DNNROIFinding::configure(const WireCell::Configuration &cfg) {
 
+  m_cfg = cfg;
+
   auto anode_tn = cfg["anode"].asString();
   m_anode = Factory::find_tn<IAnodePlane>(anode_tn);
-
-  auto model_path = cfg["model"].asString();
-  if (model_path.empty()) {
-    THROW(ValueError() << errmsg{
-              "Must provide output model to DNNROIFinding"});
-  }
   
   std::string fn = cfg["evalfile"].asString();
   if (fn.empty()) {
@@ -44,23 +40,8 @@ void Pytorch::DNNROIFinding::configure(const WireCell::Configuration &cfg) {
 
   h5::create(fn, H5F_ACC_TRUNC);
 
-  m_cfg = cfg;
-
   auto torch_tn = cfg["torch_script"].asString();
   m_torch = Factory::find_tn<ITorchScript>(torch_tn);
-
-  // load Torch Script Model
-  // try {
-  //   // Deserialize the ScriptModule from a file using torch::jit::load().
-  //   module = torch::jit::load(m_cfg["model"].asString());
-  //   if(m_cfg["gpu"].asBool()) module.to(at::kCUDA);
-  //   else module.to(at::kCPU);
-  //   l->info("Model: {} loaded",m_cfg["model"].asString());
-  // }
-  // catch (const c10::Error& e) {
-  //   l->critical( "error loading model: {}", m_cfg["model"].asString());
-  //   exit(0);
-  // }
 
   m_timers.insert({"frame2eigen",0});
   m_timers.insert({"eigen2tensor",0});
@@ -87,8 +68,7 @@ WireCell::Configuration Pytorch::DNNROIFinding::default_configuration() const {
   cfg["nticks"] = 6000;
 
   // TorchScript model
-  cfg["model"] = "model.pt";
-  cfg["gpu"] = true;
+  cfg["torch_script"] = "TorchScript:dnn_roi";
 
   // taces used as input
   cfg["intags"] = Json::arrayValue;
@@ -177,11 +157,6 @@ namespace {
     auto channels = anode->channels();
     const int cbeg = channels.front()+win_cbeg;
     const int cend = channels.front()+win_cend-1;
-    // std::cout << "[yuhw] " <<
-    // " anode->ident(): " << anode->ident() <<
-    // " channels.front(): " << channels.front() <<
-    // " channels.back(): " << channels.back() <<
-    // std::endl;
 
     const size_t ncols = nticks;
     const size_t nrows = cend-cbeg+1;
@@ -260,7 +235,7 @@ bool Pytorch::DNNROIFinding::operator()(const IFrame::pointer &inframe,
 
   // Create a vector of inputs.
   std::vector<torch::jit::IValue> inputs;
-  if(m_cfg["gpu"].asBool()) inputs.push_back(batch.cuda());
+  if(m_torch->gpu()) inputs.push_back(batch.cuda());
   else inputs.push_back(batch);
 
   duration += (std::clock() - start) / (double)CLOCKS_PER_SEC;
@@ -270,7 +245,6 @@ bool Pytorch::DNNROIFinding::operator()(const IFrame::pointer &inframe,
   start = std::clock();
   duration = 0;
   // Execute the model and turn its output into a tensor.
-  // torch::Tensor output = module.forward(inputs).toTensor().cpu();
   torch::Tensor output = m_torch->forward(inputs).toTensor().cpu();
 
   duration += (std::clock() - start) / (double)CLOCKS_PER_SEC;
@@ -299,7 +273,7 @@ bool Pytorch::DNNROIFinding::operator()(const IFrame::pointer &inframe,
   1., 0.,
   m_cfg["cbeg"].asInt(), m_cfg["cend"].asInt(),
   m_cfg["tick0"].asInt(), m_cfg["nticks"].asInt());
-  l->info("decon_charge_eigen: ncols: {} nrows: {}", decon_charge_eigen.cols(), decon_charge_eigen.rows()); // c600 x r800
+  // l->info("decon_charge_eigen: ncols: {} nrows: {}", decon_charge_eigen.cols(), decon_charge_eigen.rows()); // c600 x r800
 
   // apply ROI
   auto sp_charge = Array::mask(decon_charge_eigen.transpose(), mask_e, 0.7);
@@ -311,7 +285,7 @@ bool Pytorch::DNNROIFinding::operator()(const IFrame::pointer &inframe,
   {
     const unsigned long ncols = mask_e.cols();
     const unsigned long nrows = mask_e.rows();
-    l->info("ncols: {} nrows: {}", ncols, nrows);
+    // l->info("ncols: {} nrows: {}", ncols, nrows);
     std::string aname = String::format("/%d/frame_%s%d", m_save_count, "dlroi", m_anode->ident());
     h5::write<float>(fd, aname, mask_e.data(), h5::count{ncols, nrows}, h5::chunk{ncols, nrows} | h5::gzip{2});
 
@@ -321,7 +295,9 @@ bool Pytorch::DNNROIFinding::operator()(const IFrame::pointer &inframe,
   duration += (std::clock() - start) / (double)CLOCKS_PER_SEC;
   l->info("h5: {}", duration);
   m_timers["h5"] += duration;
-
+  
+  start = std::clock();
+  duration = 0;
   //eigen to frame
   ITrace::vector* itraces = new ITrace::vector;
   IFrame::trace_list_t trace_index;
@@ -337,11 +313,13 @@ bool Pytorch::DNNROIFinding::operator()(const IFrame::pointer &inframe,
              itraces->size(), trace_index.size());
 
   outframe = IFrame::pointer(sframe);
+  duration += (std::clock() - start) / (double)CLOCKS_PER_SEC;
+  l->info("eigen2frame: {}", duration);
   
-  l->info("timer summary:");
-  for (auto pair : m_timers) {
-    l->info("{} : {}",pair.first, pair.second);
-  }
+  // l->info("timer summary:");
+  // for (auto pair : m_timers) {
+  //   l->info("{} : {}",pair.first, pair.second);
+  // }
 
   ++m_save_count;
   return true;

--- a/pytorch/src/TorchScript.cxx
+++ b/pytorch/src/TorchScript.cxx
@@ -38,7 +38,7 @@ void Pytorch::TorchScript::configure(const WireCell::Configuration &cfg) {
   try {
     // Deserialize the ScriptModule from a file using torch::jit::load().
     m_module = torch::jit::load(m_cfg["model"].asString());
-    if (m_cfg["gpu"].asBool())
+    if (gpu())
       m_module.to(at::kCUDA);
     else
       m_module.to(at::kCPU);

--- a/pytorch/src/TorchScript.cxx
+++ b/pytorch/src/TorchScript.cxx
@@ -1,0 +1,70 @@
+#include "WireCellPytorch/TorchScript.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/String.h"
+
+WIRECELL_FACTORY(TorchScript, WireCell::Pytorch::TorchScript,
+                 WireCell::Pytorch::ITorchScript, WireCell::IConfigurable)
+
+using namespace WireCell;
+
+Pytorch::TorchScript::TorchScript() : m_ident(0), l(Log::logger("pytorch")) {}
+
+Configuration Pytorch::TorchScript::default_configuration() const {
+  Configuration cfg;
+
+  // TorchScript model
+  cfg["model"] = "model.ts";
+  cfg["gpu"] = true;
+
+  // if failed, wait this time and try again
+  cfg["wait_time"] = 500; // ms
+
+  return cfg;
+}
+
+void Pytorch::TorchScript::configure(const WireCell::Configuration &cfg) {
+
+  m_cfg = cfg;
+
+  auto model_path = m_cfg["model"].asString();
+  if (model_path.empty()) {
+    THROW(ValueError() << errmsg{"Must provide output model to TorchScript"});
+  }
+
+  // load Torch Script Model
+  try {
+    // Deserialize the ScriptModule from a file using torch::jit::load().
+    m_module = torch::jit::load(m_cfg["model"].asString());
+    if (m_cfg["gpu"].asBool())
+      m_module.to(at::kCUDA);
+    else
+      m_module.to(at::kCPU);
+    l->info("Model: {} loaded", m_cfg["model"].asString());
+  } catch (const c10::Error &e) {
+    l->critical("error loading model: {}", m_cfg["model"].asString());
+    exit(0);
+  }
+
+  m_timers["total_wait_time"] = 0;
+}
+
+torch::IValue
+Pytorch::TorchScript::forward(const std::vector<torch::IValue> &inputs) {
+  torch::IValue ret;
+  int wait_time = m_cfg["wait_time"].asInt();
+
+  bool success = false;
+  while (!success) {
+    try {
+      ret = m_module.forward(inputs);
+      success = true;
+    } catch (...) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(wait_time));
+      m_timers["total_wait_time"] += wait_time;
+    }
+  }
+
+  l->info("total_wait_time: {} sec", m_timers["total_wait_time"] / 1000.);
+
+  return ret;
+}


### PR DESCRIPTION
Wrap `torch::jit::script::Module::forward` in a WireCell service type component, so that all `DNNROIFinding` can share one torch script module instance to reduce resource overhead.

We noted `torch::jit::script::Module::forward` is not a const function by definition.
But initial tests with several threads running `forward` on same  `torch::jit::script::Module` instance yield correct results.

I would like to treat the `torch::jit::script::Module::forward` as thread safe for now.

More refer this [talk](https://indico.bnl.gov/event/7774/contributions/35250/).

Example configuration:

```jsonnet

local ts_dnnroi = {
      type: 'TorchScript',
      name: 'dnn_roi',
      data: {
        model: 'model.ts',
        gpu: true,
        wait_time: 500, #ms,
        nloop: 100,
      },  
    };

local dnn_roi_finding = [g.pnode({
      type: 'DNNROIFinding',
      name: 'dnn_roi_finding_apa%d' % n,
      data: {
        torch_script: wc.tn(ts_dnnroi),
        intags: ['loose_lf%d'%n, 'mp2_roi%d'%n, 'mp3_roi%d'%n],
        decon_charge_tag: 'decon_charge%d' % n,
        outtag: "dnn_sp%d"%n,
        evalfile: "tsmodel-eval%d.h5"%n,
        anode: wc.tn(tools.anodes[n]),
        cbeg: 800,
        cend: 1600,
      },  
    }, nin=1, nout=1, uses=[ts_dnnroi]),
    for n in std.range(0, std.length(tools.anodes) - 1)
    ];
```

