### PR TITLE
Imaging cfg, empty object and clustering sync

### DIFF
--- a/cfg/pgrapher/common/helpers.jsonnet
+++ b/cfg/pgrapher/common/helpers.jsonnet
@@ -7,5 +7,8 @@
     nf :: import "helpers/nf.jsonnet",
     sp :: import "helpers/sp.jsonnet",
     dnnroi :: import "helpers/dnnroi.jsonnet",
+    img :: import "helpers/img.jsonnet",
+    frames :: import "helpers/frames.jsonnet",
+    magnify :: import "helpers/magnify.jsonnet",
 }
     

--- a/cfg/pgrapher/common/helpers/frames.jsonnet
+++ b/cfg/pgrapher/common/helpers/frames.jsonnet
@@ -1,0 +1,14 @@
+local pg = import 'pgraph.jsonnet';
+local wc = import 'wirecell.jsonnet';
+
+function(anode)
+{
+    local apaid = anode.data.ident,
+
+    // A sink of frames which dumps info to log
+    logframes :: function(name=apaid) pg.pnode({
+        type: "DumpFrames",
+        name: "name",
+    }, nin=1, nout=0),
+}
+

--- a/cfg/pgrapher/common/helpers/img.jsonnet
+++ b/cfg/pgrapher/common/helpers/img.jsonnet
@@ -1,0 +1,127 @@
+// Help build imaging nodes.  This provides a function which returns
+// an object of methods and (sub)objects on the given anode.
+
+local pg = import 'pgraph.jsonnet';
+local wc = import 'wirecell.jsonnet';
+
+function(anode)
+{
+    local apaid = anode.data.ident,
+
+    // The conventional slicing node 
+    slicing :: function(name=apaid, tag="", span=4) pg.pnode({
+        type: "SumSlices",
+        name: name,
+        data: {
+            tag: tag,
+            tick_span: span,
+            anode: wc.tn(anode),
+        },
+    }, nin=1, nout=1, uses=[anode]),
+
+    // A function that tries to figure out if anode is wrapped or if
+    // single faced which face number is sensitive.
+    tiling :: function(name=apaid)
+        if std.length(std.prune(anode.data.faces)) == 2 then
+            $.wrapped_tiling(name)
+        else if std.type(anode.data.faces[0]) == "null" then
+            $.single_tiling(name, 1)
+        else
+            $.single_tiling(name, 0),
+
+    // A function that returns a tiling node for single faced anodes
+    single_tiling :: function(name=apaid, face=0) pg.pnode({
+        type: "GridTiling",
+        name: "%s-%d"%[name, face],
+        data: {
+            anode: wc.tn(anode),
+            face: face,
+        }
+    }, nin=1, nout=1, uses=[anode]),
+
+    // A function providing a subgraph to do tiling for wrapped (two
+    // faced) anodes
+    wrapped_tiling :: function(name=apaid) {
+
+        local slice_fanout = pg.pnode({
+            type: "SliceFanout",
+            name: name,
+            data: { multiplicity: 2 },
+        }, nin=1, nout=2),
+
+        local tilings = [
+            pg.pnode({
+                type: "GridTiling",
+                name: "%s-%d"%[name, face],
+                data: {
+                    anode: wc.tn(anode),
+                    face: face,
+                }
+            }, nin=1, nout=1, uses=[anode]) for face in [0,1]],
+
+        local blobsync = pg.pnode({
+            type: "BlobSetSync",
+            name: name,
+            data: { multiplicity: 2 }
+        }, nin=2, nout=1),
+
+        ret: pg.intern(
+            innodes=[slice_fanout],
+            outnodes=[blobsync],
+            centernodes=tilings,
+            edges=
+                [pg.edge(slice_fanout, tilings[n], n, 0) for n in [0,1]] +
+                [pg.edge(tilings[n], blobsync, 0, n) for n in [0,1]],
+            name=name),
+    }.ret,
+
+    // A node that clusters blobs between slices w/in the given number
+    // of slice spans.  Makes blob-blob edges
+    clustering :: function(name=apaid, spans=1.0) pg.pnode({
+        type: "BlobClustering",
+        name: name,
+        data:  { spans : spans }
+    }, nin=1, nout=1),
+
+    // A node that groups wires+channels into measurements.  Makes
+    // blob-measure edges.
+    grouping :: function(name=apaid) pg.pnode({
+        type: "BlobGrouping",
+        name: name,
+        data:  {
+        }
+    }, nin=1, nout=1),
+
+
+    // A node that "solves" for blob charge given blob-measure edges.
+    // Only blobs with charge above threshold are kept.
+    solving :: function(name=apaid, threshold=0.0) pg.pnode({
+        type: "BlobSolving",
+        name: name,
+        data:  { threshold: threshold }
+    }, nin=1, nout=1),
+
+    // A nominal imaging omnibus pipeline starting with a frame ending
+    // in solved cluster.  Note, there are many ways to reasonably
+    // form a full chain.  This is but one which implements the graph
+    // in the raygrid.pdf figure 12 but starting with IFrame input and
+    // ending with a solving.
+    nominal :: function(name=apaid, tag="", span=4, spans=1.0, threshold=0.0) pg.pipeline([
+        $.slicing(name, tag, span),
+        $.tiling(name),
+        $.clustering(name, spans),
+        $.grouping(name),
+        $.solving(name, threshold)
+    ]),
+
+
+    // A function that projects blobs back to frames.  
+    reframing :: function(name=apaid, tag="") pg.pnode({
+        type: "BlobReframer",
+        name: name,
+        data: {
+            frame_tag: tag,
+        }
+    }, nin=1, nout=1),
+
+}

