### PR TITLE
Pyfix plus pir throw

### DIFF
--- a/cfg/pgrapher/common/sim/nodes.jsonnet
+++ b/cfg/pgrapher/common/sim/nodes.jsonnet
@@ -79,7 +79,7 @@ function(params, tools)
             tick: params.daq.tick,
             nsigma: 3,
         },
-    }, nin=1, nout=1, uses=[anode] + pirs),
+    }, nin=1, nout=1, uses=[anode, tools.random] + pirs),
 
     // This may look similar to above but above is expected to diverge
     make_depozipper :: function(name, anode, pirs) g.pnode({
@@ -97,7 +97,7 @@ function(params, tools)
             tick: params.daq.tick,
             nsigma: 3,
         },
-    }, nin=1, nout=1, uses=[anode] + pirs),
+    }, nin=1, nout=1, uses=[anode, tools.random] + pirs),
 
     make_reframer :: function(name, anode, tags=[]) g.pnode({
         type: 'Reframer',

--- a/gen/inc/WireCellGen/PlaneImpactResponse.h
+++ b/gen/inc/WireCellGen/PlaneImpactResponse.h
@@ -99,6 +99,7 @@ namespace WireCell {
             typedef std::vector<region_indices_t> wire_region_indicies_t;
             const wire_region_indicies_t& bywire_map() const { return m_bywire; }
             std::pair<int, int> closest_wire_impact(double relpitch) const;
+            const std::vector<IImpactResponse::pointer>& irs() const { return m_ir; }
 
            private:
             std::string m_frname;

--- a/gen/src/ImpactTransform.cxx
+++ b/gen/src/ImpactTransform.cxx
@@ -19,7 +19,7 @@ Gen::ImpactTransform::ImpactTransform(IPlaneImpactResponse::pointer pir, BinnedD
     // arrange the field response (210 in total, pitch_range/impact)
     // number of wires nwires ...
     m_num_group = std::round(m_pir->pitch() / m_pir->impact()) + 1;  // 11
-    m_num_pad_wire = std::round((m_pir->nwires() - 1) / 2.);         // 10
+    m_num_pad_wire = std::round((m_pir->nwires() - 1) / 2.);         // 10 for wires, 5 for PCB strips
 
     const auto pimpos = m_bd.pimpos();
     //  const int nsamples = m_bd.tbins().nbins();
@@ -27,8 +27,8 @@ Gen::ImpactTransform::ImpactTransform(IPlaneImpactResponse::pointer pir, BinnedD
     // const int nwires = rb.nbins();
 
     //
-
-    // std::cout << m_num_group << " " << m_num_pad_wire << std::endl;
+    
+    //std::cerr << "ImpactTransform: num_group:" << m_num_group << " num_pad_wire:" << m_num_pad_wire << std::endl;
     for (int i = 0; i != m_num_group; i++) {
         double rel_cen_imp_pos;
         if (i != m_num_group - 1) {
@@ -40,11 +40,16 @@ Gen::ImpactTransform::ImpactTransform(IPlaneImpactResponse::pointer pir, BinnedD
         m_vec_impact.push_back(std::round(rel_cen_imp_pos / m_pir->impact()));
         std::map<int, IImpactResponse::pointer> map_resp;  // already in freq domain
 
+        //std::cerr << "ImpactTransform: " << rel_cen_imp_pos << std::endl;
         for (int j = 0; j != m_pir->nwires(); j++) {
+            // std::cerr << "ImpactTransform: "
+            //           << i << " " << j << " "
+            //           << rel_cen_imp_pos - (j-m_num_pad_wire)*m_pir->pitch()<< " "
+            //           << std::endl;
+
             map_resp[j - m_num_pad_wire] = m_pir->closest(rel_cen_imp_pos - (j - m_num_pad_wire) * m_pir->pitch());
             Waveform::compseq_t response_spectrum = map_resp[j - m_num_pad_wire]->spectrum();
 
-            //	std::cout << i << " " << j << " " << rel_cen_imp_pos - (j-m_num_pad_wire)*m_pir->pitch()<< " " <<
             //response_spectrum.size() << std::endl;
         }
         // std::cout << m_vec_impact.back() << std::endl;

--- a/gen/test/test_impcalc.cxx
+++ b/gen/test/test_impcalc.cxx
@@ -1,0 +1,55 @@
+#include "WireCellUtil/Logging.h"
+#include "WireCellUtil/Testing.h"
+#include <map>
+#include <cmath>
+
+using spdlog::debug;
+using namespace WireCell;
+
+struct PIR {
+
+    int nwires{21};             // number of wires spanning response
+    double pitch{5.0};          // wire pitch in mm
+    double impact{0.5};         // impact pitch in mm
+
+    int nimp_per_wire() const {
+        return 1 + int(round(pitch/impact))/2;
+    }
+    double half_extent() const {
+        return (nwires/2  + 0.5) * pitch;
+    }
+    std::pair<int, int> closest_wire_impact(double relpitch) const {
+        const int center_wire = nwires / 2;
+
+        const int relwire = int(round(relpitch / pitch));
+        const int wire_index = center_wire + relwire;
+
+        const double remainder_pitch = relpitch - relwire * pitch;
+        const int impact_index = int(round(remainder_pitch / impact)) + nimp_per_wire() / 2;
+
+        debug("impcalc: rp:{:6.2f} ii:({},{}) relwire:{} remainder:{} (pitch:{:4.1f})",
+              relpitch,
+              wire_index, impact_index,
+              relwire, remainder_pitch, pitch);
+
+        return std::make_pair(wire_index, impact_index);
+    }
+};
+
+int main()
+{
+    Log::add_stdout(true, "debug");
+    Log::set_level("debug");
+
+
+
+    PIR pir;
+    Assert(6 == pir.nimp_per_wire());
+
+    for (double rp=-pir.half_extent(); rp<=pir.half_extent(); rp += pir.impact) {
+        pir.closest_wire_impact(rp);
+    }
+
+    debug("nwires:{} half_extent:{}", pir. nwires, pir.half_extent());
+    return 0;
+}

--- a/gen/test/test_pir.cxx
+++ b/gen/test/test_pir.cxx
@@ -1,0 +1,54 @@
+#include "WireCellUtil/PluginManager.h"
+#include "WireCellUtil/Testing.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellGen/PlaneImpactResponse.h"
+#include "WireCellUtil/Units.h"
+#include "WireCellUtil/Logging.h"
+
+#include <string>
+
+using spdlog::debug;
+using spdlog::error;
+using namespace WireCell;
+
+int main(int argc, char* argv[]) {
+    Log::add_stdout(true, "debug");
+    Log::set_level("debug");
+
+    PluginManager& pm = PluginManager::instance();
+    pm.add("WireCellGen");
+    pm.add("WireCellSigProc");
+
+    std::string response_file = "dune-garfield-1d565.json.bz2";
+    if (argc > 1) {
+        response_file = argv[1];
+    };
+
+    {
+        auto icfg = Factory::lookup<IConfigurable>("FieldResponse");
+        auto cfg = icfg->default_configuration();
+        cfg["filename"] = response_file;
+        icfg->configure(cfg);
+    }
+
+    Gen::PlaneImpactResponse pir;
+    auto cfg = pir.default_configuration();
+    cfg["plane"] = 0;
+    cfg["nticks"] = 9595;
+    cfg["tick"] = 0.5 * units::us;
+    pir.configure(cfg);
+
+    const auto& irs = pir.irs();
+    const auto& bywire_map = pir.bywire_map();
+    for (int iwire=0; iwire<pir.nwires(); ++iwire) {
+        const auto& ri = bywire_map[iwire];
+        Assert(ri.size() == 11); // number of imps spanning a wire region
+        for (size_t ind=0; ind<ri.size(); ++ind) {
+            size_t ri_ind = ri[ind];
+            const auto ir = irs[ind];
+            debug("iwire:{} ind:{} ri_ind:{} imp:{}", iwire, ind, ri_ind, ir->impact());
+        }
+        
+    }
+    return 0;
+}

--- a/python/wirecell/sigproc/main.py
+++ b/python/wirecell/sigproc/main.py
@@ -258,6 +258,53 @@ def plot_garfield_track_response(ctx, gain, shaping, tick, tick_padding, electro
             open(dump_data,"wt").write(json.dumps(data.tolist(), indent=4))
 
 
+@cli.command("plot-response-compare-waveforms")
+@click.option("-p", "--plane", default=0,
+              help="Plane")
+@click.option("--irange", default='0',
+              help="Impact range as comma separated integers")
+@click.option("--trange", default='0,70',
+              help="Set time range in us as comma pair. def: 0,70")
+@click.argument("responsefile1")
+@click.argument("responsefile2")
+@click.argument("outfile")
+@click.pass_context
+def plot_response_compare_waveforms(ctx, plane, irange, trange, responsefile1, responsefile2, outfile):
+    '''
+    Plot common response waveforms from two sets
+    '''
+    import wirecell.sigproc.response.persist as per
+    import wirecell.sigproc.response.plots as plots
+
+    irange = list(map(int, irange.split(',')))
+    trange = list(map(int, trange.split(',')))
+
+    colors = ["red","blue"]
+    styles = ["solid","solid"]
+
+    import matplotlib.pyplot as plt
+    import numpy
+    def plot_paths(rfile, n):
+        fr = per.load(rfile)
+        pr = fr.planes[plane]
+        print(f'{colors[n]} {rfile}: plane={plane} {len(pr.paths)} paths:')
+        for ind in irange:
+            path = pr.paths[ind]
+            tot_q = numpy.sum(path.current)*fr.period
+            dt_us = fr.period/units.us
+            tot_es = tot_q / units.eplus
+            print (f'\t{ind}: {path.pitchpos:f}: {len(path.current)} samples, dt={dt_us:.3f} us, tot={tot_es:.3f} electrons')
+            plt.gca().set_xlim(*trange)
+
+            times = plots.time_linspace(fr, plane)
+
+            plt.plot(times/units.us, path.current, color=colors[n], linestyle=styles[n])
+        
+    plot_paths(responsefile1,0)
+    plot_paths(responsefile2,1)
+    plt.savefig(outfile)
+
+
 
 
 @cli.command("plot-response")
@@ -265,10 +312,12 @@ def plot_garfield_track_response(ctx, gain, shaping, tick, tick_padding, electro
               help="Set a region to demark as 'electrode 0'. def: none")
 @click.option("--trange", default='0,70',
               help="Set time range in us as comma pair. def: 0,70")
+@click.option("--reflect/--no-reflect", default=True,
+              help="Apply symmetry reflection")
 @click.argument("responsefile")
 @click.argument("outfile")
 @click.pass_context
-def plot_response(ctx, responsefile, outfile, region, trange):
+def plot_response(ctx, responsefile, outfile, region, trange, reflect):
     '''
     Plot per plane responses.
     '''
@@ -277,7 +326,7 @@ def plot_response(ctx, responsefile, outfile, region, trange):
 
     trange = list(map(int, trange.split(',')))
     fr = per.load(responsefile)
-    plots.plot_planes(fr, outfile, trange, region)
+    plots.plot_planes(fr, outfile, trange, region, reflect)
 
 
 

--- a/python/wirecell/sigproc/response/plots.py
+++ b/python/wirecell/sigproc/response/plots.py
@@ -166,7 +166,7 @@ def lg10(current):
             else: c[tind, pind] = 0
     return c
 
-def plot_planes(fr, filename=None, trange=(0,70), region=None):
+def plot_planes(fr, filename=None, trange=(0,70), region=None, reflect=True):
     '''
     Plot field response as time vs impact positions.
 
@@ -185,7 +185,7 @@ def plot_planes(fr, filename=None, trange=(0,70), region=None):
 
     for planeid in range(3):
         vlim = vlims[planeid]
-        t, p, c = get_plane(fr, planeid, reflect=True) # change to false to debug
+        t, p, c = get_plane(fr, planeid, reflect=reflect)
         print (t.shape, p.shape, c.shape)
         ax = axes[planeid]
         # ax.axis([65, 90, -20, 20])
@@ -277,3 +277,5 @@ def plot_specs(fr, filename=None):
             print ("warning: saving to PDF takes an awfully long time.  Try PNG.")
 
         fig.savefig(filename)
+
+

--- a/python/wirecell/sigproc/response/plots.py
+++ b/python/wirecell/sigproc/response/plots.py
@@ -17,7 +17,7 @@ def time_linspace(fr, planeid):
     tmin = fr.tstart
     tmax = tmin + ntbins*period
     tdelta = (tmax-tmin)/ntbins
-    print ('TBINS:', ntbins, tmin, tmax, tdelta, period)
+    #print ('TBINS:', ntbins, tmin, tmax, tdelta, period)
     return numpy.linspace(tmin, tmax, ntbins, endpoint=False)
 
 def hz_linspace(fr, planeid):
@@ -31,7 +31,7 @@ def hz_linspace(fr, planeid):
     hzmin = 0
     hzmax = 1.0/period_s
     hzdelta = hzmax/nfbins
-    print (f'FBINS: {nfbins} {hzmin}Hz {hzmax/1e6}MHz {hzdelta/1000.0}kHz {period_s*1e6:f}us')
+    #print (f'FBINS: {nfbins} {hzmin}Hz {hzmax/1e6}MHz {hzdelta/1000.0}kHz {period_s*1e6:f}us')
     return numpy.linspace(hzmin, hzmax, nfbins, endpoint=False)
 
 
@@ -50,7 +50,7 @@ def impact_linspace(fr, planeid):
     nibins_f = 2*imax/idelta
     nibins = int(round(nibins_f))
     assert abs(nibins-nibins_f) < 1e-6;
-    print (f'IBINS: {nibins} +/-{imax:f} {idelta:f} {nibins_f:f}')
+    #print (f'IBINS: {nibins} +/-{imax:f} {idelta:f} {nibins_f:f}')
     return numpy.linspace(-imax, imax, nibins+1)
 
 def impact_linspace_index(ls, pitchpos):
@@ -129,10 +129,8 @@ def get_current(fr, planeid, reflect):
     ilin = impact_linspace(fr, planeid)
 
     nimps, ntbins = times.shape
-    print (f'{nimps} {ntbins}')
 
     currents = numpy.zeros_like(times)
-    print(f'{currents.shape}')
 
     imp_uniq = numpy.unique(numpy.sort(impacts.reshape(impacts.size)))
     imp_delta = imp_uniq[1]-imp_uniq[0]
@@ -141,7 +139,7 @@ def get_current(fr, planeid, reflect):
     for path in pr.paths:
         assert path.current.size == ntbins
         pitchpos = path.pitchpos
-        print (f'plane:{planeid} pp:{pitchpos} nimps:{nimps} id:{imp_delta} im:{imp_min}')
+        #print (f'plane:{planeid} pp:{pitchpos} nimps:{nimps} id:{imp_delta} im:{imp_min}')
         imps,ref_imps = impact_linspace_index(ilin, pitchpos)
         
         inds = list(imps)
@@ -187,7 +185,6 @@ def plot_planes(fr, filename=None, trange=(0,70), region=None, reflect=True):
     for planeid in range(3):
         vlim = vlims[planeid]
         t, p, c = get_plane(fr, planeid, reflect=reflect)
-        print (t.shape, p.shape, c.shape)
         ax = axes[planeid]
         # ax.axis([65, 90, -20, 20])
 

--- a/python/wirecell/sigproc/response/plots.py
+++ b/python/wirecell/sigproc/response/plots.py
@@ -58,8 +58,8 @@ def impact_linspace_index(ls, pitchpos):
     nbins = len(ls)-1           # includes final HIGH-SIDE bin edge.
     d = ls[1]-ls[0]
     ind = int(round((pitchpos - ls[0])/d))
-    assert ind >= 0
-    assert ind < nbins
+    if ind <0 or ind >= nbins:
+        raise IndexError(f'out of range ls[0]:{ls[0]} d:{d} pp:{pitchpos} nbins:{nbins}')
 
     assert ind%2 == 0           # bad linspace
     if ind%10 == 0:             # wire or half way line
@@ -141,6 +141,7 @@ def get_current(fr, planeid, reflect):
     for path in pr.paths:
         assert path.current.size == ntbins
         pitchpos = path.pitchpos
+        print (f'plane:{planeid} pp:{pitchpos} nimps:{nimps} id:{imp_delta} im:{imp_min}')
         imps,ref_imps = impact_linspace_index(ilin, pitchpos)
         
         inds = list(imps)

--- a/root/test/test_fieldresp.cxx
+++ b/root/test/test_fieldresp.cxx
@@ -1,4 +1,5 @@
 #include "WireCellUtil/Testing.h"
+#include "WireCellUtil/Logging.h"
 
 /// needed to pretend like we are doing WCT internals
 #include "WireCellUtil/PluginManager.h"
@@ -13,9 +14,14 @@
 
 using namespace WireCell;
 using namespace std;
+using spdlog::debug;
+using spdlog::error;
 
 int main(int argc, char* argv[])
 {
+    Log::add_stdout(true, "debug");
+    Log::set_level("debug");
+
     std::string frfname = "ub-10-wnormed.json.bz2";
     if (argc > 1) {
         frfname = argv[1];
@@ -43,6 +49,21 @@ int main(int argc, char* argv[])
 
     cerr << "FR with " << fr.planes[0].paths.size() << " responses per plane\n";
     Assert(fr.planes[0].paths.size() == 21 * 6);
+
+    for (auto pr : fr.planes) {
+        const int n_per = 6;
+        const double imp_pitch = 2.0 * std::abs(pr.paths[n_per - 1].pitchpos - pr.paths[0].pitchpos);
+        debug("plane:{}, pitch:{:f}, pitchpos: front:{:f}, back:{:f}, imp-pitch:{:f}",
+              pr.planeid, pr.pitch,
+              pr.paths.front().pitchpos,
+              pr.paths.back().pitchpos,
+              imp_pitch
+            );
+        // for (auto path : pr.paths) {
+        //     debug("\tpitchpos:{}", path.pitchpos);
+        // }
+    }
+
 
     // Make a new data set which is the average FR
     Response::Schema::FieldResponse fravg = Response::wire_region_average(fr);


### PR DESCRIPTION
This is some minor fixes made during drifires/pcbro response function work

* some cosmetic improvements in the python plot command for response functions
* it was discovered that impact transform was not checking return value of PIR for nullptr which led to mystery segfault when given bad response functions.  I change to throwing exception.  Either way, well formed response function data should not fire the error.

Please just give is a look over before merging.