### PR TITLE
Fix #115 array ordering mismatch and deal with Numpy dynamically chosing C/F order

### DIFF
--- a/gen/src/DepoTransform.cxx
+++ b/gen/src/DepoTransform.cxx
@@ -151,7 +151,7 @@ bool Gen::DepoTransform::operator()(const input_pointer& in, output_pointer& out
         IDepo::vector face_depos, dropped_depos;
         auto bb = face->sensitive();
         if (bb.empty()) {
-            l->debug("anode {} face {} is marked insensitive, skipping", m_anode->ident(), face->ident());
+            l->debug("DepoTransform: anode {} face {} is marked insensitive, skipping", m_anode->ident(), face->ident());
             continue;
         }
 
@@ -167,7 +167,7 @@ bool Gen::DepoTransform::operator()(const input_pointer& in, output_pointer& out
         if (face_depos.size()) {
             auto ray = bb.bounds();
             l->debug(
-                "anode: {}, face: {}, processing {} depos spanning "
+                "DepoTransform: anode: {}, face: {}, processing {} depos spanning "
                 "t:[{},{}]ms, bb:[{}-->{}]cm",
                 m_anode->ident(), face->ident(), face_depos.size(), face_depos.front()->time() / units::ms,
                 face_depos.back()->time() / units::ms, ray.first / units::cm, ray.second / units::cm);
@@ -175,7 +175,7 @@ bool Gen::DepoTransform::operator()(const input_pointer& in, output_pointer& out
         if (dropped_depos.size()) {
             auto ray = bb.bounds();
             l->debug(
-                "anode: {}, face: {}, dropped {} depos spanning "
+                "DepoTransform: anode: {}, face: {}, dropped {} depos spanning "
                 "t:[{},{}]ms, outside bb:[{}-->{}]cm",
                 m_anode->ident(), face->ident(), dropped_depos.size(), dropped_depos.front()->time() / units::ms,
                 dropped_depos.back()->time() / units::ms, ray.first / units::cm, ray.second / units::cm);

--- a/gen/src/Drifter.cxx
+++ b/gen/src/Drifter.cxx
@@ -246,8 +246,8 @@ bool Gen::Drifter::operator()(const input_pointer& depo, output_queue& outq)
         flush(outq);
 
         if (n_dropped) {
-            l->debug("at EOS, dropped {} / {} depos from stream, outside of all {} drift regions", n_dropped,
-                     n_dropped + n_drifted, m_xregions.size());
+            l->debug("drifter: EOS, dropped {} / {} depos from stream, outside of all {} drift xregions",
+                     n_dropped, n_dropped + n_drifted, m_xregions.size());
         }
         n_drifted = n_dropped = 0;
         return true;

--- a/util/inc/WireCellUtil/NumpyHelper.h
+++ b/util/inc/WireCellUtil/NumpyHelper.h
@@ -36,14 +36,22 @@ namespace WireCell::Numpy {
     
     template <typename ARRAY>
     void load2d(ARRAY& array, std::string aname, std::string fname) {
-        using ROWM = Eigen::Array<typename ARRAY::Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
         using Scalar = typename ARRAY::Scalar;
-        
+
         cnpy::NpyArray np = cnpy::npz_load(fname, aname);
 
-        ROWM temp = Eigen::Map<ROWM>(np.data<Scalar>(),
-                                     np.shape[0], np.shape[1]);
-        array = temp;
+        if (np.fortran_order) {
+            using COLM = Eigen::Array<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
+            COLM temp = Eigen::Map<COLM>(np.data<Scalar>(),
+                                         np.shape[0], np.shape[1]);
+            array = temp;
+        }
+        else{
+            using ROWM = Eigen::Array<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+            ROWM temp = Eigen::Map<ROWM>(np.data<Scalar>(),
+                                         np.shape[0], np.shape[1]);
+            array = temp;
+        }
     }
 
 }

--- a/util/test/test_cnpy_eigen3.cxx
+++ b/util/test/test_cnpy_eigen3.cxx
@@ -1,0 +1,89 @@
+/**
+   Eigen defaults column-major ordering (FORTRAN).
+
+   Cnpy defaults to row-major ordering (C).
+
+   This is like test_cnpy_eigen.cxx but uses the numpy helpers.
+
+ */
+
+#include "WireCellUtil/NumpyHelper.h"
+#include "WireCellUtil/Array.h"
+
+using ntype = int;
+
+using ArrayType = Eigen::Array<ntype, Eigen::Dynamic, Eigen::Dynamic>;
+
+const int Nrows = 3;
+const int Ncols = 4;
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2) {
+        std::cerr
+            << "This test needs a numpy file\n"
+            << "To generate it, run util/test/test_cnpy_eigen3.py\n";
+        return 0;
+    }
+
+    std::string fname = argv[1];
+
+    ArrayType narr;
+    WireCell::Numpy::load2d(narr, "n_order", fname);
+    assert(narr.rows() == Nrows);
+    assert(narr.cols() == Ncols);
+
+    ArrayType carr;
+    WireCell::Numpy::load2d(carr, "c_order", fname);
+    assert(carr.rows() == Nrows);
+    assert(carr.cols() == Ncols);
+
+    ArrayType farr;
+    WireCell::Numpy::load2d(farr, "f_order", fname);
+    assert(farr.rows() == Nrows);
+    assert(farr.cols() == Ncols);
+
+    std::cerr << "Expected:\n";
+    for (int irow = 0; irow < Nrows; ++irow) {
+        for (int icol=0; icol < Ncols; ++icol) {
+            ntype val = icol + irow*Ncols;
+            std::cerr << " " << val;
+        }
+        std::cerr << std::endl;
+    }
+    std::cerr << "N order:\n";
+    for (int irow = 0; irow < Nrows; ++irow) {
+        for (int icol=0; icol < Ncols; ++icol) {
+            std::cerr << " " << narr(irow, icol);
+        }
+        std::cerr << std::endl;
+    }
+    std::cerr << "C order:\n";
+    for (int irow = 0; irow < Nrows; ++irow) {
+        for (int icol=0; icol < Ncols; ++icol) {
+            std::cerr << " " << carr(irow, icol);
+        }
+        std::cerr << std::endl;
+    }
+    std::cerr << "F order:\n";
+    for (int irow = 0; irow < Nrows; ++irow) {
+        for (int icol=0; icol < Ncols; ++icol) {
+            std::cerr << " " << farr(irow, icol);
+        }
+        std::cerr << std::endl;
+    }
+
+    for (int irow = 0; irow < Nrows; ++irow) {
+        for (int icol=0; icol < Ncols; ++icol) {
+            ntype val = icol + irow*Ncols;
+            std::cerr << "["<<irow<<","<<icol<<"] = "
+                      << val << " | " << carr(irow,icol) << " | " << farr(irow,icol) 
+                      << std::endl;
+            assert(narr(irow,icol) == val);
+            assert(carr(irow,icol) == val);
+            assert(farr(irow,icol) == val);
+        }
+    }
+
+    return 0;
+}

--- a/util/test/test_cnpy_eigen3.py
+++ b/util/test/test_cnpy_eigen3.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+
+import numpy
+
+dtype = 'int32'
+
+arr = numpy.array(numpy.arange(12), dtype=dtype);
+arr.resize(3,4)
+
+c_order = numpy.array(arr, order='C', dtype=dtype)
+f_order = numpy.array(arr, order='F', dtype=dtype)
+
+print(arr)
+print(f'native : {arr.shape} {arr.dtype}\n{arr.flags}')
+print(f'nativeT: {arr.T.shape} {arr.T.dtype}\n{arr.T.flags}')
+print(f'c_order: {c_order.shape} {c_order.dtype}\n{c_order.flags}')
+print(f'f_order: {f_order.shape} {f_order.dtype}\n{f_order.flags}')
+
+print('saving test_cnpy_eigen3.npz')
+numpy.savez('test_cnpy_eigen3.npz',
+            c_order = c_order,
+            f_order = f_order,
+            n_order = arr)


### PR DESCRIPTION
Now check cnpy's `fortran_order` on loading in order to pick Eigen row- or column-wise mappings.