### PR TITLE
Fix #113 ImpactResponse multi-thread race

### DIFF
--- a/gen/inc/WireCellGen/PlaneImpactResponse.h
+++ b/gen/inc/WireCellGen/PlaneImpactResponse.h
@@ -36,10 +36,11 @@ namespace WireCell {
               , m_long_waveform(long_wf)
               , m_long_waveform_pad(long_waveform_pad)
             {
+                m_spectrum = Waveform::dft(m_waveform);
             }
 
             /// Frequency-domain spectrum of response
-            const Waveform::compseq_t& spectrum();
+            const Waveform::compseq_t& spectrum() const { return m_spectrum; };
             const Waveform::realseq_t& waveform() const { return m_waveform; };
             int waveform_pad() const { return m_waveform_pad; };
 

--- a/gen/src/EmpiricalNoiseModel.cxx
+++ b/gen/src/EmpiricalNoiseModel.cxx
@@ -298,7 +298,7 @@ const IChannelSpectrum::amplitude_t& Gen::EmpiricalNoiseModel::operator()(int ch
         ilen = int(len / m_wlres);
         // there might be  aproblem with the wire length's unit
         // ilen = int(len);
-        m_chid_to_intlen[chid] = ilen;
+        m_chid_to_intlen[chid] = ilen; // fixme: not thread safe
     }
     else {
         ilen = chlen->second;
@@ -312,7 +312,7 @@ const IChannelSpectrum::amplitude_t& Gen::EmpiricalNoiseModel::operator()(int ch
     auto lenamp = amp_cache.find(ilen);
     if (lenamp == amp_cache.end()) {
         auto amp = interpolate(iplane, ilen * m_wlres);  // interpolate ...
-        amp_cache[ilen] = amp;
+        amp_cache[ilen] = amp;  // fixme: not thread safe
     }
     lenamp = amp_cache.find(ilen);
 

--- a/gen/src/PlaneImpactResponse.cxx
+++ b/gen/src/PlaneImpactResponse.cxx
@@ -11,17 +11,6 @@ WIRECELL_FACTORY(PlaneImpactResponse, WireCell::Gen::PlaneImpactResponse, WireCe
 using namespace std;
 using namespace WireCell;
 
-const Waveform::compseq_t& Gen::ImpactResponse::spectrum()
-{
-    if (m_spectrum.size() != 0) {
-        return m_spectrum;
-    }
-    else {
-        m_spectrum = Waveform::dft(m_waveform);
-        return m_spectrum;
-    }
-}
-
 
 Gen::PlaneImpactResponse::PlaneImpactResponse(int plane_ident, size_t nbins, double tick)
   : m_frname("FieldResponse")

--- a/iface/inc/WireCellIface/IPlaneImpactResponse.h
+++ b/iface/inc/WireCellIface/IPlaneImpactResponse.h
@@ -22,7 +22,7 @@ namespace WireCell {
         virtual ~IImpactResponse();
 
         /// Frequency-domain spectrum of response
-        virtual const Waveform::compseq_t& spectrum() = 0;
+        virtual const Waveform::compseq_t& spectrum() const = 0;
         /// Time-domain waveform of the response
         virtual const Waveform::realseq_t& waveform() const = 0;
         // minimum padding for the response

--- a/sio/inc/WireCellSio/NumpyFrameSaver.h
+++ b/sio/inc/WireCellSio/NumpyFrameSaver.h
@@ -1,4 +1,4 @@
-/** Some frames to a Numpy file */
+/** Save frames to a Numpy file */
 
 #ifndef WIRECELLSIO_NUMPYFRAMESAVER
 #define WIRECELLSIO_NUMPYFRAMESAVER


### PR DESCRIPTION
This has been with us for a while but would be rare to hit.

- job must run TbbFlow instead of Pgrapher
- just have more than one AnodePlane
- two threads must both request spectrum() for the same wire
- at the same time
- and both be the first time requested

There are still other races of this type though maybe all in "service"
type components that are only used from one "node" component.