--- a/cfg/pgrapher/common/helpers/io.jsonnet
+++ b/cfg/pgrapher/common/helpers/io.jsonnet
@@ -2,6 +2,7 @@
 // components.
 
 local pg = import "pgraph.jsonnet";
+local wc = import "wirecell.jsonnet";
 
 {
     // If a frame is written out "dense" it the sink needs to know
@@ -35,6 +36,34 @@ local pg = import "pgraph.jsonnet";
                                      tags=tags,
                                      digitize=digitize,
                                      dense=dense), filename),
+
+    // A pass-through node for ICluster which saves as a side-effect.
+    cluster_json_tap :: function(name, drift_speed=1.6*wc.mm/wc.us, filepat=null) pg.pnode({
+        type: "JsonClusterTap",
+        name: name,
+        data: {
+            filename: if std.type(filepat) == "null" then "clusters-"+name+"-%04d.json" else filepat,
+            drift_speed: drift_speed
+        },
+    }, nin=1, nout=1),
+
+    // Write a cluster to a graphviz file
+    cluster_graphviz :: function(name, filepat=null) pg.pnode({
+        type: "ClusterSink",
+        name: name,
+        data: {
+            filename: if std.type(filepat) == "null" then "clusters-apa-"+name+"-%04d.dot" else filepat,
+        }
+    }, nin=1, nout=0),
+
+    // Write out in a WCT cluster file format (json+tar[+compression])
+    cluster_file :: function(name, filename=null) pg.pnode({
+        type: 'ClusterFileSink',
+        name: name,
+        data: {
+            outname: if std.type(filename) == "null" then "clusters-"+name+".tar.bz2" else filename,
+        },
+    }, nin=1, nout=0),
 
 
 }

--- a/cfg/pgrapher/common/helpers/magnify.jsonnet
+++ b/cfg/pgrapher/common/helpers/magnify.jsonnet
@@ -1,0 +1,22 @@
+local pg = import 'pgraph.jsonnet';
+local wc = import 'wirecell.jsonnet';
+
+function(anode)
+{
+    local apaid = anode.data.ident,
+
+    // fill ROOT histograms with frames
+    magnify :: function(name, filename="magnify-"+apaid+".root", frame_tags=["orig"+apaid]) ret: g.pnode({
+        type: 'MagnifySink',
+        name: name,
+        data: {
+            output_filename: filename,
+            root_file_mode: 'UPDATE',
+            frames: frame_tags,
+            trace_has_tag: true,
+            anode: wc.tn(anode),
+        },
+    }, nin=1, nout=1),
+
+}
+    

--- a/img/inc/WireCellImg/BlobClustering.h
+++ b/img/inc/WireCellImg/BlobClustering.h
@@ -68,7 +68,7 @@ namespace WireCell {
             // Add the newbs to the graph.  Return true if a flush is needed (eg, because of a gap)
             bool graph_bs(const input_pointer& newbs);
 
-            // return true if a gap exists between the slice of newbs and the last bs.
+            // Return true if a gap exists between the slice of newbs and the last bs.
             bool judge_gap(const input_pointer& newbs);
 
             // Blob set must be kept, this saves them.

--- a/img/inc/WireCellImg/GridTiling.h
+++ b/img/inc/WireCellImg/GridTiling.h
@@ -39,6 +39,8 @@ namespace WireCell {
             IAnodeFace::pointer m_face;
             double m_threshold;
 
+            IBlobSet::pointer make_empty(const input_pointer& slice);
+
         };
     }  // namespace Img
 }  // namespace WireCell

