### PR TITLE
add support for larsoft and icaruscode

### DIFF
--- a/cfg/pgrapher/experiment/icarus/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/magnify-sinks.jsonnet
@@ -66,9 +66,9 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        frames: ['tight_lf%d' %n, 'loose_lf%d' %n, 'cleanup_roi%d' %n,
-                 'break_roi_1st%d' %n, 'break_roi_2nd%d' %n,
-                 'shrink_roi%d' %n, 'extend_roi%d' %n],
+        frames: ['tight_lf%d' % tools.anodes[n].data.ident, 'loose_lf%d' % tools.anodes[n].data.ident, 'cleanup_roi%d' % tools.anodes[n].data.ident,
+                 'break_roi_1st%d' % tools.anodes[n].data.ident, 'break_roi_2nd%d' % tools.anodes[n].data.ident,
+                 'shrink_roi%d' % tools.anodes[n].data.ident, 'extend_roi%d' % tools.anodes[n].data.ident],
         trace_has_tag: true,
         anode: wc.tn(tools.anodes[n]),
       },

--- a/cfg/pgrapher/experiment/icarus/params.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/params.jsonnet
@@ -131,6 +131,7 @@ base {
     },
 
     daq: super.daq {
+        tick: 0.4*wc.us,
         nticks: 4096,
     },
 
