### PR TITLE
[cfg] simulate via larsoft gen and g4

### DIFF
--- a/cfg/pgrapher/experiment/icarus/chndb-base.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/chndb-base.jsonnet
@@ -21,7 +21,7 @@ function(params, anode, field, n, rms_cuts=[])
     // For MicroBooNE, channel groups is a 2D list.  Each element is
     // one group of channels which should be considered together for
     // coherent noise filtering.
-    groups: [std.range(g*64, (g+1)*64-1) for g in std.range(0,171)],
+    groups: [std.range(g*32, (g+1)*32-1) for g in std.range(0,171)],
     // groups: [std.range(n * 2560 + u * 40, n * 2560 + (u + 1) * 40 - 1) for u in std.range(0, 19)]
     //         + [std.range(n * 2560 + 800 + v * 40, n * 2560 + 800 + (v + 1) * 40 - 1) for v in std.range(0, 19)]
     //         + [std.range(n * 2560 + 1600 + w * 48, n * 2560 + 1600 + (w + 1) * 48 - 1) for w in std.range(0, 19)],

--- a/cfg/pgrapher/experiment/icarus/funcs.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/funcs.jsonnet
@@ -6,6 +6,8 @@ local g = import 'pgraph.jsonnet';
     //  Return a list of channel by anode index [1-8]
     anode_channels(n):: std.range(1056 * (n % 2) + 13312 * (n - n % 2) / 2, 1056 * (n % 2 + 1) - 1 + 13312 * (n - n % 2) / 2) + std.range(1056 * 2 + 13312 * (n - n % 2) / 2, 13312 - 1 + 13312 * (n - n % 2) / 2),
 
+    // Return the number of split (1 or 2) for an anode
+    anode_split(ident):: (ident%100 - ident%10)/10,
 
     //  Build a depofanout-[signal]-[framesummer]-[pipelines]-fanin graph.
     //  FrameSummer add up the two "split" anodes into one frame.
@@ -60,4 +62,39 @@ local g = import 'pgraph.jsonnet';
                       name=name),
     }.ret,
 
+  // Build a fanout-[pipelines]-fanin graph.  pipelines is a list of
+  // pnode objects, one for each spine of the fan.
+  fanpipe:: function(fout, pipelines, fin, name='fanpipe', outtags=[], fout_tag_rules=[], fin_tag_rules=[]) {
+
+    local fanmult = std.length(pipelines),
+    local fannums = std.range(0, fanmult - 1),
+
+    local fanout = g.pnode({
+      type: fout,
+      name: name,
+      data: {
+        multiplicity: fanmult,
+        tag_rules: fout_tag_rules,
+      },
+    }, nin=1, nout=fanmult),
+
+
+    local fanin = g.pnode({
+      type: fin,
+      name: name,
+      data: {
+        multiplicity: fanmult,
+        tag_rules: fin_tag_rules,
+        tags: outtags,
+      },
+    }, nin=fanmult, nout=1),
+
+    ret: g.intern(innodes=[fanout],
+                  outnodes=[fanin],
+                  centernodes=pipelines,
+                  edges=
+                  [g.edge(fanout, pipelines[n], n, 0) for n in std.range(0, fanmult - 1)] +
+                  [g.edge(pipelines[n], fanin, 0, n) for n in std.range(0, fanmult - 1)],
+                  name=name),
+  }.ret,
 }

--- a/cfg/pgrapher/experiment/icarus/nf.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/nf.jsonnet
@@ -77,7 +77,7 @@ function(params, anode, chndbobj, n, name='')
           // wc.tn(gaincalib),
         ],
         grouped_filters: [
-          wc.tn(grouped),
+          // wc.tn(grouped),
         ],
         channel_status_filters: [
         ],
@@ -85,21 +85,8 @@ function(params, anode, chndbobj, n, name='')
         intraces: 'orig%d' % anode.data.ident,  // frame tag get all traces
         outtraces: 'raw%d' % anode.data.ident,
       },
-      //}, uses=[chndbobj, anode, single, grouped, bitshift, status], nin=1, nout=1),
-      //}, uses=[chndbobj, anode, single, grouped, status], nin=1, nout=1),
     }, uses=[chndbobj, anode, sticky, single, grouped, gaincalib], nin=1, nout=1),
 
 
