### PR TITLE
Issue85and86

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,8 +1,0 @@
-((nil . ((fill-column . 80)))
- (c++-mode . ((c-file-style . "stroustup")
-            (c-file-offsets
-             (access-label -2)
-             (inline-open 0)
-             (case-label 4)
-             (inlambda 0)))))
-

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ venv*
 clusters-*.dot
 clusters-*.json
 *.zip
-data
 calgrind.*
 *.hdf
 wct-deps.dot

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 	path = wire-cell-tbb
 	url = git@github.com:WireCell/wire-cell-tbb.git
         update = merge
+[submodule "data"]
+	path = data
+	url = https://github.com/WireCell/wire-cell-data.git

--- a/README.org
+++ b/README.org
@@ -92,11 +92,21 @@ It is suggested to first build the code before running tests.
 
 ** Installing
 
-To install the code while still avoiding the tests do:
+To install the built toolkit and its configuration support files while
+still avoiding the tests do:
 
 #+BEGIN_EXAMPLE
   $ ./wcb -p --notests install
 #+END_EXAMPLE
+
+Optionally, the *reference* configuration and data files for one or more
+supported experiments may be installed by giving naming them with the
+~--install-config~ option.  A name matches a sub-directory under
+[[file:cfg/pgrapher/experiment/][cfg/pgrapher/experiment/]] or the special ~all~ name will install all.
+
+#+begin_example
+  $ ./wcb -p --notests --install-config=<name> install
+#+end_example
 
 ** Testing
 

--- a/cfg/pgrapher/common/funcs.jsonnet
+++ b/cfg/pgrapher/common/funcs.jsonnet
@@ -1,66 +1,9 @@
-// This provides some util functions.
-
+// Functions originally provided by this file are moved into
+// pgraph.jsonnet under the "fan." object.  Please avoid importing
+// this file for new any configuration.  It is kept only to preserve
+// backward compatibility for older files.
 local g = import "pgraph.jsonnet";
-
 {
-    // Build a fanout-[pipelines]-fanin graph.  pipelines is a list of
-    // pnode objects, one for each spine of the fan.
-    fanpipe :: function(fout, pipelines, fin, name="fanpipe", outtags=[], tag_rules=[]) {
-
-        local fanmult = std.length(pipelines),
-
-        local fanout = g.pnode({
-            type: fout,
-            name: name,
-            data: {
-                multiplicity: fanmult,
-                tag_rules: tag_rules,
-            },
-        }, nin=1, nout=fanmult),
-
-
-        local fanin = g.pnode({
-            type: fin,
-            name: name,
-            data: {
-                multiplicity: fanmult,
-                tags: outtags,
-            },
-        }, nin=fanmult, nout=1),
-
-        ret: g.intern(innodes=[fanout],
-                      outnodes=[fanin],
-                      centernodes=pipelines,
-                      edges=
-                      [g.edge(fanout, pipelines[n], n, 0) for n in std.range(0, fanmult-1)] +
-                      [g.edge(pipelines[n], fanin, 0, n) for n in std.range(0, fanmult-1)],
-                      name=name),
-    }.ret,
-
-    // Build a fanout-[pipelines] graph where each pipe is self
-    // terminated.  pipelines is a list of pnode objects, one for each
-    // spine of the fan.
-    fansink :: function(fout, pipelines, name="fansink", tag_rules=[]) {
-
-        local fanmult = std.length(pipelines),
-
-        local fanout = g.pnode({
-            type: fout,
-            name: name,
-            data: {
-                multiplicity: fanmult,
-                tag_rules: tag_rules,
-            },
-        }, nin=1, nout=fanmult),
-
-
-        ret: g.intern(innodes=[fanout],
-                      outnodes=[],
-                      centernodes=pipelines,
-                      edges=
-                      [g.edge(fanout, pipelines[n], n, 0) for n in std.range(0, fanmult-1)],
-                      name=name),
-    }.ret,
-
-
+    fanpipe :: g.fan.pipe,
+    fansink :: g.fan.sink,
 }