@@ -158,7 +159,7 @@ base {
         // The "absolute" time (ie, in G4 time) that the lower edge of
         // of final readout tick #0 should correspond to.  This is a
         // "fixed" notion.
-        local tick0_time = -250*wc.us,
+        local tick0_time = -340*wc.us, // TriggerOffsetTPC from detectorclocks_icarus.fcl
 
         // Open the ductor's gate a bit early.
         local response_time_offset = $.det.response_plane / $.lar.drift_speed,
@@ -184,8 +185,9 @@ base {
 
         fields: [
             // "garfield-1d-3planes-21wires-6impacts-dune-v1.json.bz2",
-            "garfield-1d-boundary-path-rev-dune.json.bz2",
+            // "garfield-1d-boundary-path-rev-dune.json.bz2",
             // "garfield-1d-boundary-path-rev-dune-no-grid.json.bz2",
+            "garfield-icarus-fnal-commissioning.json.bz2",
         ],
 
         // fixme: this is for microboone and probably bogus for

--- a/cfg/pgrapher/experiment/icarus/sp-filters.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/sp-filters.jsonnet
@@ -40,7 +40,7 @@ local wf(name, data={}) = {
 [
   lf('ROI_tight_lf', { tau: 0.014 * wc.megahertz }),  // 0.02 
   lf('ROI_tighter_lf', { tau: 0.06 * wc.megahertz }),  // 0.1 
-  lf('ROI_loose_lf', { tau: 0.002 * wc.megahertz }),  // 0.0025 
+  lf('ROI_loose_lf', { tau: 0.0025 * wc.megahertz }),  // 0.0025 
 
   hf('Gaus_tight'),
   hf('Gaus_wide', { sigma: 0.12 * wc.megahertz }), 

--- a/cfg/pgrapher/experiment/icarus/wcls-decode-to-sig.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/wcls-decode-to-sig.jsonnet
@@ -126,7 +126,7 @@ local chndb = [{
 local nf_maker = import 'pgrapher/experiment/icarus/nf.jsonnet';
 local nf_pipes = [nf_maker(params, tools.anodes[n], chndb[n], n, name='nf%d' % n) for n in std.range(0, std.length(tools.anodes) - 1)];
 
-local sp = sp_maker(params, tools, { sparse: sigoutform == 'sparse' });
+local sp = sp_maker(params, tools, { sparse: sigoutform == 'sparse', use_roi_debug_mode: false, });
 local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
 
 local util = import 'pgrapher/experiment/icarus/funcs.jsonnet';
@@ -157,7 +157,7 @@ local nfsp_pipes = [
                sp_pipes[n],
                magnifyio.decon_pipe[n],
                magnifyio.threshold_pipe[n],
-               // magnifyio.debug_pipe[n], // use_roi_debug_mode=true in sp.jsonnet
+               magnifyio.debug_pipe[n], // use_roi_debug_mode: true in sp.jsonnet
              ],
              'nfsp_pipe_%d' % n)
   for n in std.range(0, std.length(tools.anodes) - 1)

--- a/cfg/pgrapher/experiment/icarus/wcls-sim-drift-simchannel.fcl
+++ b/cfg/pgrapher/experiment/icarus/wcls-sim-drift-simchannel.fcl
@@ -32,7 +32,7 @@ physics :{
 
             inputers: ["wclsSimDepoSource:electron"]
             outputers: [
-            //   "wclsSimChannelSink:postdrift",
+               "wclsSimChannelSink:postdrift",
                "wclsFrameSaver:simdigits"
             //   ,"wclsFrameSaver:nfdigits",
             //   "wclsFrameSaver:spsignals",

--- a/cfg/pgrapher/experiment/icarus/wcls-sim-drift-simchannel.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/wcls-sim-drift-simchannel.jsonnet
@@ -111,28 +111,29 @@ local sp_maker = import 'pgrapher/experiment/icarus/sp.jsonnet';
 local sp = sp_maker(params, tools);
 local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
 
-// local rng = tools.random;
-// local wcls_simchannel_sink = g.pnode({
-//   type: 'wclsSimChannelSink',
-//   name: 'postdrift',
-//   data: {
-//     artlabel: 'simpleSC',  // where to save in art::Event
-//     anodes_tn: [wc.tn(anode) for anode in tools.anodes],
-//     rng: wc.tn(rng),
-//     tick: 0.5 * wc.us,
-//     start_time: -0.25 * wc.ms,
-//     readout_time: self.tick * 6000,
-//     nsigma: 3.0,
-//     drift_speed: params.lar.drift_speed,
-//     u_to_rp: 90.58 * wc.mm,
-//     v_to_rp: 95.29 * wc.mm,
-//     y_to_rp: 100 * wc.mm,
-//     u_time_offset: 0.0 * wc.us,
-//     v_time_offset: 0.0 * wc.us,
-//     y_time_offset: 0.0 * wc.us,
-//     use_energy: true,
-//   },
-// }, nin=1, nout=1, uses=tools.anodes);
+local rng = tools.random;
+local wcls_simchannel_sink = g.pnode({
+  type: 'wclsSimChannelSink',
+  name: 'postdrift',
+  data: {
+    artlabel: 'simpleSC',  // where to save in art::Event
+    anodes_tn: [wc.tn(anode) for anode in tools.anodes],
+    rng: wc.tn(rng),
+    tick: params.daq.tick,
+    start_time: -0.34 * wc.ms, // TriggerOffsetTPC from detectorclocks_icarus.fcl
+    readout_time: params.daq.readout_time,
+    nsigma: 3.0,
+    drift_speed: params.lar.drift_speed,
+    u_to_rp: 100 * wc.mm,
+    v_to_rp: 100 * wc.mm,
+    y_to_rp: 100 * wc.mm,
+    u_time_offset: 0.0 * wc.us,
+    v_time_offset: 0.0 * wc.us,
+    y_time_offset: 0.0 * wc.us,
+    g4_ref_time: -1150 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
+    use_energy: true,
+  },
+}, nin=1, nout=1, uses=tools.anodes);
 
 local make_noise_model = function(anode, csdb=null) {
     type: "EmpiricalNoiseModel",
@@ -219,8 +220,7 @@ local sink = sim.frame_sink;
 //     },
 //   }, nin=1, nout=1);
 
-// local graph = g.pipeline([wcls_input.depos, drifter, wcls_simchannel_sink, bagger, bi_manifold, retagger, wcls_output.sim_digits, sink]);
-local graph = g.pipeline([wcls_input.depos, drifter, bagger, pipe_reducer, retagger, wcls_output.sim_digits, sink]);
+local graph = g.pipeline([wcls_input.depos, drifter,  wcls_simchannel_sink, bagger, pipe_reducer, retagger, wcls_output.sim_digits, sink]);
 
 local app = {
   type: 'Pgrapher',


### PR DESCRIPTION
Some configuration to work with `icaruscode` is added. Here is the example to do simulation in the larsoft environment.
```
lar -n1 -c prod_muon_2GeV_perp_Collection.fcl
lar -n1 -c standard_g4_icarus.fcl input.root
lar -n1 -c pgrapher/experiment/icarus/wcls-sim-drift-simchannel.fcl input.root
```
Here is the event display from a BNB simulation. The time offset between the RawDigits and the SimChannel is because of the time difference between the G4RefTime and the pre-trigger window.
![rawdigits_vs_simchannel](https://user-images.githubusercontent.com/10663117/78606392-3e28a780-782b-11ea-95d6-d790af5ad22d.png)