--- a/img/inc/WireCellImg/SumSlice.h
+++ b/img/inc/WireCellImg/SumSlice.h
@@ -54,6 +54,24 @@ namespace WireCell {
            protected:
             typedef std::map<size_t, Data::Slice*> slice_map_t;
             void slice(const IFrame::pointer& in, slice_map_t& sm);
+            ISlice::pointer make_empty(const IFrame::pointer& inframe);
+
+            // If true, the subclasses will add an EOS at end of
+            // slices from one input frame.  See also pad_empty.
+            //
+            // Note, if slice-level EOS is enabled then it is up to
+            // the graph designer to assure something "eats up" the
+            // extra EOS.
+            //
+            // As an alternative, consider leaving this false and rely
+            // on a downstream node to re-sync by watching the ID of
+            // the frame associated with each slice to change.  Again,
+            // see pad_empty.
+            bool m_slice_eos{false};
+
+            // If true, then a frame which produces no nominal slices
+            // will instead produce a single empty slice.
+            bool m_pad_empty{true};
 
            private:
             IAnodePlane::pointer m_anode;

--- a/img/src/BlobSolving.cxx
+++ b/img/src/BlobSolving.cxx
@@ -64,6 +64,13 @@ static double blob_weight(IBlob::pointer iblob, ISlice::pointer islice, const cl
 
 static void solve_slice(cluster_indexed_graph_t& grind, ISlice::pointer islice)
 {
+    // fixme: make blob-measure and find connected components.
+
+    // fixme: for each subgraph determine if needs L1
+    // - one blob: no
+    // - no small eigenvalues: no
+    // - o.w. yes
+
     std::vector<std::vector<int> > b2minds;
     IndexedSet<IBlob::pointer> blobs;
     IndexedSet<IChannel::shared_vector> measures;
@@ -74,6 +81,7 @@ static void solve_slice(cluster_indexed_graph_t& grind, ISlice::pointer islice)
             if (neigh.code() == 'm') {
                 IChannel::shared_vector imeas = std::get<IChannel::shared_vector>(neigh.ptr);
                 int mind = measures(imeas);
+                // fixme: check if "dead" and do not save.
                 minds.push_back(mind);
                 continue;
             }
@@ -111,6 +119,8 @@ static void solve_slice(cluster_indexed_graph_t& grind, ISlice::pointer islice)
             }
         }
     }
+
+    // fixme: add stable ordering.
 
     Ress::Params params;
     params.model = Ress::lasso;

