### PR TITLE
update configuration of elec response for ICARUS and pDSP

### DIFF
--- a/cfg/pgrapher/common/tools.jsonnet
+++ b/cfg/pgrapher/common/tools.jsonnet
@@ -60,7 +60,9 @@ function(params)
     },
 
     elec_resp : {
-        type: "ColdElecResponse",
+        type: if std.objectHas(params.elec, "type")
+              then params.elec.type
+              else "ColdElecResponse", // default
         data: sim_response_binning {
             shaping: params.elec.shaping,
             gain: params.elec.gain,

--- a/cfg/pgrapher/experiment/icarus/params.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/params.jsonnet
@@ -85,7 +85,11 @@ base {
     },
 
     elec: super.elec {
-        // later defined in simparams.jsonnet
+        type: "WarmElecResponse",
+        gain: 30*wc.mV/wc.fC,
+        shaping: 1.3*wc.us,
+        postgain: 1.0,
+        start: 0,
     },
 
 

--- a/cfg/pgrapher/experiment/icarus/simparams.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/simparams.jsonnet
@@ -38,8 +38,8 @@ base {
   // place.  See the "scale" parameter of wcls.input.depos() defined
   // in pgrapher/common/ui/wcls/nodes.jsonnet.
   elec: super.elec {
-    postgain: 1.0,
-    shaping: 2.2 * wc.us,
+    // postgain: 1.0,
+    // shaping: 2.2 * wc.us,
   },
 
   sys_status: false,

--- a/cfg/pgrapher/experiment/icarus/sp.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/sp.jsonnet
@@ -11,7 +11,7 @@ function(params, tools, override = {}) {
   local pc = tools.perchanresp_nameuses,
 
   // ICARUS needs a per-anode sigproc
-  make_sigproc(anode, eresponse, name=null):: g.pnode({
+  make_sigproc(anode, name=null):: g.pnode({
     type: 'OmnibusSigProc',
     name:
       if std.type(name) == 'null'
@@ -26,7 +26,7 @@ function(params, tools, override = {}) {
       ctoffset: 0.0*wc.microsecond, // default -8.0
       per_chan_resp: pc.name,
       fft_flag: 0,  // 1 is faster but higher memory, 0 is slightly slower but lower memory
-      elecresponse : wc.tn(eresponse),
+      elecresponse : wc.tn(tools.elec_resp),
       postgain: 1,  // default 1.2
       ADC_mV: 4096 / (1400.0 * wc.mV),  // default 4096/2000
       troi_col_th_factor: 5.0,  // default 5
@@ -67,6 +67,6 @@ function(params, tools, override = {}) {
       process_planes: [0, util.anode_split(anode.data.ident)], // balance the left and right split
 
     } + override,
-  }, nin=1, nout=1, uses=[anode, eresponse, tools.field] + pc.uses + spfilt),
+  }, nin=1, nout=1, uses=[anode, tools.field, tools.elec_resp] + pc.uses + spfilt),
 
 }

--- a/cfg/pgrapher/experiment/pdsp/params.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/params.jsonnet
@@ -120,7 +120,8 @@ base {
     },
 
     elec: super.elec {
-
+        postgain: 1.0,
+        shaping: 2.2 * wc.us,
     },
 
 

--- a/cfg/pgrapher/experiment/pdsp/simparams.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/simparams.jsonnet
@@ -144,8 +144,8 @@ base {
   // place.  See the "scale" parameter of wcls.input.depos() defined
   // in pgrapher/common/ui/wcls/nodes.jsonnet.
   elec: super.elec {
-    postgain: 1.0,
-    shaping: 2.2 * wc.us,
+  //  postgain: 1.0,
+  //  shaping: 2.2 * wc.us,
   },
 
   sys_status: false,


### PR DESCRIPTION
The default shaping time in common/params.jsonnet is 2.0us, while the default value in OmnibusSigproc is 2.2us. We should use 2.2us to configure the "ColdElecResponse" component now.