### PR TITLE
Fix #109.  Adds back multithreading.

### DIFF
--- a/apps/inc/WireCellApps/Main.h
+++ b/apps/inc/WireCellApps/Main.h
@@ -91,11 +91,17 @@ namespace WireCell {
         /// Call to finalize any terminal components.
         void finalize();
 
+
+
        private:
         ConfigManager m_cfgmgr;
         std::vector<std::string> m_plugins, m_apps, m_cfgfiles, m_load_path;
         Persist::externalvars_t m_extvars, m_extcode, m_tlavars, m_tlacode;
         Log::logptr_t l;
+
+        // Limit number of threads.  0 means set no limit.  This is
+        // only relevant if we are built with TBB support
+        int m_threads{0};
     };
 
 }  // namespace WireCell

--- a/apps/wscript_build
+++ b/apps/wscript_build
@@ -1,3 +1,8 @@
-bld.smplpkg('WireCellApps', use='WireCellIface FFTWTHREADS')
+if 'HAVE_TBB' in bld.env:
+    bld.smplpkg('WireCellApps', use='WireCellIface FFTWTHREADS TBB')
+else:
+    bld.smplpkg('WireCellApps', use='WireCellIface FFTWTHREADS')
+
+
 #            app_use='WireCellUtil JSONNET',
 #            test_use='WireCellUtil DYNAMO BOOST JSONCPP JSONNET')

--- a/tbb/inc/WireCellTbb/DataFlowGraph.h
+++ b/tbb/inc/WireCellTbb/DataFlowGraph.h
@@ -7,8 +7,6 @@
 #include "WireCellTbb/NodeWrapper.h"
 #include "WireCellTbb/WrapperFactory.h"
 
-#include <tbb/global_control.h>
-
 #include <map>
 #include <string>
 
@@ -31,10 +29,10 @@ namespace WireCellTbb {
         virtual WireCell::Configuration default_configuration() const;
 
        private:
-        tbb::global_control m_sched; // pass in number of threads
         tbb::flow::graph m_graph;    // here lives the TBB graph
         WrapperFactory m_factory;
         WireCell::Log::logptr_t l;
+        int m_thread_limit{0};  // 0 means no limit
     };
 
 }  // namespace WireCellTbb

--- a/tbb/test/test_max_threads.cxx
+++ b/tbb/test/test_max_threads.cxx
@@ -1,0 +1,26 @@
+#include <tbb/info.h>
+#include <tbb/global_control.h>
+
+#include <iostream>
+
+int main()
+{
+    std::cerr << tbb::info::default_concurrency() << std::endl;
+    {
+        tbb::global_control global_limit(tbb::global_control::max_allowed_parallelism, 2);
+        std::cerr << global_limit.active_value(tbb::global_control::max_allowed_parallelism) << std::endl;
+        {
+            tbb::global_control global_limit2(tbb::global_control::max_allowed_parallelism, 4);
+            std::cerr << "\t" <<
+                global_limit2.active_value(tbb::global_control::max_allowed_parallelism) << std::endl;
+        }
+    }
+
+    {
+        tbb::global_control* gl = new tbb::global_control(tbb::global_control::max_allowed_parallelism, 16);
+        std::cerr << gl->active_value(tbb::global_control::max_allowed_parallelism) << std::endl;
+        delete gl;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This adds a `-t/--threads` option to `wire-cell` (actually in `Main` so _art_ interface may also set if it desires).  This option is only available if the `libWireCellApps` is compiled with TBB support.  It also reinstates the `max_threads` option to `DataFlowGraph` in `libWireCellTbb`.

The behavior is scoped and default is to perform no limitation.  If not limited, the default TBB behavior appears to set the limit to match the number of cores on the system.  If a limit is set in `Main` then `DataFlowGraph` can only set an identical or smaller limit.   The limit in both contexts lasts only over their "execute" method.  So, for example if either are used to clamp down in the context of an _art_ job, this limit should not "leak" over into a limit imposed to non-WCT _art_ modules. 


I tested build and running both with and without TBB so probably its fine to merge.