--- a/img/src/GridTiling.cxx
+++ b/img/src/GridTiling.cxx
@@ -24,6 +24,10 @@ void Img::GridTiling::configure(const WireCell::Configuration& cfg)
 {
     m_anode = Factory::find_tn<IAnodePlane>(cfg["anode"].asString());
     m_face = m_anode->face(cfg["face"].asInt());
+    if (!m_face) {
+        log->error("no such face: {}", cfg["face"]);
+        THROW(ValueError() << errmsg{"APA lacks face"});
+    }
     m_threshold = get(cfg, "threshold", m_threshold);
     log->debug("configured with anode={} face={}",
                m_anode->ident(), m_face->ident());
@@ -45,8 +49,17 @@ bool Img::GridTiling::operator()(const input_pointer& slice, output_pointer& out
     if (!slice) {
         m_blobs_seen = 0;
         log->debug("EOS");
-        // SPDLOG_LOGGER_TRACE(log, "GridTiling: EOS");
         return true;  // eos
+    }
+
+    const auto anodeid = m_anode->ident();
+    const auto faceid = m_face->ident();
+
+    auto chvs = slice->activity();
+
+    if (chvs.empty()) {
+        log->debug("anode={} face={} slice={} no activity", anodeid, faceid, slice->ident());
+        return true;
     }
 
     const int sbs_ident = slice->ident();
@@ -58,14 +71,6 @@ bool Img::GridTiling::operator()(const input_pointer& slice, output_pointer& out
     std::vector<std::vector<Activity::value_t> > measures(nlayers);
     measures[0].push_back(1);  // assume first two layers in RayGrid::Coordinates
     measures[1].push_back(1);  // are for horiz/vert bounds
-
-    const auto anodeid = m_anode->ident();
-    const auto faceid = m_face->ident();
-    auto chvs = slice->activity();
-    if (chvs.empty()) {
-        SPDLOG_LOGGER_TRACE(log, "anode={} face={} slice={} no activity", anodeid, faceid, slice->ident());
-        return true;
-    }
 
     const int nactivities = slice->activity().size();
     int total_activity = 0;

--- a/img/src/GridTiling.cxx
+++ b/img/src/GridTiling.cxx
@@ -2,6 +2,7 @@
 
 #include "WireCellUtil/RayTiling.h"
 #include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/Units.h"
 #include "WireCellIface/SimpleBlob.h"
 
 WIRECELL_FACTORY(GridTiling, WireCell::Img::GridTiling,
@@ -43,6 +44,11 @@ WireCell::Configuration Img::GridTiling::default_configuration() const
     return cfg;
 }
 
+IBlobSet::pointer Img::GridTiling::make_empty(const input_pointer& slice)
+{
+    return std::make_shared<SimpleBlobSet>(slice->ident(), slice);
+}
+
 bool Img::GridTiling::operator()(const input_pointer& slice, output_pointer& out)
 {
     out = nullptr;
@@ -58,7 +64,10 @@ bool Img::GridTiling::operator()(const input_pointer& slice, output_pointer& out
     auto chvs = slice->activity();
 
     if (chvs.empty()) {
-        log->debug("anode={} face={} slice={} no activity", anodeid, faceid, slice->ident());
+        log->debug("anode={} face={} slice={}, time={} ms no activity",
+                   anodeid, faceid, slice->ident(),
+                   slice->frame()->time()/units::ms);
+        out = make_empty(slice);
         return true;
     }
 

--- a/img/src/SumSlice.cxx
+++ b/img/src/SumSlice.cxx
@@ -39,6 +39,9 @@ WireCell::Configuration Img::SumSliceBase::default_configuration() const
     // If given, use tagged traces.  Otherwise use all traces.
     cfg["tag"] = m_tag;
 
+    // If true, emit an EOS at end of one input frame's slices
+    cfg["slice_eos"] = m_slice_eos;
+
     return cfg;
 }
 
@@ -47,14 +50,23 @@ void Img::SumSliceBase::configure(const WireCell::Configuration& cfg)
     m_anode = Factory::find_tn<IAnodePlane>(cfg["anode"].asString());  // throws
     m_tick_span = get(cfg, "tick_span", m_tick_span);
     m_tag = get<std::string>(cfg, "tag", m_tag);
+    m_slice_eos = get<bool>(cfg, "slice_eos", m_slice_eos);
+    m_pad_empty = get<bool>(cfg, "pad_empty", m_pad_empty);
 }
 
-void Img::SumSliceBase::slice(const IFrame::pointer& in, slice_map_t& svcmap)
+ISlice::pointer Img::SumSliceBase::make_empty(const IFrame::pointer& inframe)
 {
-    const double tick = in->tick();
+    const double tick = inframe->tick();
+    const double span = tick * m_tick_span;
+    return std::make_shared<Img::Data::Slice>(inframe, 0, 0, span);
+}
+
+void Img::SumSliceBase::slice(const IFrame::pointer& inframe, slice_map_t& svcmap)
+{
+    const double tick = inframe->tick();
     const double span = tick * m_tick_span;
 
-    for (auto trace : Aux::tagged_traces(in, m_tag)) {
+    for (auto trace : Aux::tagged_traces(inframe, m_tag)) {
         const int tbin = trace->tbin();
         const int chid = trace->channel();
         IChannel::pointer ich = m_anode->channel(chid);
@@ -69,7 +81,7 @@ void Img::SumSliceBase::slice(const IFrame::pointer& in, slice_map_t& svcmap)
             auto s = svcmap[slicebin];
             if (!s) {
                 const double start = slicebin * span;  // thus relative to slice frame's time.
-                svcmap[slicebin] = s = new Img::Data::Slice(in, slicebin, start, span);
+                svcmap[slicebin] = s = new Img::Data::Slice(inframe, slicebin, start, span);
             }
             s->sum(ich, q);
         }
@@ -93,14 +105,17 @@ bool Img::SumSlicer::operator()(const input_pointer& in, output_pointer& out)
         auto s = sit.second;
         islices.push_back(ISlice::pointer(s));
     }
+    if (m_slice_eos) {
+        islices.push_back(nullptr);
+    }
     out = make_shared<Img::Data::SliceFrame>(islices, in->ident(), in->time());
 
     return true;
 }
 
-bool Img::SumSlices::operator()(const input_pointer& in, output_queue& slices)
+bool Img::SumSlices::operator()(const input_pointer& inframe, output_queue& slices)
 {
-    if (!in) {
+    if (!inframe) {
         log->debug("EOS");
         slices.push_back(nullptr);
         return true;  // eos
@@ -108,7 +123,7 @@ bool Img::SumSlices::operator()(const input_pointer& in, output_queue& slices)
 
     // Slices will be sparse in general.  Index by a "slice bin" number
     slice_map_t svcmap;
-    slice(in, svcmap);
+    slice(inframe, svcmap);
 
     // intern
     for (auto sit : svcmap) {
@@ -124,12 +139,20 @@ bool Img::SumSlices::operator()(const input_pointer& in, output_queue& slices)
     }
 
     if (slices.empty()) {
-        log->warn("frame={}, made no slices", in->ident());
-        return true;
+        log->warn("frame={} time={} ms, made no slices",
+                  inframe->ident(), inframe->time()/units::ms);
+        if (m_pad_empty) {
+            slices.push_back(make_empty(inframe));
+        }
     }
-    log->debug("frame={}, made {} slices in [{},{}] from {}",
-               in->ident(), slices.size(),
-               slices.front()->ident(), slices.back()->ident(),
-               svcmap.size());
+    else {
+        log->debug("frame={}, made {} slices in [{},{}] from {}",
+                   inframe->ident(), slices.size(),
+                   slices.front()->ident(), slices.back()->ident(),
+                   svcmap.size());
+    }
+    if (m_slice_eos) {
+        slices.push_back(nullptr);
+    }
     return true;
 }

--- a/img/src/SumSlice.cxx
+++ b/img/src/SumSlice.cxx
@@ -123,7 +123,11 @@ bool Img::SumSlices::operator()(const input_pointer& in, output_queue& slices)
         slices.push_back(ISlice::pointer(s));
     }
 
-    log->debug("frame={}, make {} slices in [{},{}] from {}",
+    if (slices.empty()) {
+        log->warn("frame={}, made no slices", in->ident());
+        return true;
+    }
+    log->debug("frame={}, made {} slices in [{},{}] from {}",
                in->ident(), slices.size(),
                slices.front()->ident(), slices.back()->ident(),
                svcmap.size());

--- a/img/test/test-empty-frame.jsonnet
+++ b/img/test/test-empty-frame.jsonnet
@@ -1,0 +1,48 @@
+// This makes a job that sends an empty frame down through imaging to assure nothing crashes.
+
+local wc = import "wirecell.jsonnet";
+local pg = import "pgraph.jsonnet";
+
+local params = import "pgrapher/experiment/uboone/simparams.jsonnet";
+
+// this can maybe be moved to a generic spot
+local hs = import "pgrapher/common/helpers.jsonnet";
+
+local tools_maker = import 'pgrapher/common/tools.jsonnet';
+local tools = tools_maker(params);
+
+local wires = hs.aux.wires(params.files.wires);
+local anodes = hs.aux.anodes(wires, params.det.volumes);
+
+local src = pg.pnode({
+    type: "SilentNoise",
+    data: {
+        noutputs: 10,
+    },        
+}, nin=0, nout=1);
+
+local anode = anodes[0];
+
+local imgpipe(anode) = pg.pipeline([
+    hs.img(anode).nominal(),
+    hs.io.cluster_file(anode.data.ident,
+                       "test-empty-frame-clusters-%d.tar.bz2"%anode.data.ident)
+], "img-" + anode.name);
+
+local graph = pg.pipeline([src, imgpipe(anodes[0])], "main");
+local app = {
+  type: 'Pgrapher',
+  data: {
+    edges: pg.edges(graph),
+  },
+};
+
+local cmdline = {
+    type: "wire-cell",
+    data: {
+        plugins: ["WireCellGen", "WireCellPgraph", "WireCellSio", "WireCellSigProc", "WireCellRoot", "WireCellImg"],
+        apps: ["Pgrapher"]
+    }
+};
+
+[cmdline] + pg.uses(graph) + [app]


### PR DESCRIPTION
This PR provides three related bits:

1. Some more new cfg "helpers", in particular `img.jsonnet`.  Example use in `img/test/test-empty-frame.jsonnet`.

2. Some fixes to allow "empty" objects to positively mark that some node produced no output so that sync can be kept.
3. Reworking of the `BlobClustering` to restore frame level sync.