### PR TITLE
Quick update for ICARUS

### DIFF
--- a/gen/src/DepoSplat.cxx
+++ b/gen/src/DepoSplat.cxx
@@ -95,7 +95,7 @@ ITrace::vector Gen::DepoSplat::process_face(IAnodeFace::pointer face, const IDep
 
             if (tbeg > tend) continue;
 
-            if (tbeg < 0) continue;
+            if (pbeg > pend) continue;
 
             Gen::GausDesc time_desc(tcen, tsig);
             Gen::GausDesc pitch_desc(pcen, psig);

--- a/tbb/inc/WireCellTbb/FaninCat.h
+++ b/tbb/inc/WireCellTbb/FaninCat.h
@@ -69,13 +69,17 @@ namespace WireCellTbb {
         {
             int nin = wcnode->input_types().size();
             // an exhaustive switch to convert from run-time to compile-time types and enumerations.
-            Assert(nin > 0 && nin <= 6);  // fixme: exception instead?
+            Assert(nin > 0 && nin <= 10);  // fixme: exception instead?
             if (1 == nin) m_receiver_ports = build_faniner<1>(graph, wcnode, m_joiner, m_caller);
             if (2 == nin) m_receiver_ports = build_faniner<2>(graph, wcnode, m_joiner, m_caller);
             if (3 == nin) m_receiver_ports = build_faniner<3>(graph, wcnode, m_joiner, m_caller);
             if (4 == nin) m_receiver_ports = build_faniner<4>(graph, wcnode, m_joiner, m_caller);
             if (5 == nin) m_receiver_ports = build_faniner<5>(graph, wcnode, m_joiner, m_caller);
             if (6 == nin) m_receiver_ports = build_faniner<6>(graph, wcnode, m_joiner, m_caller);
+            if (7 == nin) m_receiver_ports = build_faniner<7>(graph, wcnode, m_joiner, m_caller);
+            if (8 == nin) m_receiver_ports = build_faniner<8>(graph, wcnode, m_joiner, m_caller);
+            if (9 == nin) m_receiver_ports = build_faniner<9>(graph, wcnode, m_joiner, m_caller);
+            if (10 == nin) m_receiver_ports = build_faniner<10>(graph, wcnode, m_joiner, m_caller);
         }
 
         virtual receiver_port_vector receiver_ports() { return m_receiver_ports; }

--- a/tbb/inc/WireCellTbb/FanoutCat.h
+++ b/tbb/inc/WireCellTbb/FanoutCat.h
@@ -73,13 +73,17 @@ namespace WireCellTbb {
         {
             int nout = wcnode->output_types().size();
             // an exhaustive switch to convert from run-time to compile-time types and enumerations.
-            Assert(nout > 0 && nout <= 6);  // fixme: exception instead?
+            Assert(nout > 0 && nout <= 10);  // fixme: exception instead?
             if (1 == nout) m_sender_ports = build_fanouter<1>(graph, wcnode, m_spliter, m_caller);
             if (2 == nout) m_sender_ports = build_fanouter<2>(graph, wcnode, m_spliter, m_caller);
             if (3 == nout) m_sender_ports = build_fanouter<3>(graph, wcnode, m_spliter, m_caller);
             if (4 == nout) m_sender_ports = build_fanouter<4>(graph, wcnode, m_spliter, m_caller);
             if (5 == nout) m_sender_ports = build_fanouter<5>(graph, wcnode, m_spliter, m_caller);
             if (6 == nout) m_sender_ports = build_fanouter<6>(graph, wcnode, m_spliter, m_caller);
+            if (7 == nout) m_sender_ports = build_fanouter<7>(graph, wcnode, m_spliter, m_caller);
+            if (8 == nout) m_sender_ports = build_fanouter<8>(graph, wcnode, m_spliter, m_caller);
+            if (9 == nout) m_sender_ports = build_fanouter<9>(graph, wcnode, m_spliter, m_caller);
+            if (10 == nout) m_sender_ports = build_fanouter<10>(graph, wcnode, m_spliter, m_caller);
         }
 
         virtual sender_port_vector sender_ports() { return m_sender_ports; }


### PR DESCRIPTION
 - increase `FaninCat`/`FanoutCat` maximum fork number to 10, which is the maximum using current TBB configuration
 - fixed a bug in `DepoSplat`: add protection for pitch number; remove the `tbeg` protection for it is not needed