-//    local pmtfilter = g.pnode({
-//        type: "OmnibusPMTNoiseFilter",
-//        name:name,
-//        data: {
-//            intraces: "quiet",
-//            outtraces: "raw",
-//            anode: wc.tn(anode),
-//        }
-//    }, nin=1, nout=1, uses=[anode]),
-
-    //pipe:  g.pipeline([obnf, pmtfilter], name=name),
     pipe: g.pipeline([obnf], name=name),
   }.pipe

--- a/cfg/pgrapher/experiment/icarus/sp.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/sp.jsonnet
@@ -4,6 +4,7 @@ local g = import 'pgraph.jsonnet';
 local wc = import 'wirecell.jsonnet';
 
 local spfilt = import 'pgrapher/experiment/icarus/sp-filters.jsonnet';
+local util = import 'pgrapher/experiment/icarus/funcs.jsonnet';
 
 function(params, tools, override = {}) {
 
@@ -62,6 +63,7 @@ function(params, tools, override = {}) {
       mp2_roi_tag: 'mp2_roi%d' % anode.data.ident,
       
       isWrapped: false,
+      process_planes: [0, util.anode_split(anode.data.ident)], // balance the left and right split
 
     } + override,
   }, nin=1, nout=1, uses=[anode, tools.field] + pc.uses + spfilt),