--- a/cfg/wscript_build
+++ b/cfg/wscript_build
@@ -2,9 +2,11 @@ bld.install_files('${PREFIX}/share/wirecell',
                   bld.path.ant_glob("*.jsonnet") +
                   bld.path.ant_glob("pgrapher/common/**/*.jsonnet"),
                   relative_trick=True)
-for exp in getattr(bld.options, 'install_config', "").split(','):
-    if exp == "all": exp = "*"
-    bld.install_files('${PREFIX}/share/wirecell',
-                      bld.path.ant_glob("pgrapher/experiment/%s/**/*.jsonnet" % exp) +
-                      bld.path.ant_glob("pgrapher/experiment/%s/**/*.fcl" % exp),
-                      relative_trick=True)
+exps = getattr(bld.options, 'install_config', None)
+if exps:
+    for exp in exps.split(","):
+        if exp == "all": exp = "*"
+        bld.install_files('${PREFIX}/share/wirecell',
+                          bld.path.ant_glob("pgrapher/experiment/%s/**/*.jsonnet" % exp) +
+                          bld.path.ant_glob("pgrapher/experiment/%s/**/*.fcl" % exp),
+                          relative_trick=True)

--- a/cfg/wscript_build
+++ b/cfg/wscript_build
@@ -1,2 +1,1 @@
-bld.install_files('${PREFIX}/share/wirecell',
-                  ['vector.jsonnet', 'wirecell.jsonnet'])
+bld.install_files('${PREFIX}/share/wirecell', bld.path.ant_glob("*.jsonnet"))

--- a/cfg/wscript_build
+++ b/cfg/wscript_build
@@ -1,1 +1,10 @@
-bld.install_files('${PREFIX}/share/wirecell', bld.path.ant_glob("*.jsonnet"))
+bld.install_files('${PREFIX}/share/wirecell',
+                  bld.path.ant_glob("*.jsonnet") +
+                  bld.path.ant_glob("pgrapher/common/**/*.jsonnet"),
+                  relative_trick=True)
+for exp in getattr(bld.options, 'install_config', "").split(','):
+    if exp == "all": exp = "*"
+    bld.install_files('${PREFIX}/share/wirecell',
+                      bld.path.ant_glob("pgrapher/experiment/%s/**/*.jsonnet" % exp) +
+                      bld.path.ant_glob("pgrapher/experiment/%s/**/*.fcl" % exp),
+                      relative_trick=True)

--- a/wscript
+++ b/wscript
@@ -7,8 +7,16 @@ APPNAME = 'WireCell'
 def options(opt):
     opt.load("wcb")
 
+    # this used in cfg/wscript_build
+    opt.add_option('--install-config', type=str, default="",
+                   help="Install configuration files for given experiment")
+
+
 def configure(cfg):
     cfg.load("wcb")
+
+    # fixme: should go into wcb.py
+    cfg.find_program("jsonnet", var='JSONNET')
 
     # boost 1.59 uses auto_ptr and GCC 5 deprecates it vociferously.
     cfg.env.CXXFLAGS += ['-Wno-deprecated-declarations']


### PR DESCRIPTION
This addresses the two related issues #85 and #86 

- copy all top level .jsonnet files to `$PREFIX/share/wirecell/`.
- move `funcs.jsonnet` content to `pgraph.jsonnet` and leave behind backward compatibility code.
- if `--install-config=<name>` given then install also the `pgrapher/common/` files and the configuration and data files for experiment `<name>`.

This PR also adds `wire-cell-data` as a git submodule so that `wcb` build can find the files.  This submodule is only required for this purpose.  Developers or users that get their data in other ways may leave the submodule dangling.

The data files are identified based on the `.files` data object value from the experiment's `params.jsonnet` file.  If data files are named outside this structure they will not be picked up by the install method.