### PR TITLE
Lower pitchpos by epsilon to avoid round-off error

### DIFF
--- a/gen/src/ImpactTransform.cxx
+++ b/gen/src/ImpactTransform.cxx
@@ -1,7 +1,7 @@
 #include "WireCellGen/ImpactTransform.h"
 #include "WireCellUtil/Testing.h"
 #include "WireCellUtil/FFTBestLength.h"
-
+#include "WireCellUtil/Exceptions.h"
 #include <iostream>  // debugging.
 using namespace std;
 
@@ -47,7 +47,24 @@ Gen::ImpactTransform::ImpactTransform(IPlaneImpactResponse::pointer pir, BinnedD
             //           << rel_cen_imp_pos - (j-m_num_pad_wire)*m_pir->pitch()<< " "
             //           << std::endl;
 
-            map_resp[j - m_num_pad_wire] = m_pir->closest(rel_cen_imp_pos - (j - m_num_pad_wire) * m_pir->pitch());
+            try {
+                map_resp[j - m_num_pad_wire] = m_pir->closest(rel_cen_imp_pos - (j - m_num_pad_wire) * m_pir->pitch());
+            }
+            catch (ValueError& ve) {
+                std::cerr << "ImpactTransform: I angered PIR with: i="
+                          << i << " j=" << j
+                          << " rel_cen_imp_pos=" << rel_cen_imp_pos
+                          << " m_num_pad_wire=" << m_num_pad_wire
+                          << " m_num_group=" << m_num_group
+                          << " pir->pitch=" << m_pir->pitch()
+                          << " pir->impact=" << m_pir->impact()
+                          << " pir->nwires=" << m_pir->nwires()
+                          << " looking for: "
+                          << rel_cen_imp_pos - (j - m_num_pad_wire) * m_pir->pitch()
+                          << std::endl;                
+                continue;
+            }
+                
             Waveform::compseq_t response_spectrum = map_resp[j - m_num_pad_wire]->spectrum();
 
             //response_spectrum.size() << std::endl;

--- a/sio/src/NumpyDepoLoader.cxx
+++ b/sio/src/NumpyDepoLoader.cxx
@@ -107,10 +107,9 @@ bool Sio::NumpyDepoLoader::next()
     std::vector<SimpleDepo*> sdepos;
     for (size_t ind=0; ind < ndepos; ++ind) {
 
-        log->debug("dump: {}: t={} q={} x={} y={} z={}", ind,
-                   data(ind, 0), data(ind, 1),
-                   data(ind, 2), data(ind, 3), data(ind, 4));
-
+        // log->debug("dump: {}: t={} q={} x={} y={} z={}", ind,
+        //            data(ind, 0), data(ind, 1),
+        //            data(ind, 2), data(ind, 3), data(ind, 4));
 
         auto sdepo = new SimpleDepo(
             data(ind, 0),        // t
@@ -171,5 +170,13 @@ bool Sio::NumpyDepoLoader::operator()(WireCell::IDepo::pointer& outdepo)
 
     outdepo = m_depos.front();
     m_depos.pop_front();
+    auto log = Log::logger("sio");
+    if (!outdepo) {
+        log->debug("depo loader got no depo");
+    }
+    // else {
+    //     log->debug("depo loader: t={} q={} x={}",
+    //                outdepo->time(), outdepo->charge(), outdepo->pos().x());
+    // }
     return true;
 }


### PR DESCRIPTION
Going from floating point pitch position to integer wire number is subject to a round-off error in PIR due to a `ceil()`.  When the pitchpos is slightly too large the `ceil()` will pop to the next higher wire number.  

This was encountered when using 7.35mm pitch for the pcbro response converter.  It can be fixed there as well but best to fix it in WCT so we won't chase our tails next time around.

The fix is to subtract a small fraction of the pitch prior to the `ceil()`.