--- a/cfg/pgrapher/experiment/icarus/wcls-decode-to-sig.fcl
+++ b/cfg/pgrapher/experiment/icarus/wcls-decode-to-sig.fcl
@@ -20,7 +20,7 @@ source: {
 
 physics :{
    producers: {
-      nfspl1 : {
+      wclsnfsp : {
          module_type : WireCellToolkit
          wcls_main: {
             tool_type: WCLS
@@ -43,7 +43,7 @@ physics :{
             // or after the WCT app is run.  These names MUST be used identically in the Jsonnet
             // fixme: https://github.com/WireCell/larwirecell/issues/3
             //outputers: ["wclsFrameSaver:nfsaver", "wclsFrameSaver:spsaver"]
-            // outputers: ["wclsFrameSaver:spsaver"]
+            outputers: ["wclsFrameSaver:spsaver"]
 
             // This sets the "main" Jsonnet file which provides the 
             // configuration for the Wire-Cell Toolkit components.  It is
@@ -53,9 +53,8 @@ physics :{
             // Set the "external variables" required by the Jsonnet.
             params : {
                // This locates the input raw::RawDigit collection in the art::Event 
-               raw_input_label: "daq"
-               // raw_input_label: "simmer:orig"
-               //raw_input_label: "caldata"
+               // raw_input_label: "daq"
+               raw_input_label: "simmer:daq"
 
                // Set "data" vs. "sim".  The epoch below probably should follow suit.
                reality: "data"
@@ -75,7 +74,7 @@ physics :{
       }
    }
 
-   p1 : [ nfspl1 ]
+   p1 : [ wclsnfsp ]
    trigger_paths : [ p1 ]
    
    o1 : [ out1 ]
@@ -90,7 +89,7 @@ outputs:{
       saveMemoryObjectThreshold: 10485760 
 
       outputCommands :   [
-         // "keep *_*_*_*"
+         "keep *_*_*_*"
          // "drop *_nfspl1_raw_*",
          // "drop *_nfspl1_threshold_*",
          // "drop *_nfspl1_wiener_*",

--- a/cfg/pgrapher/experiment/icarus/wcls-sim-drift-simchannel.fcl
+++ b/cfg/pgrapher/experiment/icarus/wcls-sim-drift-simchannel.fcl
@@ -1,0 +1,72 @@
+#include "services_icarus.fcl"
+
+services:
+{
+   TFileService:            { }
+                             @table::icarus_basic_services
+}
+
+process_name: wclssim
+physics :{
+   producers: {
+      plopper : {
+        module_type : BlipMaker
+      }
+      simmer : {
+         module_type : WireCellToolkit
+         wcls_main: {
+            tool_type: WCLS
+            apps: ["Pgrapher"]
+
+            // logsinks: ["stdout"]
+            // loglevels: ["magnify:debug"]
+
+            plugins: ["WireCellPgraph", "WireCellGen","WireCellSio","WireCellRoot","WireCellLarsoft"]
+
+            // needs to be found via your WIRECELL_PATH 
+            configs: ["pgrapher/experiment/icarus/wcls-sim-drift-simchannel.jsonnet"]
+
+
+            // Contract note: these exact "type:name" must be used to identify
+            // the configuration data structures for these components in the Jsonnet.
+
+            inputers: ["wclsSimDepoSource:electron"]
+            outputers: [
+            //   "wclsSimChannelSink:postdrift",
+               "wclsFrameSaver:simdigits"
+            //   ,"wclsFrameSaver:nfdigits",
+            //   "wclsFrameSaver:spsignals",
+            //   "wclsFrameSaver:spthresholds"
+            ]
+
+            // Make available parameters via Jsonnet's std.extVar()
+            params: {
+            }
+         }
+      }
+   }
+   p1 : [ plopper, simmer ]
+   outputFiles : [ out ]
+   
+   trigger_paths : [ p1 ]
+   end_paths: [ outputFiles ]
+}
+outputs: {
+   out: {
+      module_type: RootOutput
+      // fileName: "%ifb_wcsim.root"
+      fileName: "wcsim.root"
+
+      outputCommands :   [
+         // "drop *", "keep recob::Wires_*_*_*"
+         "keep *_*_*_*"
+         // "drop *_nfspl1_raw_*",
+         // "drop *_nfspl1_threshold_*",
+         // "drop *_nfspl1_wiener_*",
+         // "drop *_nfspl1_gauss_*",
+         // "drop *_wcNoiseFilter_*_*",
+         // "drop *_daq_*_*"
+      ]
+
+   }
+}

--- a/cfg/pgrapher/experiment/icarus/wcls-sim-drift-simchannel.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/wcls-sim-drift-simchannel.jsonnet
@@ -1,0 +1,235 @@
+// This is a main entry point for configuring a wire-cell CLI job to
+// simulate protoDUNE-SP.  It is simplest signal-only simulation with
+// one set of nominal field response function.  It excludes noise.
+// The kinematics are a mixture of Ar39 "blips" and some ideal,
+// straight-line MIP tracks.
+//
+// Output is a Python numpy .npz file.
+
+local g = import 'pgraph.jsonnet';
+local f = import 'pgrapher/common/funcs.jsonnet';
+local wc = import 'wirecell.jsonnet';
+
+local io = import 'pgrapher/common/fileio.jsonnet';
+local tools_maker = import 'pgrapher/common/tools.jsonnet';
+local params = import 'pgrapher/experiment/icarus/simparams.jsonnet';
+
+local tools = tools_maker(params);
+
+local sim_maker = import 'pgrapher/experiment/icarus/sim.jsonnet';
+local sim = sim_maker(params, tools);
+
+local nanodes = std.length(tools.anodes);
+local anode_iota = std.range(0, nanodes - 1);
+
+
+local output = 'wct-sim-ideal-sig.npz';
+
+
+//local depos = g.join_sources(g.pnode({type:"DepoMerger", name:"BlipTrackJoiner"}, nin=2, nout=1),
+//                             [sim.ar39(), sim.tracks(tracklist)]);
+// local depos = sim.tracks(tracklist, step=1.0 * wc.mm);
+
+local wcls_maker = import 'pgrapher/ui/wcls/nodes.jsonnet';
+local wcls = wcls_maker(params, tools);
+local wcls_input = {
+  // depos: wcls.input.depos(name="", art_tag="ionization"),
+  depos: wcls.input.depos(name='electron', art_tag='ionization'),  // default art_tag="blopper"
+};
+
+// Collect all the wc/ls output converters for use below.  Note the
+// "name" MUST match what is used in theh "outputers" parameter in the
+// FHiCL that loads this file.
+local mega_anode = {
+  type: 'MegaAnodePlane',
+  name: 'meganodes',
+  data: {
+    anodes_tn: [wc.tn(anode) for anode in tools.anodes],
+  },
+};
+local wcls_output = {
+  // ADC output from simulation
+  // sim_digits: wcls.output.digits(name="simdigits", tags=["orig"]),
+  sim_digits: g.pnode({
+    type: 'wclsFrameSaver',
+    name: 'simdigits',
+    data: {
+      // anode: wc.tn(tools.anode),
+      anode: wc.tn(mega_anode),
+      digitize: true,  // true means save as RawDigit, else recob::Wire
+      frame_tags: ['daq'],
+      // Three options for nticks:
+      // - If nonzero, force number of ticks in output waveforms.
+      // - If zero, use whatever input data has. (default)
+      // - If -1, use value as per LS's detector properties service.
+      // nticks: params.daq.nticks,
+      // nticks: -1,
+      // chanmaskmaps: ['bad'],
+    },
+  }, nin=1, nout=1, uses=[mega_anode]),
+
+  // The noise filtered "ADC" values.  These are truncated for
+  // art::Event but left as floats for the WCT SP.  Note, the tag
+  // "raw" is somewhat historical as the output is not equivalent to
+  // "raw data".
+  nf_digits: wcls.output.digits(name='nfdigits', tags=['raw']),
+
+  // The output of signal processing.  Note, there are two signal
+  // sets each created with its own filter.  The "gauss" one is best
+  // for charge reconstruction, the "wiener" is best for S/N
+  // separation.  Both are used in downstream WC code.
+  sp_signals: wcls.output.signals(name='spsignals', tags=['gauss', 'wiener']),
+
+  // save "threshold" from normal decon for each channel noise
+  // used in imaging
+  sp_thresholds: wcls.output.thresholds(name='spthresholds', tags=['threshold']),
+};
+
+//local deposio = io.numpy.depos(output);
+local drifter = sim.drifter;
+local bagger = sim.make_bagger();
+
+// signal plus noise pipelines
+//local sn_pipes = sim.signal_pipelines;
+// local sn_pipes = sim.splusn_pipelines;
+local analog_pipes = sim.analog_pipelines;
+
+local perfect = import 'pgrapher/experiment/icarus/chndb-base.jsonnet';
+local chndb = [{
+  type: 'OmniChannelNoiseDB',
+  name: 'ocndbperfect%d' % n,
+  data: perfect(params, tools.anodes[n], tools.field, n),
+  uses: [tools.anodes[n], tools.field],  // pnode extension
+} for n in anode_iota];
+
+
+// local nf_maker = import 'pgrapher/experiment/icarus/nf.jsonnet';
+// local nf_pipes = [nf_maker(params, tools.anodes[n], chndb_pipes[n]) for n in std.range(0, std.length(tools.anodes)-1)];
+// local nf_pipes = [nf_maker(params, tools.anodes[n], chndb[n], n, name='nf%d' % n) for n in anode_iota];
+
+local sp_maker = import 'pgrapher/experiment/icarus/sp.jsonnet';
+local sp = sp_maker(params, tools);
+local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
+
+// local rng = tools.random;
+// local wcls_simchannel_sink = g.pnode({
+//   type: 'wclsSimChannelSink',
+//   name: 'postdrift',
+//   data: {
+//     artlabel: 'simpleSC',  // where to save in art::Event
+//     anodes_tn: [wc.tn(anode) for anode in tools.anodes],
+//     rng: wc.tn(rng),
+//     tick: 0.5 * wc.us,
+//     start_time: -0.25 * wc.ms,
+//     readout_time: self.tick * 6000,
+//     nsigma: 3.0,
+//     drift_speed: params.lar.drift_speed,
+//     u_to_rp: 90.58 * wc.mm,
+//     v_to_rp: 95.29 * wc.mm,
+//     y_to_rp: 100 * wc.mm,
+//     u_time_offset: 0.0 * wc.us,
+//     v_time_offset: 0.0 * wc.us,
+//     y_time_offset: 0.0 * wc.us,
+//     use_energy: true,
+//   },
+// }, nin=1, nout=1, uses=tools.anodes);
+
+local make_noise_model = function(anode, csdb=null) {
+    type: "EmpiricalNoiseModel",
+    name: "empericalnoise-" + anode.name,
+    data: {
+        anode: wc.tn(anode),
+        chanstat: if std.type(csdb) == "null" then "" else wc.tn(csdb),
+        spectra_file: params.files.noise,
+        nsamples: params.daq.nticks,
+        period: params.daq.tick,
+        wire_length_scale: 1.0*wc.cm, // optimization binning
+    },
+    uses: [anode] + if std.type(csdb) == "null" then [] else [csdb],
+};
+local noise_model = make_noise_model(mega_anode);
+local add_noise = function(model, n) g.pnode({
+    type: "AddNoise",
+    name: "addnoise%d-" %n + model.name,
+    data: {
+        rng: wc.tn(tools.random),
+        model: wc.tn(model),
+  nsamples: params.daq.nticks,
+        replacement_percentage: 0.02, // random optimization
+    }}, nin=1, nout=1, uses=[model]);
+local noises = [add_noise(noise_model, n) for n in std.range(0,3)];
+
+// local digitizer = sim.digitizer(mega_anode, name="digitizer", tag="orig");
+// "AnodePlane:anode110"
+// "AnodePlane:anode120"
+// "AnodePlane:anode111"
+// "AnodePlane:anode121"
+// "AnodePlane:anode112"
+// "AnodePlane:anode122"
+// "AnodePlane:anode113"
+// "AnodePlane:anode123"
+local digitizers = [
+    sim.digitizer(mega_anode, name="digitizer%d-" %n + mega_anode.name, tag="orig%d"%n)
+    for n in std.range(0,3)];
+
+local frame_summers = [
+    g.pnode({
+        type: 'FrameSummer',
+        name: 'framesummer%d' %n,
+        data: {
+            align: true,
+            offset: 0.0*wc.s,
+        },
+    }, nin=2, nout=1) for n in std.range(0, 3)];
+
+local actpipes = [g.pipeline([noises[n], digitizers[n]], name="noise-digitizer%d" %n) for n in std.range(0,3)];
+local util = import 'pgrapher/experiment/icarus/funcs.jsonnet';
+local outtags = ['orig%d' % n for n in std.range(0, 3)];
+local pipe_reducer = util.fansummer('DepoSetFanout', analog_pipes, frame_summers, actpipes, 'FrameFanin', 'fansummer', outtags);
+
+local retagger = g.pnode({
+  type: 'Retagger',
+  data: {
+    // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
+    tag_rules: [{
+      // Retagger also handles "frame" and "trace" like fanin/fanout
+      // merge separately all traces like origN to orig.
+      frame: {
+        '.*': 'orig',
+      },
+      merge: {
+        'orig\\d': 'daq',
+      },
+    }],
+  },
+}, nin=1, nout=1);
+
+//local frameio = io.numpy.frames(output);
+local sink = sim.frame_sink;
+
+// local magnifio = g.pnode({
+//     type: 'MagnifySink',
+//     name: 'magnifio',
+//     data: {
+//       output_filename: 'icarus-sim-drift.root',
+//       root_file_mode: 'UPDATE',
+//       frames: ['daq'],
+//       trace_has_tag: false,   // traces from source have NO tag
+//       anode: wc.tn(mega_anode),
+//     },
+//   }, nin=1, nout=1);
+
+// local graph = g.pipeline([wcls_input.depos, drifter, wcls_simchannel_sink, bagger, bi_manifold, retagger, wcls_output.sim_digits, sink]);
+local graph = g.pipeline([wcls_input.depos, drifter, bagger, pipe_reducer, retagger, wcls_output.sim_digits, sink]);
+
+local app = {
+  type: 'Pgrapher',
+  data: {
+    edges: g.edges(graph),
+  },
+};
+
+
+// Finally, the configuration sequence which is emitted.
+
+g.uses(graph) + [app]


### PR DESCRIPTION
Connect with larsoft simulation chain, for example:
```
lar -n1 -c simulation_genie_icarus_bnb.fcl
lar -n1 -c standard_g4_icarus.fcl [xxx-root-file-from-above.root]
lar -n1 -c pgrapher/experiment/icarus/wcls-sim-drift-simchannel.fcl [xxx-root-file-from-above.root]
lar -n1 -c pgrapher/experiment/icarus/wcls-decode-to-sig.fcl [xxx-root-file-from-above.root]
```
Here is the raw waveform from the Magnify display.
![image](https://user-images.githubusercontent.com/10663117/75633770-ed8fb000-5bd5-11ea-9618-53204acc0d48.png)

