### PR TITLE
Fix problems due to loss of Hermitian symmetry as in #164.

### DIFF
--- a/aux/inc/WireCellAux/DftTools.h
+++ b/aux/inc/WireCellAux/DftTools.h
@@ -1,6 +1,46 @@
 /**
-   This provides std::vector and Eigen::Array typed interface to an
-   IDFT.
+   DftTools provides support for 1D std::vector (called "vector" here)
+   and 2D Eigen::Array (called "array" there typed interface to calls
+   made on an IDFT.  Besides providing concrete typing and necessary
+   data transforms, it includes higher level functions expressed in
+   terms of IDFT primitives.  
+
+   IDFT rules apply, in particular, forward transforms do not accrue
+   any normalization and reverse transforms accrue a normalization of
+   1/N where N is the number of elements transformed.
+
+   The API uses variable names to hint at the semantic meaning of
+   arguments.  We write a time/interval-space vector or array is
+   "wave" or if complex as "cwave".  A frequency-space vector or array
+   is written as "spec".  Where Hermitian-symmetry is anticipated we
+   write "hspec" (h=Hermitian or "half" but the spectrum still spans
+   the full 2*Nyquist frequency range).  No spectra in this API are
+   real-valued.
+
+   For 2D Eigen::Arrays, some functions take an "axis".  The axis
+   identifies the logical array "dimension" over which the transform
+   is applied.  The word "dimension" here means as in the
+   "2-dimensions" (row = dimension 0, col = dimension 1) and here it
+   does not mean "array size".
+
+   For example, axis=1 means the transform is applied along the column
+   dimension.  Or, in other words, conceptually it means that each row
+   is transformed individually (the row elements being columns).
+   Note: this is the same convention as held by numpy.fft.
+
+   For 1D vectors, there is of course only one axis.
+   
+   Implementation note: the "axis" is interpreted in the "logical"
+   sense of how Eigen arrays are indexed as array(irow, icol).  Ie,
+   the dimension traversing rows is axis 0 and the dimension
+   traversing columns is axis 1.  The internal storage order of an
+   Eigen array may differ from the logical order and indeed that of
+   the array template type order.  Neither is pertinent when deciding
+   the value to give for "axis".
+
+   Some function take 2D Eigen::Arrays and do not take an "axis"
+   argument.  These perform transforms on both axes.
+
  */
 
 #ifndef WIRECELL_AUX_DFTTOOLS
@@ -12,73 +52,61 @@
 
 namespace WireCell::Aux {
 
+    /// Suported data types.
     using complex_t = IDFT::complex_t;
-
-    // std::vector based functions
-
     using real_vector_t = std::vector<float>;
+    using real_array_t = Eigen::ArrayXXf;
     using complex_vector_t = std::vector<complex_t>;
+    using complex_array_t = Eigen::ArrayXXcf;
 
-    /// Return a version of the input with the upper half becoming the
-    /// mirrored complex conjugate of the lower half.  The lower half
-    /// is unchanged.  The zeroth element is not mirrored and if the
-    /// input is even the element corresponding to the Nyquist bin is
-    /// not mirrored.
+    /// Produce a spectrum with Hermitian-symmetry along the given
+    /// axis enforced.  The samples above the Nyquist frequency will
+    /// be mirrored and complex conjugates of the samples below the
+    /// Nyquist frequency.  The zero sample is not mirrored and if the
+    /// number of samples is even the central "Nyquist bin" is not
+    /// mirrored (it is its own mirror).
     complex_vector_t hermitian_symmetry(const complex_vector_t& spec);
+    complex_array_t hermitian_symmetry(const complex_array_t& spec, int axis);
 
-    // As above but in-place.
+    // As above perform the transform in-place.
     void hermitian_symmetry_inplace(complex_vector_t& spec);
+    void hermitian_symmetry_inplace(complex_array_t& spec, int axis);
+
+    // Perform forward DFT, returning a complex spectrum given a
+    // complex waveform.  The 2D array version lacking an "axis"
+    // performs foward DFT in both directions.
+    complex_vector_t fwd(const IDFT::pointer& dft, const complex_vector_t& cwave);
+    complex_array_t fwd(const IDFT::pointer& dft, const complex_array_t& cwave);
+    complex_array_t fwd(const IDFT::pointer& dft, const complex_array_t& cwave, int axis);
+
+    // Perform forward DFT, returning a complex spectrum given a real
+    // waveform.  The spectrum will have Hermitian symmetry along the
+    // axis of transform but only up to round-off errors accrued
+    // during the transform.
+    complex_vector_t fwd_r2c(const IDFT::pointer& dft, const real_vector_t& wave);
+    complex_array_t fwd_r2c(const IDFT::pointer& dft, const real_array_t& wave, int axis);
+
+    // Perform the inverse or reverse DFT, returning a complex
+    // waveform given a complex spectrum.
+    complex_vector_t inv(const IDFT::pointer& dft, const complex_vector_t& spec);
+    complex_array_t inv(const IDFT::pointer& dft, const complex_array_t& spec);
+    complex_array_t inv(const IDFT::pointer& dft, const complex_array_t& spec, int axis);
+
+    // Perform inverse or reverse DFT, returning a real waveform given
+    // a complex spectrum.  Prior to the DFT, the spectrum is forced
+    // to have Hermitial symmetry and thus any input values above the
+    // Nyquist frequency are ignored.
+    real_vector_t inv_c2r(const IDFT::pointer& dft, const complex_vector_t& spec);
+    real_array_t inv_c2r(const IDFT::pointer& dft, const complex_array_t& spec, int axis);
 
 
-    // 1D with std::vector.
-
-    // Perform forward c2c transform on vector.
-    inline complex_vector_t fwd(const IDFT::pointer& dft, const complex_vector_t& seq)
-    {
-        complex_vector_t ret(seq.size());
-        dft->fwd1d(seq.data(), ret.data(), ret.size());
-        return ret;
-    }
-
-    // Perform forward r2c transform on vector.
-    inline complex_vector_t fwd_r2c(const IDFT::pointer& dft, const real_vector_t& vec)
-    {
-        complex_vector_t cvec(vec.size());
-        std::transform(vec.begin(), vec.end(), cvec.begin(),
-                       [](float re) { return Aux::complex_t(re,0.0); } );
-        return fwd(dft, cvec);
-    }
-
-    // Perform inverse c2c transform on vector.
-    inline complex_vector_t inv(const IDFT::pointer& dft, const complex_vector_t& spec)
-    {
-        complex_vector_t ret(spec.size());
-        dft->inv1d(spec.data(), ret.data(), ret.size());
-        return ret;
-    }
-
-    // Perform inverse c2r transform on vector.  Note: this ignores
-    // all frequencies in the input spectrum which are above the
-    // Nyquist frequency.
-    inline real_vector_t inv_c2r(const IDFT::pointer& dft, const complex_vector_t& spec)
-    {
-        complex_vector_t symspec = hermitian_symmetry(spec);
-        auto cvec = inv(dft, symspec);
-        real_vector_t rvec(cvec.size());
-        std::transform(cvec.begin(), cvec.end(), rvec.begin(),
-                       [](const Aux::complex_t& c) { return std::real(c); });
-        return rvec;
-    }
-
-    // 1D high-level interface
-
-    /// Convovle in1 and in2.  Returned vecgtor has size sum of sizes
-    /// of in1 and in2 less one element in order to assure no periodic
-    /// aliasing.  Caller need not (should not) pad either input.
-    /// Caller is free to truncate result as required.
+    /// Convolve in1 and in2 via DFT.  Returned vecgtor has size sum
+    /// of sizes of in1 and in2 less one element in order to assure no
+    /// periodic aliasing.  Caller need not (should not) pad either
+    /// input.  Caller is free to truncate result as required.
     real_vector_t convolve(const IDFT::pointer& dft,
-                           const real_vector_t& in1,
-                           const real_vector_t& in2);
+                           const real_vector_t& wave1,
+                           const real_vector_t& wave2);
 
 
     /// Replace response res1 in meas with response res2.
@@ -98,48 +126,9 @@ namespace WireCell::Aux {
                           const real_vector_t& res2);
 
 
-    // Eigen array based functions
-
-    /// 2D array types.  Note, use Array::cast<complex_t>() if you
-    /// need to convert rom real or arr.real() to convert to real.
-    using real_array_t = Eigen::ArrayXXf;
-    using complex_array_t = Eigen::ArrayXXcf;
-    
-    // 2D with Eigen arrays.  Use eg arr.cast<complex_>() to provde
-    // from real or arr.real()() to convert result to real.
-
-    // Full complex to complex forward transform.
-    complex_array_t fwd(const IDFT::pointer& dft, const complex_array_t& arr);
-    // Full complex to complex inverse transform.
-    complex_array_t inv(const IDFT::pointer& dft, const complex_array_t& arr);
-
-    // Forward transform of real to complex.
-    // complex_array_t fwd_r2c(const IDFT::pointer& dft, const real_array_t& arr);
-
-    // Perform inverse c2r transform on array. 
-    // real_array_t inv_c2r(const IDFT::pointer& dft, const complex_array_t& arr, int axis=0);
-
-    // Transform a 2D array along one axis.
-    //
-    // The axis identifies the logical array "dimension" over which
-    // the transform is applied.  For example, axis=1 means the
-    // transforms are applied along columns (ie, on a per-row basis).
-    // Note: this is the same convention as held by numpy.fft.
-    //
-    // The axis is interpreted in the "logical" sense Eigen arrays
-    // indexed as array(irow, icol).  Ie, the dimension traversing
-    // rows is axis 0 and the dimension traversing columns is axis 1.
-    // Note: internal storage order of an Eigen array may differ from
-    // the logical order and indeed that of the array template type
-    // order.  Neither is pertinent in setting the axis.
-    complex_array_t fwd(const IDFT::pointer& dft, const complex_array_t& arr, int axis);
-    complex_array_t inv(const IDFT::pointer& dft, const complex_array_t& arr, int axis);
-
 
     // Fixme: possible additions
     // - superposition of 2 reals for 2x speedup
-    // - r2c / c2r for 1b
-
 }
 
 #endif

--- a/aux/inc/WireCellAux/Rand.h
+++ b/aux/inc/WireCellAux/Rand.h
@@ -1,0 +1,53 @@
+#ifndef WIRECELL_AUX_RAND
+#define WIRECELL_AUX_RAND
+
+namespace WireCell::Aux {
+
+    // A generator of normal Gaussian-distributed numbers that
+    // "recycles" its results to trade off randomness for speed.  It
+    // maintains a fixed-capacity ring buffer that it samples such
+    // that the stream returned by each call begins at a random
+    // location in the ring.  The buffer is filled with new randomness
+    // at a rate give by the "replace" parameter which is used to find
+    // an integer which coprime with the capacty an near to
+    // int(replace*capacity) modulo capacity.
+    class RecyclingNormals {
+        IRandom::pointer rng
+        size_t replace;
+        size_t cursor{0};
+        real_vector_t ring;
+      public:
+
+        /// 
+        RecyclingNormals(IRandom::pointer rng,
+                         double replacment_fraction=0.02,
+                         size_t capacity = 1024)
+            : rng(rng), ring(capacity, 0)
+        {
+            replace = WireCell::nearest_coprime(capacity, (1-replacement_fraction)*capacity);
+            // start fully fresh
+            for (size_t ind=0; ind<capacity; ++ind) {
+                ring[ind] = rng->normal(0,1);
+            }
+        }
+
+        float& at(size_t index) {
+            return ring[index%ring.size()];
+        }
+
+        float next() {
+            const size_t ind = cursor % ring.size();
+
+            if (cursor % replace == 0) {
+                ring[ind] = rng->normal(0,1);
+            }
+            float ret = ring[ind];
+            ++cursor;
+            return ret;
+        }
+
+    }
+
+}
+
+#endif

--- a/aux/inc/WireCellAux/RandTools.h
+++ b/aux/inc/WireCellAux/RandTools.h
@@ -8,9 +8,11 @@
 
 #include <vector>
 
-namespace WireCell::Aux {
+namespace WireCell::Aux::RandTools::Normals {
 
-    // A generator of normal Gaussian-distributed numbers which
+    using real_vector_t = std::vector<float>;
+
+    // A generator of Gaussian-distributed numbers which partly
     // "recycles" its prior results to trade off randomness for speed.
     // 
     // It generates a "pseudo-pseudo-random" stream by holding the
@@ -25,20 +27,28 @@ namespace WireCell::Aux {
     // size.  This will maximize the number of calls before a sampling
     // returns to a prior ring index.  See nearest_coprime() in
     // WireCellUtil/Math.h. for an easy way to provide that.
-    class RecyclingNormals {
+    //
+    // With 2% replacement, speedup is about 2x compared to fully
+    // regenerating as in Fresh.
+    class Recycling {
       public:
 
-        using real_vector_t = std::vector<float>;
-
-        RecyclingNormals(IRandom::pointer rng,
-                         size_t capacity = 1024,
-                         double replacement_fraction=0.02);
+        Recycling(IRandom::pointer rng,
+                  size_t capacity = 1024,
+                  double replacement_fraction=0.02,
+                  double mean=0.0, double sigma=1.0);
 
         // Return a pseudo-pseudo-random normal
         float operator()();
 
         // Return a vector of pseudo-pseudo-random normals of size.
         real_vector_t operator()(size_t size);
+
+        // Resize the ring.  Enlarged capcity is filled with fresh
+        // randoms.
+        void resize(size_t capacity);
+
+        size_t size() const { return ring.size(); }
 
         // The replacement period.
         size_t replacement() const { return replace; }
@@ -47,16 +57,18 @@ namespace WireCell::Aux {
         IRandom::pointer rng;
         IRandom::double_func normf;
         size_t nreplace, replace;
+        double repfrac{0.02};
         size_t cursor{0};  // may eventually roll over, we do not care
         real_vector_t ring;
     };
 
     // Return freshly generated normals. 
-    class FreshNormals {
+    class Fresh {
       public:
         using real_vector_t = std::vector<float>;
 
-        FreshNormals(IRandom::pointer rng);
+        Fresh(IRandom::pointer rng,
+              double mean=0.0, double sigma=1.0);
 
         // Return a pseudo-random normal
         float operator()();

--- a/aux/inc/WireCellAux/RandTools.h
+++ b/aux/inc/WireCellAux/RandTools.h
@@ -28,14 +28,13 @@ namespace WireCell::Aux::RandTools::Normals {
     // returns to a prior ring index.  See nearest_coprime() in
     // WireCellUtil/Math.h. for an easy way to provide that.
     //
-    // With 2% replacement, speedup is about 2x compared to fully
-    // regenerating as in Fresh.
+    // With a 4% replacement, speedup is about 2x compared to fully
+    // regenerating as in Fresh.  See test_noise.
     class Recycling {
       public:
 
-        Recycling(IRandom::pointer rng,
-                  size_t capacity = 1024,
-                  double replacement_fraction=0.02,
+        Recycling(IRandom::pointer rng, size_t capacity, 
+                  double replacement_fraction=0.04,
                   double mean=0.0, double sigma=1.0);
 
         // Return a pseudo-pseudo-random normal

--- a/aux/inc/WireCellAux/RandTools.h
+++ b/aux/inc/WireCellAux/RandTools.h
@@ -1,0 +1,74 @@
+/** Some tools to do things with randoms.
+ */
+
+#ifndef WIRECELL_AUX_RANDTOOLS
+#define WIRECELL_AUX_RANDTOOLS
+
+#include "WireCellIface/IRandom.h"
+
+#include <vector>
+
+namespace WireCell::Aux {
+
+    // A generator of normal Gaussian-distributed numbers which
+    // "recycles" its prior results to trade off randomness for speed.
+    // 
+    // It generates a "pseudo-pseudo-random" stream by holding the
+    // prior randoms in a fixed-capacity ring buffer which it samples
+    // monotonically and it adds fresh randoms at a rate give by the
+    // "replacement_fraction" parameter.
+    //
+    // It provides scalar and vector sampling operators.
+    //
+    // When the vector operator is use for constant size vectors it is
+    // recomended to set the capacity to be coprime with the vector
+    // size.  This will maximize the number of calls before a sampling
+    // returns to a prior ring index.  See nearest_coprime() in
+    // WireCellUtil/Math.h. for an easy way to provide that.
+    class RecyclingNormals {
+      public:
+
+        using real_vector_t = std::vector<float>;
+
+        RecyclingNormals(IRandom::pointer rng,
+                         size_t capacity = 1024,
+                         double replacement_fraction=0.02);
+        float& at(size_t index);
+
+        // Return a pseudo-pseudo-random normal
+        float operator()();
+
+        // Return a vector of pseudo-pseudo-random normals of size.
+        real_vector_t operator()(size_t size);
+
+        // The replacement period.
+        size_t replacement() const { return replace; }
+
+      private:
+        IRandom::pointer rng;
+        size_t nreplace, replace;
+        size_t cursor{0};  // may eventually roll over, we do not care
+        real_vector_t ring;
+    };
+
+    // Return freshly generated normals. 
+    class FreshNormals {
+      public:
+        using real_vector_t = std::vector<float>;
+
+        FreshNormals(IRandom::pointer rng);
+
+        // Return a pseudo-random normal
+        float operator()();
+
+        // Return a vector of pseudo-random normals of size.
+        real_vector_t operator()(size_t size);
+
+
+      private:
+        IRandom::pointer rng;
+    };
+
+}
+
+#endif

--- a/aux/inc/WireCellAux/RandTools.h
+++ b/aux/inc/WireCellAux/RandTools.h
@@ -33,7 +33,6 @@ namespace WireCell::Aux {
         RecyclingNormals(IRandom::pointer rng,
                          size_t capacity = 1024,
                          double replacement_fraction=0.02);
-        float& at(size_t index);
 
         // Return a pseudo-pseudo-random normal
         float operator()();
@@ -46,6 +45,7 @@ namespace WireCell::Aux {
 
       private:
         IRandom::pointer rng;
+        IRandom::double_func normf;
         size_t nreplace, replace;
         size_t cursor{0};  // may eventually roll over, we do not care
         real_vector_t ring;
@@ -66,7 +66,7 @@ namespace WireCell::Aux {
 
 
       private:
-        IRandom::pointer rng;
+        IRandom::double_func normf;
     };
 
 }

--- a/aux/inc/WireCellAux/Spectra.h
+++ b/aux/inc/WireCellAux/Spectra.h
@@ -10,8 +10,12 @@
 #include <vector>
 #include <functional>
 
-namespace WireCell::Aux {
+namespace WireCell::Aux::Spectra {
 
+
+    using real_vector_t = std::vector<float>;
+    using complex_vector_t = std::vector< std::complex<float> >;
+    
 
     /** Wave Collector
          
@@ -20,9 +24,6 @@ namespace WireCell::Aux {
     */
     class WaveCollector {
       public:
-
-        using real_vector_t = std::vector<float>;
-
 
         WaveCollector(IDFT::pointer dft);
 
@@ -44,36 +45,36 @@ namespace WireCell::Aux {
     /** Wave Generator
 
         From a mean spectra, generate waves
+
+        The mean spectral amplitude must span the full, regularly
+        sampled frequency range from 0 to F_max=2*F_Nyquist.  The
+        spectral sampling will determine the waveform sampling.  If
+        your spectrum sampling differs from your desired waveform
+        sampling see the linterp/irrterp functions from Interpolate.h.
+
+        See WireCell::Aux::Normals::Recycling or FreshNormals from
+        RandTools.h for examples of what can be provided for the
+        normal_f function object.
     */
     class WaveGenerator {
       public:
-
-        using real_vector_t = std::vector<float>;
-        using complex_vector_t = std::vector< std::complex<float> >;
 
         // Something that returns n random samplings from normal
         // Gaussian distribution N(mu=0,sigma=1).  See RandTools.h for
         // some examples to use.
         using normal_f = std::function<real_vector_t(size_t n)>;
 
-        /// The meanspec provides the mean spectral amplitude spanning
-        /// the full frequency range from 0 to Fmax=2*FNyquist.  Note,
-        /// this sampling determines that of the generated waves.  See
-        /// linterp/irrterp functions if your spectrum's sampling 
-        /// differs from what wave sampling you want.
-        WaveGenerator(IDFT::pointer dft, normal_f normal,
-                      const real_vector_t& meanspec);
+        WaveGenerator(IDFT::pointer dft, normal_f normal);                      
 
         // Generate a complex, Hermitian-symmetric spectrum from the
         // mean spectrum.
-        complex_vector_t spec();
+        complex_vector_t spec(const real_vector_t& meanspec);
 
         // Generate a real, interval-space waveform.
-        real_vector_t wave();
+        real_vector_t wave(const real_vector_t& meanspec);
 
       private:
         IDFT::pointer dft;
-        const real_vector_t& meanspec;
         normal_f normal;
     };
 }

--- a/aux/inc/WireCellAux/Spectra.h
+++ b/aux/inc/WireCellAux/Spectra.h
@@ -1,0 +1,77 @@
+/**
+   Common utilities for handling spectra.
+
+ */
+#ifndef WIRECELL_AUX_SPECTRA
+#define WIRECELL_AUX_SPECTRA
+
+#include "WireCellAux/DftTools.h"
+#include "WireCellUtil/Math.h"
+#include <vector>
+#include <functional>
+
+namespace WireCell::Aux {
+
+    /** Wave Collector
+         
+        This is a small helper to which you may progressively of
+        waveforms of a common size and produce a mean spectrum.
+    */
+    class WaveCollector {
+      public:
+
+        using real_vector_t = std::vector<float>;
+
+
+        WaveCollector(IDFT::pointer dft);
+
+        /// Add a waveform's contribution to the spectrum.
+        void add(const real_vector_t& wave);
+
+        // Return the full domain, real-valued mean spectral amplitude
+        // so far collected.
+        real_vector_t mean();
+
+      private:
+        IDFT::pointer dft;
+        real_vector_t sum;
+        size_t count{0};
+        
+    };
+     
+
+    /** Wave Generator
+
+        From a mean spectra, generate waves
+    */
+    class WaveGenerator {
+      public:
+
+        using real_vector_t = std::vector<float>;
+        using complex_vector_t = std::vector< std::complex<float> >;
+
+        // Something that returns n random samplings from normal
+        // Gaussian distribution N(mu=0,sigma=1).  See RandTools.h for
+        // some examples to use.
+        using normal_f = std::function<real_vector_t(size_t n)>;
+
+        /// The meanspec provides the mean spectral amplitude spanning
+        /// the full frequency range from 0 to Fmax=2*FNyquist.  Note,
+        /// this sampling determines that of the generated waves.  See
+        /// linterp/irrterp functions if your spectrum's sampling
+        /// differs from what wave sampling you want.
+        WaveGenerator(IDFT::pointer dft, normal_f normal,
+                      const real_vector_t& meanspec);
+
+        // Generate a complex, Hermitian-symmetric spectrum from the
+        // mean spectrum
+        complex_vector_t spec();
+
+      private:
+        IDFT::pointer dft;
+        const real_vector_t& meanspec;
+        normal_f normal;
+    };
+}
+
+#endif

--- a/aux/inc/WireCellAux/Spectra.h
+++ b/aux/inc/WireCellAux/Spectra.h
@@ -12,6 +12,7 @@
 
 namespace WireCell::Aux {
 
+
     /** Wave Collector
          
         This is a small helper to which you may progressively of
@@ -58,14 +59,17 @@ namespace WireCell::Aux {
         /// The meanspec provides the mean spectral amplitude spanning
         /// the full frequency range from 0 to Fmax=2*FNyquist.  Note,
         /// this sampling determines that of the generated waves.  See
-        /// linterp/irrterp functions if your spectrum's sampling
+        /// linterp/irrterp functions if your spectrum's sampling 
         /// differs from what wave sampling you want.
         WaveGenerator(IDFT::pointer dft, normal_f normal,
                       const real_vector_t& meanspec);
 
         // Generate a complex, Hermitian-symmetric spectrum from the
-        // mean spectrum
+        // mean spectrum.
         complex_vector_t spec();
+
+        // Generate a real, interval-space waveform.
+        real_vector_t wave();
 
       private:
         IDFT::pointer dft;

--- a/aux/inc/WireCellAux/Testing.h
+++ b/aux/inc/WireCellAux/Testing.h
@@ -1,0 +1,56 @@
+/**
+   This API provides various utility functions to help make it easier
+   to write plugin test programs (eg in <pkg>/test/test_*.cxx ).
+
+   It provides some default-configured objects.
+
+   Functions here MUST NOT be used in real components as they apply a
+   fixed configuration.  When writing WCT components, these
+   configurations must be left open for the user to satisfy.
+
+ */
+
+#include "WireCellAux/DftTools.h"
+#include "WireCellAux/RandTools.h"
+
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellIface/IAnodePlane.h"
+
+#include "WireCellUtil/NamedFactory.h"
+
+#include <string>
+#include <vector>
+
+namespace WireCell::Aux::Testing {
+
+    // Load plugins.  If empty, load "core" plugins.
+    void load_plugins(std::vector<std::string> list = {});
+
+    // Return default-configured configurable interface.
+    template<typename IFACE>
+    typename IFACE::pointer get_default(const std::string& typenam,
+                                        const std::string& instnam="")
+    {
+        auto icfg = WireCell::Factory::lookup<WireCell::IConfigurable>(typenam, instnam);
+        auto cfg = icfg->default_configuration();
+        icfg->configure(cfg);
+        return WireCell::Factory::find<IFACE>(typenam, instnam);
+    }
+
+    // Return FftwDFT 
+    IDFT::pointer get_dft();
+
+    // Return named Random
+    IRandom::pointer get_random(const std::string& name="default");
+
+    // A number of named detectors are 'known' here.
+    const std::vector<std::string>& known_detectors();
+
+    // Return some configured anodes for a known detector.
+    IAnodePlane::vector anodes(const std::string detector);
+
+    // Initialize WCT logging with argv[0].
+    void loginit(const char* argv0);
+
+}
+

--- a/aux/src/DftTools.cxx
+++ b/aux/src/DftTools.cxx
@@ -7,6 +7,29 @@
 using namespace WireCell;
 using namespace WireCell::Aux;
 
+
+void Aux::hermitian_symmetry_inplace(Aux::complex_vector_t& spec)
+{
+    const size_t fullsize = spec.size();
+    const size_t halfsize = fullsize/2; // integer division
+    size_t extra = 0;
+    if (spec.size() % 2) {           // odd, no Nyquist bin
+        extra = 1;
+    }
+    for (size_t ind=halfsize+extra; ind<fullsize; ++ind) {
+        spec[ind] = std::conj(spec[fullsize-ind]);
+    }
+}
+         
+Aux::complex_vector_t Aux::hermitian_symmetry(const Aux::complex_vector_t& spec)
+{
+    Aux::complex_vector_t ret(spec.begin(), spec.end());
+    hermitian_symmetry_inplace(ret);
+    return ret;
+}
+
+
+
 /*
   Big fat warning to future me: Passing by reference means the input
   array may carry the .IsRowMajor optimization for implementing
@@ -16,6 +39,7 @@ using namespace WireCell::Aux;
 
 using ROWM = Eigen::Array<Aux::complex_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 using COLM = Eigen::Array<Aux::complex_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
+
 
 template<typename trans>
 Aux::complex_array_t doit(const Aux::complex_array_t& arr, trans func)
@@ -51,6 +75,7 @@ Aux::complex_array_t Aux::inv(const IDFT::pointer& dft, const Aux::complex_array
         dft->inv2d(in_data, out_data, nrows, ncols);
     });
 }
+
 
 // template<typename trans>
 // Aux::complex_array_t doit1b(const Aux::complex_array_t& arr, int axis, trans func)
@@ -110,17 +135,6 @@ Aux::complex_array_t Aux::inv(const IDFT::pointer& dft,
     Aux::complex_array_t ret = arr; 
     dft->inv1b(ret.data(), ret.data(), ret.cols(), ret.rows(), !axis);
     return ret;
-}
-
-Aux::complex_array_t Aux::fwd_r2c(const IDFT::pointer& dft,
-                                  const real_array_t& arr)
-{
-    return Aux::fwd(dft, arr.cast<Aux::complex_t>());
-}
-Aux::real_array_t Aux::inv_c2r(const IDFT::pointer& dft,
-                               const complex_array_t& arr)
-{
-    return Aux::inv(dft, arr).real();
 }
 
 

--- a/aux/src/RandTools.cxx
+++ b/aux/src/RandTools.cxx
@@ -23,10 +23,11 @@ void Recycling::resize(size_t capacity)
             ring[ind] = normf();
         }
     }
-    size_t jump = (1-repfrac)*capacity;
+    size_t jump = 1/repfrac;
     jump = std::max(jump, 1UL);
     jump = std::min(jump, capacity-1);
     nreplace = replace = WireCell::nearest_coprime(capacity, jump);
+    // nreplace = replace = jump;
 }
 
 // Return a pseudo-pseudo-random normal.
@@ -59,6 +60,12 @@ real_vector_t Recycling::operator()(size_t size)
     // concerned about ring capacity vs sampling size.  Though, still
     // best to to pick them coprime.
     cursor = rng->range(0, ring.size()-1);
+
+    // When replacement fraction is large, the above random start
+    // point can take a while before we catch up to the replace cursor
+    // and thus refreshing, so set it to our start point.  As a side
+    // effect, this guarantees the first sample is freshly random.
+    replace = cursor;
 
     real_vector_t ret(size, 0);
     for (size_t ind=0; ind<size; ++ind) {

--- a/aux/src/RandTools.cxx
+++ b/aux/src/RandTools.cxx
@@ -1,0 +1,62 @@
+#include "WireCellAux/RandTools.h"
+#include "WireCellUtil/Math.h"
+
+using namespace WireCell;
+
+
+Aux::RecyclingNormals::RecyclingNormals(IRandom::pointer rng,
+                                        size_t capacity,
+                                        double replacement_fraction)
+    : rng(rng), ring(capacity, 0)
+{
+    const size_t r = std::min(capacity-1, (size_t)((1-replacement_fraction)*capacity));
+    nreplace = replace = WireCell::nearest_coprime(capacity, r);
+    // start fully fresh
+    for (size_t ind=0; ind<capacity; ++ind) {
+        ring[ind] = rng->normal(0,1);
+    }
+}
+
+float& Aux::RecyclingNormals::at(size_t index)
+{
+    return ring[index%ring.size()];
+}
+
+// Return a pseudo-pseudo-random normal
+float Aux::RecyclingNormals::operator()()
+{
+    const size_t ind = cursor % ring.size();
+    if (cursor == replace) {
+        ring[ind] = rng->normal(0,1);
+        replace += nreplace;
+    }
+    float ret = ring[ind];
+    ++cursor;
+    return ret;
+}
+
+// Return a vector of pseudo-pseudo-random normals of size.
+Aux::RecyclingNormals::real_vector_t Aux::RecyclingNormals::operator()(size_t size)
+{
+    // Don't use std::generate as it does a copy of *this.
+    Aux::RecyclingNormals::real_vector_t ret(size, 0);
+    for (auto& f : ret) {
+        f = (*this)();
+    }
+    return ret;
+}
+
+
+
+Aux::FreshNormals::FreshNormals(IRandom::pointer rng) : rng(rng) {}
+// Return a pseudo-random normal
+float Aux::FreshNormals::operator()() { return rng->normal(0,1); }
+
+Aux::FreshNormals::real_vector_t Aux::FreshNormals::operator()(size_t size)
+{
+    Aux::RecyclingNormals::real_vector_t ret(size, 0);
+    for (auto& f : ret) {
+        f = (*this)();
+    }
+    return ret;
+}

--- a/aux/src/RandTools.cxx
+++ b/aux/src/RandTools.cxx
@@ -2,27 +2,37 @@
 #include "WireCellUtil/Math.h"
 
 using namespace WireCell;
+using namespace WireCell::Aux::RandTools::Normals;
 
 
-Aux::RecyclingNormals::RecyclingNormals(IRandom::pointer rng,
-                                        size_t capacity,
-                                        double replacement_fraction)
-    : rng(rng), normf(rng->make_normal(0,1)), ring(capacity, 0)
+Recycling::Recycling(IRandom::pointer rng,
+                     size_t capacity,
+                     double replacement_fraction,
+                     double mean, double sigma)
+    : rng(rng), normf(rng->make_normal(mean, sigma)), repfrac(replacement_fraction)
 {
-    size_t jump = (1-replacement_fraction)*capacity;
+    resize(capacity);
+}
+
+void Recycling::resize(size_t capacity)
+{
+    const size_t oldsize = ring.size();
+    ring.resize(capacity, 0);
+    if (capacity > oldsize) {
+        for (size_t ind=oldsize; ind<capacity; ++ind) {
+            ring[ind] = normf();
+        }
+    }
+    size_t jump = (1-repfrac)*capacity;
     jump = std::max(jump, 1UL);
     jump = std::min(jump, capacity-1);
     nreplace = replace = WireCell::nearest_coprime(capacity, jump);
-    // start fully fresh
-    for (size_t ind=0; ind<capacity; ++ind) {
-        ring[ind] = normf();
-    }
 }
 
 // Return a pseudo-pseudo-random normal.
 // This is only method that advances the cursor!
 // We avoid modulus ("%") for speed (1.6x speedup)
-float Aux::RecyclingNormals::operator()()
+float Recycling::operator()()
 {
     const size_t size = ring.size();
 
@@ -42,7 +52,7 @@ float Aux::RecyclingNormals::operator()()
 }
 
 // Return a vector of pseudo-pseudo-random normals of size.
-Aux::RecyclingNormals::real_vector_t Aux::RecyclingNormals::operator()(size_t size)
+real_vector_t Recycling::operator()(size_t size)
 {
     // Relying totally on coprime cycling leads to overly strong
     // correlations.  This also softens the need to be overly
@@ -50,7 +60,7 @@ Aux::RecyclingNormals::real_vector_t Aux::RecyclingNormals::operator()(size_t si
     // best to to pick them coprime.
     cursor = rng->range(0, ring.size()-1);
 
-    Aux::RecyclingNormals::real_vector_t ret(size, 0);
+    real_vector_t ret(size, 0);
     for (size_t ind=0; ind<size; ++ind) {
         ret[ind] = (*this)();
     }
@@ -60,19 +70,20 @@ Aux::RecyclingNormals::real_vector_t Aux::RecyclingNormals::operator()(size_t si
 
 
 
-Aux::FreshNormals::FreshNormals(IRandom::pointer rng)
-    : normf(rng->make_normal(0,1))
+Fresh::Fresh(IRandom::pointer rng,
+             double mean, double sigma)
+    : normf(rng->make_normal(mean, sigma))
 {
 }
 
 // Return a pseudo-random normal
-float Aux::FreshNormals::operator()() {
+float Fresh::operator()() {
     return normf();
 }
 
-Aux::FreshNormals::real_vector_t Aux::FreshNormals::operator()(size_t size)
+real_vector_t Fresh::operator()(size_t size)
 {
-    Aux::RecyclingNormals::real_vector_t ret(size, 0);
+    real_vector_t ret(size, 0);
     for (auto& f : ret) {
         f = normf();
     }

--- a/aux/src/Spectra.cxx
+++ b/aux/src/Spectra.cxx
@@ -3,13 +3,14 @@
 
 using namespace WireCell;
 using namespace WireCell::Waveform;
+using namespace WireCell::Aux::Spectra;
 
 
-Aux::WaveCollector::WaveCollector(IDFT::pointer dft) : dft(dft)
+WaveCollector::WaveCollector(IDFT::pointer dft) : dft(dft)
 {
 }
 
-void Aux::WaveCollector::add(const real_vector_t& wave)
+void WaveCollector::add(const real_vector_t& wave)
 {
     if (sum.empty()) {
         sum.resize(wave.size(), 0);
@@ -20,20 +21,20 @@ void Aux::WaveCollector::add(const real_vector_t& wave)
     ++count;
 }
 
-Aux::WaveCollector::real_vector_t Aux::WaveCollector::mean()
+real_vector_t WaveCollector::mean()
 {
     real_vector_t avg(sum.begin(), sum.end());
     scale(avg, 1.0/count);
     return avg;
 }
 
-Aux::WaveGenerator::WaveGenerator(IDFT::pointer dft, normal_f normal,
-                                  const real_vector_t& meanspec)
-    :dft(dft), meanspec(meanspec), normal(normal)
+WaveGenerator::WaveGenerator(IDFT::pointer dft, normal_f normal)
+    :dft(dft), normal(normal)
 {
 }
 
-Aux::WaveGenerator::complex_vector_t Aux::WaveGenerator::spec()
+complex_vector_t
+WaveGenerator::spec(const real_vector_t& meanspec)
 {
     const size_t nsamples = meanspec.size();
     // nsamples: even->1, odd->0
@@ -57,9 +58,10 @@ Aux::WaveGenerator::complex_vector_t Aux::WaveGenerator::spec()
     return spec;
 }
 
-Aux::WaveGenerator::real_vector_t Aux::WaveGenerator::wave()
+real_vector_t
+WaveGenerator::wave(const real_vector_t& meanspec)
 {
-    auto wave = inv_c2r(dft, spec());
+    auto wave = inv_c2r(dft, spec(meanspec));
 
     size_t nsamples = meanspec.size();
     const float mean_to_mode = sqrt(2/3.141592);

--- a/aux/src/Spectra.cxx
+++ b/aux/src/Spectra.cxx
@@ -43,15 +43,28 @@ Aux::WaveGenerator::complex_vector_t Aux::WaveGenerator::spec()
     complex_vector_t spec(nsamples, 0);
 
     auto normals = normal(nsamples);
-    for (size_t ind=0; ind < nhalf; ++ind) {
+
+    spec[0].real(meanspec[0]*normals[0]);
+    for (size_t ind=1; ind < nhalf; ++ind) {
         float mean = meanspec[ind];
         spec[ind] = std::complex(mean*normals[ind],
                                  mean*normals[ind+nhalf]);
     }
     if (nextra) {       // have Nyquist bin
-        spec[nhalf+1].real(meanspec[nhalf+1]*normals.back());
+        spec[nhalf+1].real(meanspec[nhalf]*normals.back());
     }
     hermitian_symmetry_inplace(spec);
     return spec;
 }
 
+Aux::WaveGenerator::real_vector_t Aux::WaveGenerator::wave()
+{
+    auto wave = inv_c2r(dft, spec());
+
+    size_t nsamples = meanspec.size();
+    const float mean_to_mode = sqrt(2/3.141592);
+    for (size_t ind=0; ind<nsamples; ++ind) {
+        wave[ind] *= mean_to_mode;
+    }
+    return wave;
+}

--- a/aux/src/Spectra.cxx
+++ b/aux/src/Spectra.cxx
@@ -1,0 +1,57 @@
+#include "WireCellAux/Spectra.h"
+#include "WireCellUtil/Waveform.h"
+
+using namespace WireCell;
+using namespace WireCell::Waveform;
+
+
+Aux::WaveCollector::WaveCollector(IDFT::pointer dft) : dft(dft)
+{
+}
+
+void Aux::WaveCollector::add(const real_vector_t& wave)
+{
+    if (sum.empty()) {
+        sum.resize(wave.size(), 0);
+    }
+    auto spec = fwd_r2c(dft, wave);
+    auto amp = Waveform::magnitude(spec);
+    increase(sum, amp);
+    ++count;
+}
+
+Aux::WaveCollector::real_vector_t Aux::WaveCollector::mean()
+{
+    real_vector_t avg(sum.begin(), sum.end());
+    scale(avg, 1.0/count);
+    return avg;
+}
+
+Aux::WaveGenerator::WaveGenerator(IDFT::pointer dft, normal_f normal,
+                                  const real_vector_t& meanspec)
+    :dft(dft), meanspec(meanspec), normal(normal)
+{
+}
+
+Aux::WaveGenerator::complex_vector_t Aux::WaveGenerator::spec()
+{
+    const size_t nsamples = meanspec.size();
+    // nsamples: even->1, odd->0
+    const size_t nextra = (nsamples+1)%2;
+    const size_t nhalf = nsamples / 2;
+            
+    complex_vector_t spec(nsamples, 0);
+
+    auto normals = normal(nsamples);
+    for (size_t ind=0; ind < nhalf; ++ind) {
+        float mean = meanspec[ind];
+        spec[ind] = std::complex(mean*normals[ind],
+                                 mean*normals[ind+nhalf]);
+    }
+    if (nextra) {       // have Nyquist bin
+        spec[nhalf+1].real(meanspec[nhalf+1]*normals.back());
+    }
+    hermitian_symmetry_inplace(spec);
+    return spec;
+}
+

--- a/aux/src/Spectra.cxx
+++ b/aux/src/Spectra.cxx
@@ -45,6 +45,7 @@ WaveGenerator::spec(const real_vector_t& meanspec)
 
     auto normals = normal(nsamples);
 
+    // The zero-frequency bin must be real and may be negative.
     spec[0].real(meanspec[0]*normals[0]);
     for (size_t ind=1; ind < nhalf; ++ind) {
         float mean = meanspec[ind];
@@ -52,6 +53,7 @@ WaveGenerator::spec(const real_vector_t& meanspec)
                                  mean*normals[ind+nhalf]);
     }
     if (nextra) {       // have Nyquist bin
+        // Must be real, can be negative.
         spec[nhalf+1].real(meanspec[nhalf]*normals.back());
     }
     hermitian_symmetry_inplace(spec);

--- a/aux/src/Testing.cxx
+++ b/aux/src/Testing.cxx
@@ -1,0 +1,116 @@
+#include "WireCellAux/Testing.h"
+
+#include "WireCellUtil/PluginManager.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellIface/IConfigurable.h"
+
+#include <algorithm>            // find
+
+using namespace WireCell;
+using namespace WireCell::Aux;
+
+void Testing::load_plugins(std::vector<std::string> list)
+{
+    PluginManager& pm = PluginManager::instance();
+
+    if (list.empty()) {
+        list = {"WireCellAux", "WireCellGen", "WireCellSigProc", "WireCellPgraph", "WireCellImg", "WireCellSio", "WireCellApps"};
+    }
+    for (const auto& one : list) {
+        pm.add(one);
+    }
+}
+
+WireCell::IDFT::pointer Testing::get_dft()
+{
+    load_plugins({"WireCellAux"});
+    return Factory::lookup<IDFT>("FftwDFT"); // not configurable
+}
+
+
+WireCell::IRandom::pointer Testing::get_random(const std::string& name)
+{
+    using namespace WireCell;
+    load_plugins({"WireCellGen"}); // fixme: should move Random to Aux.
+    auto rngcfg = Factory::lookup<IConfigurable>("Random", name);
+    auto cfg = rngcfg->default_configuration();
+    cfg["generator"] = name;    // default or twister
+    rngcfg->configure(cfg);
+    return Factory::find<IRandom>("Random", name);
+}
+
+
+static std::vector<std::string> knowndets = {"uboone", "pdsp"};
+const std::vector<std::string>& Testing::known_detectors()
+{
+    return knowndets;
+}
+
+static void assert_known_det(const std::string& det)
+{
+    if (std::find(knowndets.begin(), knowndets.end(), det) == knowndets.end()) {
+        THROW(ValueError() << errmsg{"unknown detector: " + det});
+    }
+}
+
+IAnodePlane::vector Testing::anodes(std::string detector)
+{
+    assert_known_det(detector);
+    load_plugins({"WireCellGen", "WireCellSigProc"});
+    IAnodePlane::vector anodes;
+    {
+        int nanodes = 1;
+        // Note: these files must be located via WIRECELL_PATH
+        std::string ws_fname = "microboone-celltree-wires-v2.1.json.bz2";
+        std::string fr_fname = "ub-10-half.json.bz2";
+        if (detector == "uboone") {
+            ws_fname = "microboone-celltree-wires-v2.1.json.bz2";
+            fr_fname = "ub-10-half.json.bz2";
+        }
+        if (detector == "pdsp") {
+            ws_fname = "protodune-wires-larsoft-v4.json.bz2";
+            fr_fname = "garfield-1d-3planes-21wires-6impacts-dune-v1.json.bz2";
+            nanodes = 6;
+        }
+
+        const std::string fr_tn = "FieldResponse";
+        const std::string ws_tn = "WireSchemaFile";
+
+        {
+            auto icfg = Factory::lookup<IConfigurable>(fr_tn);
+            auto cfg = icfg->default_configuration();
+            cfg["filename"] = fr_fname;
+            icfg->configure(cfg);
+        }
+        {
+            auto icfg = Factory::lookup<IConfigurable>(ws_tn);
+            auto cfg = icfg->default_configuration();
+            cfg["filename"] = ws_fname;
+            icfg->configure(cfg);
+        }
+
+        for (int ianode = 0; ianode < nanodes; ++ianode) {
+            std::string tn = String::format("AnodePlane:%d", ianode);
+            auto icfg = Factory::lookup_tn<IConfigurable>(tn);
+            auto cfg = icfg->default_configuration();
+            cfg["ident"] = ianode;
+            cfg["wire_schema"] = ws_tn;
+            cfg["faces"][0]["response"] = 10 * units::cm - 6 * units::mm;
+            cfg["faces"][0]["cathode"] = 2.5604 * units::m;
+            icfg->configure(cfg);
+            anodes.push_back(Factory::find_tn<IAnodePlane>(tn));
+        }
+    }
+    return anodes;
+}
+
+
+void Testing::loginit(const char* argv0)
+{
+    std::string name = argv0;
+    name += ".log";
+    Log::add_stderr(true, "trace");
+    Log::add_file(name, "trace");
+    Log::set_level("trace");
+    Log::set_pattern("[%H:%M:%S.%03e] %L [%^%=8n%$] %v");
+}

--- a/aux/test/aux_test_dft_helpers.h
+++ b/aux/test/aux_test_dft_helpers.h
@@ -204,8 +204,9 @@ namespace WireCell::Aux::Test {
 
     // Same as above but with pass by vector 
     template <typename VectorType>
-    void assert_impulse_at_index(const VectorType& vec, 
-                                 size_t index=0, const typename VectorType::value_type& val = 1.0)
+    void assert_impulse_at_index(const VectorType& vec,
+                                 size_t index=0,
+                                 const typename VectorType::value_type& val = 1.0)
     {
         assert_impulse_at_index(vec.data(), vec.size(), index, val);
     }

--- a/aux/test/check_idft.cxx
+++ b/aux/test/check_idft.cxx
@@ -30,7 +30,7 @@
     Mixed real/complex
 
     - fwd1d_r2c :: fwd1d on 1D real array producing complex array
-    - inv2d_c2r :: inv2d on 2D complex array producing real array
+    - inv1d_c2r :: inv1d on 2D complex array producing real array
 
  */
 
@@ -135,11 +135,11 @@ pig_array dispatch(const IDFT::pointer& dft, const pig_array& pa, const std::str
     if (op == "inv2d")
         return a2p<complex_t>(Aux::inv(dft, p2a<complex_t>(pa)));
 
-    if (op == "fwd2d_r2c")
-        return a2p<complex_t>(Aux::fwd_r2c(dft, p2a<scalar_t>(pa)));
+    // if (op == "fwd2d_r2c")
+    //     return a2p<complex_t>(Aux::fwd_r2c(dft, p2a<scalar_t>(pa)));
 
-    if (op == "inv2d_c2r")
-        return a2p<scalar_t>(Aux::inv_c2r(dft, p2a<complex_t>(pa)));
+    // if (op == "inv2d_c2r")
+    //     return a2p<scalar_t>(Aux::inv_c2r(dft, p2a<complex_t>(pa)));
 
     if (op == "fwd1b0")
         return a2p<complex_t>(Aux::fwd(dft, p2a<complex_t>(pa), 0));

--- a/aux/test/test_dfttools.cxx
+++ b/aux/test/test_dfttools.cxx
@@ -7,6 +7,9 @@
 #include <iostream>
 #include <memory>
 
+#include <complex>
+using namespace std::literals;
+
 using namespace WireCell;
 using namespace WireCell::Aux::Test;
 
@@ -120,14 +123,22 @@ void test_1b(IDFT::pointer dft, int axis, int nrows=8, int ncols=4)
 
 }
 
-void test_hs()
+void test_hs1d()
 {
+    std::cerr << "1d hermitian symmetry\n";
     //                            0      1      2      3      4     5
     Aux::complex_vector_t even{{1,11},{2,22},{3,33},{4,44},{5,55},{6,66}};
     Aux::complex_vector_t odd(even.begin(), even.end()-1);
 
     auto evens = Aux::hermitian_symmetry(even);
     auto odds = Aux::hermitian_symmetry(odd);
+
+    // The Nyquist bin must be real.
+    { size_t ind=3;
+        std::cerr << " even["<< ind <<"]=" << even[ind]
+                  << " evens["<<ind<<"]=" << evens[ind] << "\n";
+        assert(std::abs(evens[ind].imag()) < 1e-6);
+    }
 
     for (size_t ind=0; ind<3; ++ind) {
         assert(even[ind] == evens[ind]);
@@ -146,14 +157,151 @@ void test_hs()
     }
 }
 
+void test_hs2d_axis1()
+{
+    using c = std::complex<float>;
+
+    std::cerr << "2d hermitian symmetry\n";
+    CA even(1,6), odd(1,5);
+    even << c(1,11), c(2,22), c(3,33), c(4,44), c(5,55), c(6,66);
+    odd  << c(1,11), c(2,22), c(3,33), c(4,44), c(5,55);
+    dump("even", even);
+    std::cerr << even << std::endl;
+    dump("odd", odd);
+    std::cerr << odd << std::endl;
+
+    auto evens = Aux::hermitian_symmetry(even, 1);
+    auto odds = Aux::hermitian_symmetry(odd, 1);
+
+    // The Nyquist bin must be real.
+    { size_t ind=3;
+        std::cerr << " even["<< ind <<"]=" << even(0,ind)
+                  << " evens["<<ind<<"]=" << evens(0,ind) << "\n";
+        assert(std::abs(evens(0,ind).imag()) < 1e-6);
+    }
+
+    dump("evens", evens);
+    std::cerr << evens << std::endl;
+    dump("odds", odds);
+    std::cerr << odds << std::endl;
+
+    for (size_t ind=0; ind<3; ++ind) {
+        assert(even(0,ind) == evens(0,ind));
+        assert(odd(0,ind) == odds(0,ind));
+    }
+    for (size_t ind=1; ind<3; ++ind) {
+        size_t even_other = even.cols() - ind;
+        size_t odd_other = odd.cols() - ind;
+        std::cerr << " even["<< ind <<"]=" << even(0,ind)
+                  << " evens["<<even_other<<"]=" << evens(0,even_other)
+                  << " odd[" << ind << "]=" << odd(0,ind)
+                  << " odds[" << odd_other << "]=" << odds(0,odd_other)
+                  << "\n";
+        assert(even(0,ind) == std::conj(evens(0,even_other)));
+        assert(odd(0,ind) == std::conj(odds(0,odd_other)));
+    }
+}
+void test_hs2d_axis0()
+{
+    using c = std::complex<float>;
+
+    std::cerr << "2d hermitian symmetry\n";
+    CA even(6,1), odd(5,1);
+    even << c(1,11), c(2,22), c(3,33), c(4,44), c(5,55), c(6,66);
+    odd  << c(1,11), c(2,22), c(3,33), c(4,44), c(5,55);
+    dump("even", even);
+    std::cerr << even << std::endl;
+    dump("odd", odd);
+    std::cerr << odd << std::endl;
+
+    auto evens = Aux::hermitian_symmetry(even, 0);
+    auto odds = Aux::hermitian_symmetry(odd, 0);
+
+    // The Nyquist bin must be real.
+    { size_t ind=3;
+        std::cerr << " even["<< ind <<"]=" << even(ind,0)
+                  << " evens["<<ind<<"]=" << evens(ind,0) << "\n";
+        assert(std::abs(evens(ind,0).imag()) < 1e-6);
+    }
+
+    dump("evens", evens);
+    std::cerr << evens << std::endl;
+    dump("odds", odds);
+    std::cerr << odds << std::endl;
+
+    for (size_t ind=0; ind<3; ++ind) {
+        assert(even(ind,0) == evens(ind,0));
+        assert(odd(ind,0) == odds(ind,0));
+    }
+    for (size_t ind=1; ind<3; ++ind) {
+        size_t even_other = even.rows() - ind;
+        size_t odd_other = odd.rows() - ind;
+        std::cerr << " even["<< ind <<"]=" << even(ind,0)
+                  << " evens["<<even_other<<"]=" << evens(even_other,0)
+                  << " odd[" << ind << "]=" << odd(ind,0)
+                  << " odds[" << odd_other << "]=" << odds(odd_other,0)
+                  << "\n";
+        assert(even(ind,0) == std::conj(evens(even_other,0)));
+        assert(odd(ind,0) == std::conj(odds(odd_other,0)));
+    }
+}
+
+void test_1d_c2r_impulse(IDFT::pointer dft, size_t size = 64)
+{
+    std::cerr << "1d c2r impulse size=" << size << "\n";
+
+    RV rimp(size, 0);
+    rimp[0] = 1.0;
+
+    auto spec = Aux::fwd_r2c(dft, rimp);
+    spec[3*size/4] = 42;
+    auto wave = Aux::inv_c2r(dft, spec);
+    for (size_t ind=0; ind<size; ++ind) {
+        // std::cerr << ind << " " << rimp[ind] << " " << wave[ind] << " " << spec[ind] << "\n";
+        if (ind) {
+            assert(wave[ind] == 0.0);
+        }
+        else {
+            assert(wave[ind] == 1.0);
+        }
+    }        
+}
+void test_2d_c2r_impulse(IDFT::pointer dft, int axis, int nrows=8, int ncols=4)
+{
+    std::cerr << "2d c2r impulse axis=" << axis << " shape=(" << nrows << ", " << ncols <<")\n";
+
+    const size_t size = nrows*ncols;
+    FA r = FA::Zero(nrows, ncols);
+    r(0,0) = 1.0;
+    dump("rimp2d", r);
+    std::cerr << r << std::endl;
+    assert_impulse_at_index(r.data(), size);
+
+    auto spec = Aux::fwd_r2c(dft, r, axis);
+    dump("spec2d", spec);
+    std::cerr << spec << std::endl;
+
+    auto wave = Aux::inv_c2r(dft, spec, axis);
+    dump("wave2d", wave);
+    std::cerr << wave << std::endl;
+    assert_impulse_at_index(wave.data(), size);    
+}
+
 int main(int argc, char* argv[])
 {
-    test_hs();
+    test_hs1d();
+    test_hs2d_axis1();
+    test_hs2d_axis0();
+    return 0;
 
     DftArgs args;
     int rc = make_dft_args(args, argc, argv);
     if (rc) { return rc; }
     auto idft = make_dft(args.tn, args.pi, args.cfg);
+
+    test_1d_c2r_impulse(idft);
+    test_2d_c2r_impulse(idft, 0);
+    test_2d_c2r_impulse(idft, 1);
 
     test_1d_impulse(idft);
     test_2d_impulse(idft);

--- a/aux/test/test_dfttools.cxx
+++ b/aux/test/test_dfttools.cxx
@@ -120,8 +120,36 @@ void test_1b(IDFT::pointer dft, int axis, int nrows=8, int ncols=4)
 
 }
 
+void test_hs()
+{
+    //                            0      1      2      3      4     5
+    Aux::complex_vector_t even{{1,11},{2,22},{3,33},{4,44},{5,55},{6,66}};
+    Aux::complex_vector_t odd(even.begin(), even.end()-1);
+
+    auto evens = Aux::hermitian_symmetry(even);
+    auto odds = Aux::hermitian_symmetry(odd);
+
+    for (size_t ind=0; ind<3; ++ind) {
+        assert(even[ind] == evens[ind]);
+        assert(odd[ind] == odds[ind]);
+    }
+    for (size_t ind=1; ind<3; ++ind) {
+        size_t even_other = even.size() - ind;
+        size_t odd_other = odd.size() - ind;
+        std::cerr << " even["<< ind <<"]=" << even[ind]
+                  << " evens["<<even_other<<"]=" << evens[even_other]
+                  << " odd[" << ind << "]=" << odd[ind]
+                  << " odds[" << odd_other << "]=" << odds[odd_other]
+                  << "\n";
+        assert(even[ind] == std::conj(evens[even_other]));
+        assert(odd[ind] == std::conj(odds[odd_other]));
+    }
+}
+
 int main(int argc, char* argv[])
 {
+    test_hs();
+
     DftArgs args;
     int rc = make_dft_args(args, argc, argv);
     if (rc) { return rc; }

--- a/aux/test/test_randtools.cxx
+++ b/aux/test/test_randtools.cxx
@@ -3,18 +3,18 @@
 #include "WireCellUtil/NamedFactory.h"
 #include "WireCellUtil/TimeKeeper.h"
 #include "WireCellUtil/String.h"
-#include "WireCellIface/IRandom.h"
 #include "WireCellIface/IConfigurable.h"
 
 #include <iostream>
 
 using namespace WireCell;
 using namespace WireCell::String;
+using namespace Aux::RandTools;
 
 void test_rn(IRandom::pointer rng)
 {
     const size_t capacity = 10; // tiny
-    Aux::RecyclingNormals rn(rng, capacity); 
+    Normals::Recycling rn(rng, capacity); 
     for (size_t ind=0; ind<100; ++ind) {
         std::cerr << ind << ": " << rn() << "\n";
     }
@@ -44,7 +44,7 @@ void test_speed(IRandom::pointer rng)
 
     for (auto nsamples : sample_count) {
         for (auto capacity : capacities) {
-            Aux::RecyclingNormals rn(rng, capacity); 
+            Normals::Recycling rn(rng, capacity); 
             for (size_t ind=0; ind<nsamples; ++ind) {
                 rn();
             }
@@ -55,7 +55,7 @@ void test_speed(IRandom::pointer rng)
             tk(format("RN: %d capacity=%d (again)", nsamples, capacity));
         }
         {
-            Aux::FreshNormals fn(rng);
+            Normals::Fresh fn(rng);
             for (size_t ind=0; ind<nsamples; ++ind) {
                 fn();
             }
@@ -68,7 +68,7 @@ void test_speed(IRandom::pointer rng)
 
 void test_freshness(IRandom::pointer rng)
 {
-    Aux::RecyclingNormals rn(rng, 10); 
+    Normals::Recycling rn(rng, 10); 
     auto one = rn(100);
     auto two = rn(100);
     for (size_t ind=0; ind<100; ++ind) {

--- a/aux/test/test_randtools.cxx
+++ b/aux/test/test_randtools.cxx
@@ -1,0 +1,85 @@
+#include "WireCellAux/RandTools.h"
+#include "WireCellUtil/PluginManager.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/TimeKeeper.h"
+#include "WireCellUtil/String.h"
+#include "WireCellIface/IRandom.h"
+#include "WireCellIface/IConfigurable.h"
+
+#include <iostream>
+
+using namespace WireCell;
+using namespace WireCell::String;
+
+void test_rn(IRandom::pointer rng)
+{
+    const size_t capacity = 10; // tiny
+    Aux::RecyclingNormals rn(rng, capacity); 
+    for (size_t ind=0; ind<100; ++ind) {
+        std::cerr << ind << ": " << rn() << "\n";
+    }
+    for (size_t ind=0; ind<400; ++ind) {
+        // Note, this a bad choice for capcity and vector size.  With
+        // size == capacity/10 the 1st draw and 11'th draw will return
+        // the same location of the ring buffer and we will only see
+        // freshness due to refresh fraction.
+        auto got = rn(10);      
+        if (ind%10 == 0) {
+            for (auto x : got) {
+                std::cerr << x << " ";
+            }
+            std::cerr << "\n";
+        }
+    }
+    std::cerr << "capacity=" << capacity << " replacement=" << rn.replacement() << "\n";
+}
+
+void test_speed(IRandom::pointer rng)
+{
+    TimeKeeper tk("random normals");
+    
+    std::vector<size_t> sample_count{1000, 10000, 100000, 1000000};
+    std::vector<size_t> capacities{100, 1000};
+
+
+    for (auto nsamples : sample_count) {
+        for (auto capacity : capacities) {
+            Aux::RecyclingNormals rn(rng, capacity); 
+            for (size_t ind=0; ind<nsamples; ++ind) {
+                rn();
+            }
+            tk(format("RN: %d capacity=%d", nsamples, capacity));
+            for (size_t ind=0; ind<nsamples; ++ind) {
+                rn();
+            }
+            tk(format("RN: %d capacity=%d (again)", nsamples, capacity));
+        }
+        {
+            Aux::FreshNormals fn(rng);
+            for (size_t ind=0; ind<nsamples; ++ind) {
+                fn();
+            }
+            tk(format("FN: %d", nsamples));
+        }
+    }
+    std::cerr << tk.summary() << std::endl;
+
+}
+
+int main()
+{
+    PluginManager& pm = PluginManager::instance();
+    pm.add("WireCellGen");
+    {
+        auto rngcfg = Factory::lookup<IConfigurable>("Random");
+        auto cfg = rngcfg->default_configuration();
+        rngcfg->configure(cfg);
+    }
+    auto rng = Factory::lookup<IRandom>("Random");
+
+    test_rn(rng);
+
+    test_speed(rng);
+
+    return 0;
+}

--- a/aux/test/test_randtools.cxx
+++ b/aux/test/test_randtools.cxx
@@ -66,6 +66,16 @@ void test_speed(IRandom::pointer rng)
 
 }
 
+void test_freshness(IRandom::pointer rng)
+{
+    Aux::RecyclingNormals rn(rng, 10); 
+    auto one = rn(100);
+    auto two = rn(100);
+    for (size_t ind=0; ind<100; ++ind) {
+        std::cerr << ind << "\t" << one[ind] << "\t" << two[ind] << "\n";
+    }
+}
+
 int main()
 {
     PluginManager& pm = PluginManager::instance();
@@ -80,6 +90,8 @@ int main()
     test_rn(rng);
 
     test_speed(rng);
+
+    test_freshness(rng);
 
     return 0;
 }

--- a/gen/README.org
+++ b/gen/README.org
@@ -1,0 +1,136 @@
+#+title: Wire-Cell Gen
+
+This is the Wire-Cell "gen" sub-package.  It provides components
+related to generating simulated data.  In particular:
+
+- simple ionization deposition (depos) generators,
+- drifting depos in the bulk volume of the detector,
+- diffusion of these charges as they drift,
+- convolution of drifted ionization with detector responses
+- sampling fluctuations,
+- intrinsic and coherent noise simulation
+- ADC waveform digitization. of charge on the wire planes.
+
+What follows are various, non-exhaustive notes on parts of the
+sub-package.
+
+
+* Noise simulations
+
+Noise simulations include intrinsic / thermal noise and noise which is
+coherent across a group of channels.  Both are parameterized by a
+number of *mean noise spectra*.
+
+** Code intro
+
+The intrinsic noise is produced by the ~AddNoise~ flow graph node which
+delegates actual noise generation to a /noise model/ component.  The
+~EmpiricalNoiseModel~ component is primarily used and it accepts a
+*channel noise spectra file* which provides an array of individual
+spectra that spans a variety of wire lengths.
+
+The coherent noise is produced by the ~AddGroupNoise~ flow graph node.
+It takes a *noise group spectra file* and a *channel group file*.  Each
+spectra provides a coherent noise spectrum to be applied to a group of
+channels.
+
+** Providing noise spectra
+
+Though details of these files differ, in all cases spectra are
+supplied following these specifications:
+
+- ~freqs~ :: an array of frequencies in WCT system of units (not, the
+  base unit of frequency in WCT is [1/time] = 1/ns and *not* Hz).
+
+- amps :: an array of *mean spectral amplitude* with each element a
+  measurement corresponding to the same element of ~freqs~.
+
+The ~amps~ vs ~freqs~ sampling need *not*, and likely should not, match the
+internal sampling used in the simulation.  The input sampling need
+note even be regular nor complete.  An input spectrum consisting of a
+single sample will technically work.  However, for accuracy, enough
+samples of the spectrum should be provided so that its shape is well
+represented.  Internally, the input spectra will be *linearly
+interpolated* and *constant extrapolated* to produce whatever sampling
+the simulation requires.
+
+The value of elements of the ~amps~ array must provide an *mean spectral
+amplitude* (specifically not mode) and it must be properly normalized.
+The following guidelines describe a procedure to produce input
+spectra.
+
+- Collect a set of raw ADC waveforms in some manner that *excludes
+  signal*.  Examining the distribution of ADC in a waveform around the
+  *median* ADC of that waveform is one good way to detect if it has been
+  "contaminated" with signal.
+
+- Apply the forward discrete Fourier transform (DFT) to each waveform
+  using no FT normalization (do *not* divide by 1/N nor 1/sqrt(N)).
+  This gives a complex spectra.
+
+- Take the absolute value of that spectra to get a real spectral
+  amplitude for that waveform.
+
+- Repeat with all the waveforms in the set and form the *mean spectral
+  amplitude* by simply summing on a per-frequency-bin basis and
+  dividing by the number of waveforms in the set.
+
+- Write out the result.  Values above the Nyquist frequency are not
+  required.  Down sampling may be desired for large sets of spectra.
+
+If creation of mean spectra is performed by WCT C++ the developer may
+use:
+
+#+begin_src c++
+  #include "WireCellAux/Spectra.h"
+  // ...
+  IDFT::pointer dft = ...;
+  WaveCollector wavecol(dft);
+  for (auto wave : waves) {
+      wavecol.add(wave);
+  }
+  auto spec = wavecol.mean();
+#+end_src
+
+** Sampling spectra
+
+Current and any novel noise simulation components should use code like
+this to generate their waveforms.
+
+#+begin_src c++
+  #include "WireCellAux/RandTools.h"
+  #include "WireCellAux/Spectra.h"
+  // ...
+  using namespace WireCell;
+  IRandom::pointer rng = ...;
+  IDFT::pointer dft = ...;
+  
+  // We can make all fresh normal-distributed randoms but this will be
+  // about 2-3x slower than recycling.
+  // 
+  // FreshNormals norms(rng);
+  
+  // The size we will sample
+  const size_t nsamples = ...;
+  
+  // Maximize freshness by using a recylcing ring buffer size which is
+  // larger than and coprime with the size we sample
+  const size_t not_nsamples = nearest_coprime(2*nsamples, 1.7*nsamples);
+  
+  // See test_noise and 'wirecell-test noise' for to show this recycling
+  // of randoms is valid.
+  const double replacement_fraction = 0.02; // the default
+  RecyclingNormals norms(rng, not_nsamples, replacement_fraction);
+  
+  // A full, real and mean spectrum [0-2*Nyquist].
+  // See WaveCollector.
+  std::vector<float> true_spectrum(nsamples);
+  
+  // Given full, real and mean spectrum, make some waves
+  WaveGenerator wavegen(dft, norms, true_spectrum);
+  for (size_t iwave=0; iwave<nexample; ++iwave) {
+      auto wave = wavegen.wave();
+      use_wave(wave);
+  }
+#+end_src
+

--- a/gen/inc/WireCellGen/AddNoise.h
+++ b/gen/inc/WireCellGen/AddNoise.h
@@ -17,35 +17,34 @@
 
 #include <string>
 
-namespace WireCell {
-    namespace Gen {
+namespace WireCell::Gen {
 
-        class AddNoise : public Aux::Logger,
-                         public IFrameFilter, public IConfigurable {
-           public:
-            AddNoise(const std::string& model = "", const std::string& rng = "Random");
 
-            virtual ~AddNoise();
+    class AddNoise : public Aux::Logger,
+                     public IFrameFilter, public IConfigurable {
+      public:
+        AddNoise();
 
-            /// IFrameFilter
-            virtual bool operator()(const input_pointer& inframe, output_pointer& outframe);
+        virtual ~AddNoise();
 
-            /// IConfigurable
-            virtual void configure(const WireCell::Configuration& config);
-            virtual WireCell::Configuration default_configuration() const;
+        /// IFrameFilter
+        virtual bool operator()(const input_pointer& inframe, output_pointer& outframe);
 
-           private:
-            IRandom::pointer m_rng;
-            IDFT::pointer m_dft;
-            IChannelSpectrum::pointer m_model;
+        /// IConfigurable
+        virtual void configure(const WireCell::Configuration& config);
+        virtual WireCell::Configuration default_configuration() const;
 
-            std::string m_model_tn, m_rng_tn;
-            int m_nsamples;
-            double m_rep_percent;
+      private:
+        IRandom::pointer m_rng;
+        IDFT::pointer m_dft;
+        std::map<std::string, IChannelSpectrum::pointer> m_models;
 
-            size_t m_count{0};
-        };
-    }  // namespace Gen
-}  // namespace WireCell
+        size_t m_nsamples{9600};
+        double m_rep_percent{0.02};
+
+        size_t m_count{0};
+    };
+
+}  // namespace WireCell::Gen
 
 #endif

--- a/gen/inc/WireCellGen/EmpiricalNoiseModel.h
+++ b/gen/inc/WireCellGen/EmpiricalNoiseModel.h
@@ -107,6 +107,9 @@ namespace WireCell {
             // need to convert the electronics response in here ...
             Waveform::realseq_t m_elec_resp_freq;
             mutable std::unordered_map<int, Waveform::realseq_t> m_elec_resp_cache;
+            // sigh, this totally violates the API!  It returns the
+            // same vector every call.  It should return a unique
+            // vector.
             mutable amplitude_t comb_amp;
 
         };

--- a/gen/inc/WireCellGen/GroupNoiseModel.h
+++ b/gen/inc/WireCellGen/GroupNoiseModel.h
@@ -1,0 +1,31 @@
+#ifndef WIRECELL_GEN_GROUPNOISEMODEL
+#define WIRECELL_GEN_GROUPNOISEMODEL
+
+#include "WireCellIface/IChannelSpectrum.h"
+#include "WireCellIface/IConfigurable.h"
+#include <unordered_map>
+
+namespace WireCell::Gen {
+
+    class GroupNoiseModel : public IChannelSpectrum, public IConfigurable
+    {
+
+      public:
+        virtual ~GroupNoiseModel();
+
+        /// IChannelSpectrum
+        virtual const amplitude_t& operator()(int chid) const;
+
+        /// IConfigurable
+        virtual void configure(const WireCell::Configuration& config);
+        virtual WireCell::Configuration default_configuration() const;
+
+      private:
+
+        std::unordered_map<int, int> m_ch2grp;
+        std::unordered_map<int, amplitude_t> m_grp2amp;
+    };
+
+}
+
+#endif

--- a/gen/inc/WireCellGen/Random.h
+++ b/gen/inc/WireCellGen/Random.h
@@ -22,21 +22,27 @@ namespace WireCell {
 
             /// Sample a binomial distribution
             virtual int binomial(int max, double prob);
+            virtual int_func make_binomial(int max, double prob);
 
             /// Sample a Poisson distribution.
             virtual int poisson(double mean);
+            virtual int_func make_poisson(double mean);
 
             /// Sample a normal distribution.
             virtual double normal(double mean, double sigma);
+            virtual double_func make_normal(double mean, double sigma);
 
             /// Sample a uniform distribution
             virtual double uniform(double begin, double end);
+            virtual double_func make_uniform(double begin, double end);
 
             /// Sample an exponential distribution
             virtual double exponential(double mean);
+            virtual double_func make_exponential(double mean);
 
             /// Sample a uniform integer range.
             virtual int range(int first, int last);
+            virtual int_func make_range(int first, int last);
 
            private:
             std::string m_generator;

--- a/gen/src/AddCoherentNoise.cxx
+++ b/gen/src/AddCoherentNoise.cxx
@@ -147,7 +147,7 @@ bool Gen::AddCoherentNoise::operator()(const input_pointer& inframe, output_poin
             noise_freq[i] = tc;
         }
 
-        auto wave = Waveform::real(Aux::inv(m_dft, noise_freq));
+        auto wave = Aux::inv_c2r(m_dft, noise_freq);
 
         // Add signal (be careful to double counting with the incoherent noise)
         Waveform::increase(wave, intrace->charge());

--- a/gen/src/AddGroupNoise.cxx
+++ b/gen/src/AddGroupNoise.cxx
@@ -118,7 +118,7 @@ bool Gen::AddGroupNoise::operator()(const input_pointer &inframe,
     int groupID = m_ch2grp[chid];
 
     WireCell::Waveform::compseq_t noise_freq = m_grp2noise[groupID];
-    auto wave = Waveform::real(Aux::inv(m_dft, noise_freq));
+    auto wave = Aux::inv_c2r(m_dft, noise_freq);
     wave.resize(m_nsamples, 0);
 
     Waveform::increase(wave, intrace->charge());

--- a/gen/src/AddGroupNoise.cxx
+++ b/gen/src/AddGroupNoise.cxx
@@ -1,11 +1,11 @@
 #include "WireCellGen/AddGroupNoise.h"
+#include "Noise.h"
 
 #include "WireCellAux/DftTools.h"
 
 #include "WireCellIface/SimpleFrame.h"
 #include "WireCellIface/SimpleTrace.h"
 
-#include "Noise.h"
 #include "WireCellUtil/NamedFactory.h"
 #include "WireCellUtil/Persist.h"
 #include <Eigen/Core>

--- a/gen/src/AddNoise.cxx
+++ b/gen/src/AddNoise.cxx
@@ -72,8 +72,7 @@ bool Gen::AddNoise::operator()(const input_pointer& inframe, output_pointer& out
         int chid = intrace->channel();
         const auto& spec = (*m_model)(chid);
         auto cspec = Gen::Noise::generate_spectrum(spec, m_rng, m_rep_percent);
-        auto wave = Waveform::real(Aux::inv(m_dft, cspec));
-        // Waveform::realseq_t wave = Gen::Noise::generate_waveform(spec, m_rng, m_rep_percent);
+        auto wave = Aux::inv_c2r(m_dft, cspec);
 
         wave.resize(m_nsamples, 0);
         Waveform::increase(wave, intrace->charge());

--- a/gen/src/AddNoise.cxx
+++ b/gen/src/AddNoise.cxx
@@ -7,10 +7,9 @@
 #include "WireCellIface/SimpleTrace.h"
 #include "WireCellIface/SimpleFrame.h"
 
-#include "WireCellUtil/Persist.h"
 #include "WireCellUtil/NamedFactory.h"
 
-#include <iostream>
+#include <unordered_set>
 
 WIRECELL_FACTORY(AddNoise, WireCell::Gen::AddNoise,
                  WireCell::INamed,
@@ -21,44 +20,69 @@ using namespace WireCell;
 using namespace WireCell::Aux::RandTools;
 using namespace WireCell::Aux::Spectra;
 
-Gen::AddNoise::AddNoise(const std::string& model, const std::string& rng)
-  : Aux::Logger("AddNoise", "gen")
-  , m_model_tn(model)
-  , m_rng_tn(rng)
-  , m_nsamples(9600)
-  , m_rep_percent(0.02)  // replace 2% at a time
+Gen::AddNoise::AddNoise() : Aux::Logger("AddNoise", "gen")
 {
 }
 
-Gen::AddNoise::~AddNoise() {}
+Gen::AddNoise::~AddNoise() 
+{
+}
 
 WireCell::Configuration Gen::AddNoise::default_configuration() const
 {
     Configuration cfg;
-
-    // fixme: maybe add some tag support?
-
-    cfg["model"] = m_model_tn;
-    cfg["rng"] = m_rng_tn;
-    cfg["dft"] = "FftwDFT";     // type-name for the DFT to use
+    // The name of the noise model.  Or, if an array is given, the
+    // names of multiple noise models.  The plural spelling "models"
+    // is also checked for an array of model names.
+    cfg["model"] = "";
+    // The IRandom
+    cfg["rng"] = "Random";
+    // The IDFT
+    cfg["dft"] = "FftwDFT";
+    // The size (number of ticks) of the noise waveforms
     cfg["nsamples"] = m_nsamples;
+    // Percentage of fresh randomness added in using the recyled
+    // random normal-Gaussian distribution.  Note, to match prior
+    // interpreation of "percent" we apply twice this amount of
+    // refreshing.  0.02 remains a reasonable choice.
     cfg["replacement_percentage"] = m_rep_percent;
     return cfg;
 }
 
 void Gen::AddNoise::configure(const WireCell::Configuration& cfg)
 {
-    m_rng_tn = get(cfg, "rng", m_rng_tn);
-    m_rng = Factory::find_tn<IRandom>(m_rng_tn);
+    std::string rng_tn = get<std::string>(cfg, "rng", "Random");
+    m_rng = Factory::find_tn<IRandom>(rng_tn);
+
     std::string dft_tn = get<std::string>(cfg, "dft", "FftwDFT");
     m_dft = Factory::find_tn<IDFT>(dft_tn);
-    m_model_tn = get(cfg, "model", m_model_tn);
-    m_model = Factory::find_tn<IChannelSpectrum>(m_model_tn);
+
+    // Specify a single model name or an array of model names.  We
+    // also accept an array given as a pluralized "models".
+    std::unordered_set<std::string> model_names;
+    auto jmodel = cfg["model"];
+    if (jmodel.isString()) {
+        model_names.insert(jmodel.asString());
+    }
+    else {
+        for (const auto& jmod : jmodel) {
+            model_names.insert(jmod.asString());
+        }
+    }
+    if (cfg["models"].isArray()) {
+        for (const auto& jmod : cfg["models"]) {
+            model_names.insert(jmod.asString());
+        }
+    }
+    for (const auto& mtn : model_names) {
+        m_models[mtn] = Factory::find_tn<IChannelSpectrum>(mtn);
+        log->debug("using IChannelSpectrum: \"{}\"", mtn);
+    }
+
     m_nsamples = get<int>(cfg, "nsamples", m_nsamples);
     m_rep_percent = get<double>(cfg, "replacement_percentage", m_rep_percent);
-
-    log->debug("using IRandom: \"{}\", IChannelSpectrum: \"{}\"", m_rng_tn, m_model_tn);
 }
+
 
 bool Gen::AddNoise::operator()(const input_pointer& inframe, output_pointer& outframe)
 {
@@ -69,23 +93,48 @@ bool Gen::AddNoise::operator()(const input_pointer& inframe, output_pointer& out
         return true;
     }
 
-    Normals::Recycling rn(m_rng);
+    // We "recycle" the randoms in order to speed up generation.  Each
+    // array will start from a random location in the recycled buffer
+    // and a few percent will be "freshened".  This results in a small
+    // amount of coherency between nearby channels.
+    // Normals::Fresh rn(m_rng);
+    Normals::Recycling rn(m_rng, 2*m_nsamples, 2*m_rep_percent);
     WaveGenerator rwgen(m_dft, rn);
+
+    // Limit number of warnings below
+    static bool warned = false;
+
+    // Make waveforms of size nsample from each model, adding only
+    // ncharge of their element to the trace charge.  This
+    // full-nsample followed by ncharge-truncation may CPU-wasteful in
+    // the sparse traces case.
 
     ITrace::vector outtraces;
     for (const auto& intrace : *inframe->traces()) {
-        int chid = intrace->channel();
-        const auto& spec = (*m_model)(chid);
-        if (spec.size() > rn.size()) {
-            rn.resize(spec.size());
-        }
-        // auto cspec = Gen::Noise::generate_spectrum(spec, m_rng, m_rep_percent);
-        // auto wave = Aux::inv_c2r(m_dft, cspec);
-        auto wave = rwgen.wave(spec);
 
-        wave.resize(m_nsamples, 0);
-        Waveform::increase(wave, intrace->charge());
-        auto trace = make_shared<SimpleTrace>(chid, intrace->tbin(), wave);
+        const int chid = intrace->channel();
+        auto charge = intrace->charge(); // copies
+        const size_t ncharge = charge.size();
+
+        for (auto& [mtn, model] : m_models) {
+            const auto& spec = (*model)(chid);
+
+            // The model spec size may differ than expected nsamples.
+            // We could interpolate to correct for that which would
+            // slow things down.  Better to correct the model(s) code
+            // and configuration.
+            if (not warned and spec.size() != m_nsamples) {
+                log->warn("model {} produced {} samples instead of expected {}, future warnings muted",
+                          mtn, spec.size(), m_nsamples);
+                warned = true;
+            }
+
+            auto wave = rwgen.wave(spec);
+            wave.resize(ncharge);
+            Waveform::increase(charge, wave);
+        }
+
+        auto trace = make_shared<SimpleTrace>(chid, intrace->tbin(), charge);
         outtraces.push_back(trace);
     }
     outframe = make_shared<SimpleFrame>(inframe->ident(), inframe->time(), outtraces, inframe->tick());

--- a/gen/src/EmpiricalNoiseModel.cxx
+++ b/gen/src/EmpiricalNoiseModel.cxx
@@ -27,7 +27,7 @@ Gen::EmpiricalNoiseModel::EmpiricalNoiseModel(const std::string& spectra_file, c
                                               // const double gain_scale,
                                               // const double freq_scale,
                                               const std::string anode_tn, const std::string chanstat_tn)
-  : Aux::Logger("EmpericalNoiseModel", "gen")
+  : Aux::Logger("EmpiricalNoiseModel", "gen")
   , m_spectra_file(spectra_file)
   , m_nsamples(nsamples)
   , m_period(period)
@@ -199,6 +199,8 @@ void Gen::EmpiricalNoiseModel::configure(const WireCell::Configuration& cfg)
 
         resample(*nsptr);
         m_spectral_data[nsptr->plane].push_back(nsptr);  // assumes ordered by wire length!
+        log->debug("nwanted={} plane={} ntold={} ngot={} ninput={}",
+                   m_nsamples, nsptr->plane, nsptr->nsamples, nsptr->amps.size(), nfreqs);
     }
 }
 

--- a/gen/src/GroupNoiseModel.cxx
+++ b/gen/src/GroupNoiseModel.cxx
@@ -1,0 +1,111 @@
+#include "WireCellGen/GroupNoiseModel.h"
+
+
+#include "WireCellUtil/Persist.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/Exceptions.h"
+#include "WireCellUtil/Units.h"
+#include "WireCellUtil/Interpolate.h"
+
+WIRECELL_FACTORY(GroupNoiseModel,
+                 WireCell::Gen::GroupNoiseModel,
+                 WireCell::IChannelSpectrum,
+                 WireCell::IConfigurable)
+
+using namespace WireCell;
+
+Gen::GroupNoiseModel::~GroupNoiseModel() { } 
+
+WireCell::Configuration Gen::GroupNoiseModel::default_configuration() const
+{
+    Configuration cfg;
+
+    /// Configuration: spectra_file.  Name of file containing
+    /// array of per-group data with "groupID", array "freqs" of
+    /// frequency and array "amps" of amplitude.
+    cfg["spectral_file"] = "";
+    /// Configuration: map_file.  Name of file containing array of
+    /// per group data with "groupID" and array "channels" holding
+    /// IDs of channels in the group.
+    cfg["map_file"] = "";
+    /// Configuration: spec_scale.  An arbitrary factor multiplied to
+    /// each spectrum read from file.
+    cfg["spec_scale"] = 1.0;
+    /// Configuration: nsamples.  The number of frequency samples
+    /// in returned (no loaded) spectra.
+    cfg["nsamples"] = 1024;        
+    /// Configuration: tick.  The sampling time period
+    /// corresponding to 1/Fmax of the produced spectra
+    cfg["tick"] = 0.5*units::us;
+
+    return cfg;
+}
+
+void Gen::GroupNoiseModel::configure(const WireCell::Configuration& cfg)
+{
+    double spec_scale = get(cfg, "spec_scale", 1.0);
+    size_t nsamples = get(cfg, "nsamples", 1024);
+    double tick = get(cfg, "tick", 0.5*units::us);
+
+    std::string map_file = cfg["map_file"].asString();
+    if (map_file.empty()) {
+        THROW(ValueError() << errmsg{"no map file given to GroupNoiseModel"});
+    }
+    std::string spectral_file = cfg["spectral_file"].asString();
+    if (spectral_file.empty()) {
+        THROW(ValueError() << errmsg{"no spectral file given to GroupNoiseModel"});
+    }
+
+    m_ch2grp.clear();
+    auto mapdata = Persist::load(map_file);
+    for (unsigned int i = 0; i < mapdata.size(); ++i) {
+        auto jdata = mapdata[i];
+        const int groupID = jdata["groupID"].asInt();
+        for (auto jch : jdata["channels"]) {
+            m_ch2grp[jch.asInt()] = groupID;
+        }
+    }
+    
+    const double Fmax = 1/tick;
+    const double dF = Fmax/nsamples;
+
+    m_grp2amp.clear();
+    auto specdata = Persist::load(spectral_file);
+    for (unsigned int i = 0; i < specdata.size(); ++i) {
+        auto jdata = specdata[i];
+        const int groupID = jdata["groupID"].asInt();
+        auto spec_freq = jdata["freqs"];
+        auto spec_amps = jdata["amps"];
+        const int npts = spec_freq.size();
+        std::unordered_map<float, float> pts;
+        for (int ind=0; ind<npts; ++ind) {
+            const float freq = spec_freq[ind].asFloat();
+            pts[freq] = spec_scale * spec_amps[ind].asFloat();
+        }
+        irrterp<float> terp(pts.begin(), pts.end());
+        std::vector<float> spec(nsamples, 0);
+        terp(spec.begin(), nsamples, 0, dF);
+        m_grp2amp[groupID] = spec;
+    }
+    
+}
+
+const Gen::GroupNoiseModel::amplitude_t& Gen::GroupNoiseModel::operator()(int chid) const
+{
+    static amplitude_t dummy;
+
+    // Lookup channels group
+    auto git = m_ch2grp.find(chid);
+    if (git == m_ch2grp.end()) {
+        return dummy;
+    }
+    int groupID = git->second;
+
+    // Lookup groups spectrum
+    auto ait = m_grp2amp.find(groupID);
+    if (ait == m_grp2amp.end()) {
+        return dummy;
+    }
+    return ait->second;
+}
+

--- a/gen/src/ImpactTransform.cxx
+++ b/gen/src/ImpactTransform.cxx
@@ -229,10 +229,9 @@ Gen::ImpactTransform::ImpactTransform(IPlaneImpactResponse::pointer pir,
             m_vec_vec_charge.at(i).shrink_to_fit();
 
             // Do FFT on time
+            data_f_w = Aux::fwd_r2c(m_dft, data_t_w, 1);
             // Do FFT on wire
-            data_f_w = data_t_w.cast<IDFT::complex_t>();
-            data_f_w = Aux::fwd(m_dft, data_f_w);
-
+            data_f_w = Aux::fwd(m_dft, data_f_w, 0);
         }
 
         {

--- a/gen/src/Noise.h
+++ b/gen/src/Noise.h
@@ -10,7 +10,7 @@ namespace WireCell::Gen::Noise {
     // WireCell::Waveform::realseq_t generate_waveform(const std::vector<float>& spec, IRandom::pointer rng,
     //                                                 double replace = 0.02);
 
-    // Generate specific noise spectrum.  Caller likely wants to Aux::inv() it and take Waveform::real().
+    // Generate a specific noise spectrum.  Caller likely wants to follow up by calling Aux::inv_c2r().
     WireCell::Waveform::compseq_t generate_spectrum(const std::vector<float>& spec, IRandom::pointer rng,
                                                     double replace = 0.02);
 }

--- a/gen/src/Random.cxx
+++ b/gen/src/Random.cxx
@@ -28,6 +28,18 @@ Gen::Random::Random(const std::string& generator, const std::vector<unsigned int
 {
 }
 
+template<typename Number, typename URNG, typename Distro>
+struct Closure {
+    URNG& rng;
+    Distro dist;
+    template<typename T1>
+    Closure(URNG& rng, const T1& arg1) : rng(rng), dist(arg1) {}
+    template<typename T1, typename T2>
+    Closure(URNG& rng, const T1& arg1, const T2& arg2) : rng(rng), dist(arg1, arg2) {}
+    Number operator()() { return dist(rng); }
+};
+
+
 // This pimpl may turn out to be a bottle neck.
 template <typename URNG>
 class RandomT : public IRandom {
@@ -45,30 +57,59 @@ class RandomT : public IRandom {
         std::binomial_distribution<int> distribution(max, prob);
         return distribution(m_rng);
     }
+    virtual int_func make_binomial(int max, double prob)
+    {
+        return Closure<int, URNG, std::binomial_distribution<int>>(m_rng, max,prob);
+    }
+
     virtual int poisson(double mean)
     {
         std::poisson_distribution<int> distribution(mean);
         return distribution(m_rng);
     }
+    virtual int_func make_poisson(double mean)
+    {
+        return Closure<int, URNG, std::poisson_distribution<int>>(m_rng, mean);
+    }
+
     virtual double normal(double mean, double sigma)
     {
         std::normal_distribution<double> distribution(mean, sigma);
         return distribution(m_rng);
     }
+    virtual double_func make_normal(double mean, double sigma)
+    {
+        return Closure<double, URNG, std::normal_distribution<double>>(m_rng, mean, sigma);
+    }
+
     virtual double uniform(double begin, double end)
     {
         std::uniform_real_distribution<double> distribution(begin, end);
         return distribution(m_rng);
     }
+    virtual double_func make_uniform(double begin, double end)
+    {
+        return Closure<double, URNG, std::uniform_real_distribution<double>>(m_rng, begin, end);
+    }
+
     virtual double exponential(double mean)
     {
         std::exponential_distribution<double> distribution(mean);
         return distribution(m_rng);
     }
+    virtual double_func make_exponential(double mean)
+    {
+        return Closure<double, URNG, std::exponential_distribution<double>>(m_rng, mean);
+    }
+
     virtual int range(int first, int last)
     {
         std::uniform_int_distribution<int> distribution(first, last);
         return distribution(m_rng);
+    }
+    virtual int_func make_range(int first, int last)
+    {
+        return Closure<int, URNG, std::uniform_int_distribution<int>>(m_rng, first, last);
     }
 };
 
@@ -92,6 +133,9 @@ void Gen::Random::configure(const WireCell::Configuration& cfg)
     else if (gen == "twister") {
         m_pimpl = new RandomT<std::mt19937>(m_seeds);
     }
+    else if (gen == "") {
+        m_pimpl = new RandomT<std::mt19937>(m_seeds);
+    }
     else {
         warn("Gen::Random::configure: warning: unknown random engine: \"{}\" using default", gen);
         m_pimpl = new RandomT<std::default_random_engine>(m_seeds);
@@ -112,11 +156,15 @@ WireCell::Configuration Gen::Random::default_configuration() const
 
 int Gen::Random::binomial(int max, double prob) { return m_pimpl->binomial(max, prob); }
 int Gen::Random::poisson(double mean) { return m_pimpl->poisson(mean); }
-
 double Gen::Random::normal(double mean, double sigma) { return m_pimpl->normal(mean, sigma); }
-
 double Gen::Random::uniform(double begin, double end) { return m_pimpl->uniform(begin, end); }
-
 double Gen::Random::exponential(double mean) { return m_pimpl->exponential(mean); }
-
 int Gen::Random::range(int first, int last) { return m_pimpl->range(first, last); }
+
+
+IRandom::int_func Gen::Random::make_binomial(int max, double prob) { return m_pimpl->make_binomial(max, prob); }
+IRandom::int_func Gen::Random::make_poisson(double mean) { return m_pimpl->make_poisson(mean); }
+IRandom::double_func Gen::Random::make_normal(double mean, double sigma) { return m_pimpl->make_normal(mean, sigma); }
+IRandom::double_func Gen::Random::make_uniform(double begin, double end) { return m_pimpl->make_uniform(begin, end); }
+IRandom::double_func Gen::Random::make_exponential(double mean) { return m_pimpl->make_exponential(mean); }
+IRandom::int_func Gen::Random::make_range(int first, int last) { return m_pimpl->make_range(first, last); }

--- a/gen/test/test_empiricalnoisemodel.cxx
+++ b/gen/test/test_empiricalnoisemodel.cxx
@@ -1,0 +1,115 @@
+#include "WireCellAux/Testing.h"
+
+#include "WireCellIface/IChannelSpectrum.h"
+#include "WireCellIface/IChannelStatus.h"
+
+#include "WireCellUtil/Stream.h"
+#include "WireCellUtil/String.h"
+#include "WireCellUtil/Persist.h"
+
+#include <boost/crc.hpp>
+
+#include <unordered_set>
+
+using namespace WireCell;
+using namespace WireCell::Aux;
+using namespace WireCell::String;
+
+static
+std::ostream& dump_spectra(std::ostream& os, const std::string& fname)
+{
+    auto jspec = Persist::load(fname);
+
+    std::vector<int> planes, nsamples;
+    std::vector<float> periods, gains, shapings, wirelens, consts;
+    const int nspecs = jspec.size();
+    std::cerr << nspecs << " in " << fname << "\n";
+    for (int ind=0; ind<nspecs; ++ind) {
+        auto j = jspec[ind];
+        planes.push_back(j["plane"].asInt());
+        nsamples.push_back(j["nsamples"].asInt());
+        periods.push_back(j["period"].asFloat());
+        gains.push_back(j["gain"].asFloat());
+        shapings.push_back(j["shapings"].asFloat());
+        wirelens.push_back(j["wirelens"].asFloat());
+        consts.push_back(j["consts"].asFloat());
+        Stream::write(os, format("freqs_%03d.npy", ind), convert<std::vector<float>>(j["freqs"]));
+        Stream::write(os, format( "amps_%03d.npy", ind), convert<std::vector<float>>(j["amps"]));
+        std::cerr << "\t nsamples:" << nsamples.back() << " size=" << j["freqs"].size() << "\n";
+    }
+    std::cerr << "\t nplanes:" << planes.size() << "\n";
+    Stream::write(os, "planes.npy", planes);
+    Stream::write(os, "nsamples.npy", nsamples);
+    Stream::write(os, "periods.npy", periods);
+    Stream::write(os, "gains.npy", gains);
+    Stream::write(os, "shapings.npy", shapings);
+    Stream::write(os, "wirelens.npy", wirelens);
+    Stream::write(os, "consts.npy", consts);
+    return os;
+}
+
+int main(int argc, char* argv[])
+{
+    Testing::loginit(argv[0]);
+
+    auto rng = Testing::get_random();
+    auto dft = Testing::get_dft();
+
+    Stream::filtering_ostream out;
+    // fixme: need PR #163 merged to save as .npz
+    std::string outfile = argc > 1 ? argv[1] : std::string(argv[0]) + ".tar";
+    Stream::output_filters(out, outfile);
+    
+    std::string spectra_file = "protodune-noise-spectra-v1.json.bz2";
+    dump_spectra(out, spectra_file);
+
+    size_t nsamples = 2000;     // explicitly NOT an FFT "best" length
+
+    auto anodes = Testing::anodes("pdsp");
+    Testing::get_default<IChannelStatus>("StaticChannelStatus");
+    {
+        auto ienm = Factory::lookup<IConfigurable>("EmpiricalNoiseModel");
+        auto cfg = ienm->default_configuration();
+        cfg["spectra_file"] = spectra_file;
+        cfg["nsamples"] = nsamples;
+        cfg["period"] = 0.5*units::us;
+        cfg["wire_length_scale"] = units::cm,
+        cfg["anode"] = "AnodePlane:0";
+        cfg["dft"] = "FftwDFT";
+        cfg["chanstat"] = "StaticChannelStatus";
+        ienm->configure(cfg);
+    }
+    auto enm = Factory::find<IChannelSpectrum>("EmpiricalNoiseModel");
+
+    std::map<uint32_t, IChannelSpectrum::amplitude_t> amps;
+
+    for (auto chid : anodes[0]->channels()) {
+        const auto& spec = (*enm)(chid);
+        if (spec.size() != nsamples) {
+            std::cerr << "EmpiricalNoiseModel is broken: ask for " << nsamples << " got " << spec.size() << "\n";
+        }
+        //assert(spec.size() == nsamples);
+
+        // We do this craziness because SOMEONE violated the
+        // IChannelSpectrum API and return always the same vector.
+        boost::crc_32_type crc;
+        for (const auto& amp : spec) {
+            crc.process_bytes(&amp, sizeof(float));
+        }
+        auto key = crc.checksum();
+        amps[key] = spec;
+    }
+    std::cerr << "Got " << amps.size() << " unique spectra\n";
+    int count=0;
+    for (const auto& [key,amp] : amps) {
+        std::cerr << "Writing spec of size: " << amp.size() << "\n";
+        Stream::write(out, format("chspec_%03d.npy", count), amp);
+        ++count;
+    }
+
+    out.flush();
+    out.pop();
+    std::cerr << "May now wish to run:\n";
+    std::cerr << "wirecell-test plot -n empiricalnoisemodel " << outfile << " test_empiricalnoisemodel.pdf\n";
+    return 0;
+}

--- a/gen/test/test_noise.cxx
+++ b/gen/test/test_noise.cxx
@@ -1,0 +1,212 @@
+// A toy noise sim that makes a round trip.
+
+#include "WireCellAux/DftTools.h"
+#include "WireCellAux/FftwDFT.h"
+#include "WireCellUtil/Stream.h"
+#include "WireCellUtil/String.h"
+#include "WireCellUtil/Interpolate.h"
+
+#include <map>
+#include <random>
+
+using namespace WireCell;
+using namespace WireCell::Aux;
+using namespace WireCell::String;
+
+// An ordered map from abscissa to ordinate
+using points_t = std::map<float,float>;
+
+// Given a spectrum in the form of irregularly sampled points return a
+// spectrum of "nsamples" regularly sampled points.  Only frequencies
+// up to the central "Fnyquist" Nyquist frequency are filled, the
+// remaining are zero.  Linear interpolation and constant
+// extrapolation will be performed on the input spectrum.
+real_vector_t sample_spectrum(const points_t& half_spec,
+                              size_t nsamples, float Fnyquist)
+{
+    irrterp<float> terp(half_spec.begin(), half_spec.end());
+    real_vector_t ret(nsamples, 0);
+
+    float df = 2*Fnyquist / nsamples;
+
+    size_t nhalf = nsamples/2;
+    if (nsamples % 2 == 0) {
+        ++nhalf;
+    }
+    terp(ret.begin(), nhalf, 0, df);
+    return ret;
+}
+
+// Model a made up noise spectrum
+float fictional_spectrum(float freq, float Fnyquist = 1.0)
+{
+    // fold frequency to be between 0 and Fnyquist
+    while (freq > Fnyquist) {
+        freq -= 2*Fnyquist;
+    }
+    freq = std::abs(freq);
+    return 4000*freq*freq * exp(-20*freq);
+}
+
+// Component code should NEVER have such a struct.  Once Random is
+// moved to Aux we can use it instead of this quick and dirty stand
+// replica.
+struct RNG {
+    std::random_device rd;
+    std::mt19937 gen;
+    std::uniform_real_distribution<float> _freq;
+    std::normal_distribution<float> _normal;
+
+    RNG(float Fnyquist) : gen(rd()), _freq(0,Fnyquist) { }
+
+    float frequency() { return _freq(gen); }
+    float normal() { return _normal(gen); }
+};
+
+// Pretend to "digitize" a spectrum from some printed plot by
+// selecting values at random points.  Number of points presumably ifs
+// far smaller than eventually required to make waveforms.
+points_t digitize_spectrum(RNG& rng, size_t npoints=128, float Fnyquist=1.0)
+{
+    points_t ret;
+    for (size_t count=0; count<npoints; ++count) {
+        float freq = rng.frequency();
+        float amp = fictional_spectrum(freq, Fnyquist);
+        ret[freq] = amp;
+    }
+    return ret;
+}
+
+// Generate a fluctuated spectrum with Hermitian symmetry the input
+// average spectrum.  The input is assumed to span the entire
+// frequency domain however only the first half is considered.
+complex_vector_t generate_hermitian_spectrum(RNG& rng, const real_vector_t& avgspec)
+{
+    const size_t nsamples = avgspec.size();
+    complex_vector_t spec(nsamples);
+    size_t ndo = nsamples/2;
+    if (nsamples%2 == 0) ++ndo;
+
+    for (size_t ind=0; ind<ndo; ++ind) {
+        spec[ind] = std::complex(avgspec[ind]*rng.normal(), avgspec[ind]*rng.normal());
+    }
+    hermitian_symmetry_inplace(spec);
+    return spec;
+}
+
+
+// Generate a noise waveform from a fluctuated spectrum.
+real_vector_t spec_to_wave(IDFT::pointer& dft, const complex_vector_t& spec)
+{
+    // "real" code would inject an IDFT.
+    auto wave = inv_c2r(dft, spec);
+
+    size_t nsamples = spec.size();
+    const float mean_to_mode = sqrt(2/3.141592);
+    for (size_t ind=0; ind<nsamples; ++ind) {
+        wave[ind] *= mean_to_mode;
+    }
+    return wave;
+}
+
+
+// A progressive collector of average so we need not load all waves
+// into memory.
+class SpectralAverage {
+    IDFT::pointer dft;
+    real_vector_t total;
+    size_t count{0};
+  public:
+    SpectralAverage(IDFT::pointer dft, size_t nsamples) : dft(dft), total(nsamples, 0) { }
+    void operator()(const real_vector_t& wave) {
+        // "real" code would inject an IDFT.
+        auto spec = fwd_r2c(dft, wave);
+        const size_t nsamples = total.size(); 
+        for (size_t ind=0; ind<nsamples; ++ind) {
+            total[ind] += std::abs(spec[ind]); // ortho/nsamples-norm?
+        }
+        ++count;
+    }
+    real_vector_t mean() {
+        real_vector_t avg(total.begin(), total.end());
+        const size_t nsamples = total.size(); 
+        for (size_t ind=0; ind<nsamples; ++ind) {
+            avg[ind] /= count;
+        }
+        return avg;
+    }
+};
+
+
+std::ostream& doit(std::ostream& os,     // dump results
+                   RNG& rng, IDFT::pointer dft,
+                   size_t nsamples=1024, // frequency bins / ticks
+                   size_t npoints=128,   // points in input spectrum
+                   size_t nwaves = 1000, // number of wavesforms to generate
+                   float Fnyquist=1.0)   // Nyquist frequency
+{
+    real_vector_t freqs(nsamples);
+    float dfreq = 2*Fnyquist/nsamples;
+    for (size_t ind=0; ind<nsamples; ++ind) {
+        freqs[ind] = dfreq * ind;
+    }
+    Stream::write(os, "freqs.npy", freqs);
+
+    auto sampled_spectrum = digitize_spectrum(rng, npoints, Fnyquist);
+    std::vector<float> ss_freq, ss_spec;
+    for (const auto& [f,a] : sampled_spectrum) {
+        ss_freq.push_back(f);
+        ss_spec.push_back(a);
+    }
+    Stream::write(os, "ss_freq.npy", ss_freq);
+    Stream::write(os, "ss_spec.npy", ss_spec);
+
+    auto true_spectrum = sample_spectrum(sampled_spectrum, nsamples, Fnyquist);
+    assert(true_spectrum.size() == nsamples);
+    Stream::write(os, "true_spectrum.npy", true_spectrum);
+
+    for (size_t iwave=0; iwave<5; ++iwave) {
+        auto sampled_spectrum = generate_hermitian_spectrum(rng, true_spectrum);
+        auto wave = spec_to_wave(dft, sampled_spectrum);
+        Stream::write(os, format("example_wave%d.npy", iwave), wave);
+    }
+    SpectralAverage sa(dft, nsamples);
+    for (size_t iwave=0; iwave<nwaves; ++iwave) {
+        auto sampled_spectrum = generate_hermitian_spectrum(rng, true_spectrum);
+        auto wave = spec_to_wave(dft, sampled_spectrum);
+        sa(wave);
+    }
+    Stream::write(os, "average_spectrum.npy", sa.mean());
+    
+    return os;
+}
+
+
+int main(int argc, char* argv[])
+{
+
+    std::string outfile = argv[0];
+    outfile += ".tar";          // fixme: need PR #163 merged to save as .npz
+    if (argc > 1) {
+        outfile = argv[1];
+    }
+
+    Stream::filtering_ostream out;
+    Stream::output_filters(out, outfile);
+    
+    const size_t nsamples = 1024;
+    const size_t npoints = 128;
+    const size_t nwaves = 1000;
+    const float Fnyquist = 1.0;
+
+    // Component code should NEVER explicitly make these kind of
+    // things.  Use IDFT and IRandom instead.
+    RNG rng(Fnyquist);
+    auto dft = std::make_shared<FftwDFT>();
+
+    doit(out, rng, dft, nsamples, npoints, nwaves, Fnyquist);
+
+    out.pop();
+    std::cerr << outfile << std::endl;
+    return 0;
+}

--- a/gen/test/test_noise.cxx
+++ b/gen/test/test_noise.cxx
@@ -1,10 +1,17 @@
 // A toy noise sim that makes a round trip.
 
 #include "WireCellAux/DftTools.h"
-#include "WireCellAux/FftwDFT.h"
+#include "WireCellAux/RandTools.h"
+#include "WireCellAux/Spectra.h"
+
+#include "WireCellIface/IConfigurable.h"
+
 #include "WireCellUtil/Stream.h"
 #include "WireCellUtil/String.h"
 #include "WireCellUtil/Interpolate.h"
+#include "WireCellUtil/PluginManager.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/TimeKeeper.h"
 
 #include <map>
 #include <random>
@@ -48,98 +55,153 @@ float fictional_spectrum(float freq, float Fnyquist = 1.0)
     return 4000*freq*freq * exp(-20*freq);
 }
 
-// Component code should NEVER have such a struct.  Once Random is
-// moved to Aux we can use it instead of this quick and dirty stand
-// replica.
-struct RNG {
-    std::random_device rd;
-    std::mt19937 gen;
-    std::uniform_real_distribution<float> _freq;
-    std::normal_distribution<float> _normal;
-
-    RNG(float Fnyquist) : gen(rd()), _freq(0,Fnyquist) { }
-
-    float frequency() { return _freq(gen); }
-    float normal() { return _normal(gen); }
-};
-
 // Pretend to "digitize" a spectrum from some printed plot by
 // selecting values at random points.  Number of points presumably ifs
 // far smaller than eventually required to make waveforms.
-points_t digitize_spectrum(RNG& rng, size_t npoints=128, float Fnyquist=1.0)
+points_t digitize_spectrum(IRandom::pointer rng, size_t npoints=128, float Fnyquist=1.0)
 {
     points_t ret;
     for (size_t count=0; count<npoints; ++count) {
-        float freq = rng.frequency();
+        float freq = rng->uniform(0, Fnyquist);
         float amp = fictional_spectrum(freq, Fnyquist);
         ret[freq] = amp;
     }
     return ret;
 }
 
-// Generate a fluctuated spectrum with Hermitian symmetry the input
-// average spectrum.  The input is assumed to span the entire
-// frequency domain however only the first half is considered.
-complex_vector_t generate_hermitian_spectrum(RNG& rng, const real_vector_t& avgspec)
+
+
+real_vector_t make_true(IRandom::pointer rng,
+                        size_t nsamples=1024, size_t npoints=128, float Fnyquist=1.0)
 {
-    const size_t nsamples = avgspec.size();
-    complex_vector_t spec(nsamples);
-    size_t ndo = nsamples/2;
-    if (nsamples%2 == 0) ++ndo;
-
-    for (size_t ind=0; ind<ndo; ++ind) {
-        spec[ind] = std::complex(avgspec[ind]*rng.normal(), avgspec[ind]*rng.normal());
-    }
-    hermitian_symmetry_inplace(spec);
-    return spec;
-}
-
-
-// Generate a noise waveform from a fluctuated spectrum.
-real_vector_t spec_to_wave(IDFT::pointer& dft, const complex_vector_t& spec)
-{
-    // "real" code would inject an IDFT.
-    auto wave = inv_c2r(dft, spec);
-
-    size_t nsamples = spec.size();
-    const float mean_to_mode = sqrt(2/3.141592);
+    real_vector_t freqs(nsamples);
+    float dfreq = 2*Fnyquist/nsamples;
     for (size_t ind=0; ind<nsamples; ++ind) {
-        wave[ind] *= mean_to_mode;
+        freqs[ind] = dfreq * ind;
     }
-    return wave;
+    auto sampled_spectrum = digitize_spectrum(rng, npoints, Fnyquist);
+    auto true_spectrum = sample_spectrum(sampled_spectrum, nsamples, Fnyquist);
+    return true_spectrum;
+}
+
+// This is a copy of what was once in gen/src/Noise.cxx
+static
+void old_generate_spectrum(const std::vector<float>& spec, IRandom::pointer rng, double replace)
+{
+    // reuse randomes a bit to optimize speed.
+    static std::vector<double> random_real_part;
+    static std::vector<double> random_imag_part;
+
+    if (random_real_part.size() != spec.size()) {
+        random_real_part.resize(spec.size(), 0);
+        random_imag_part.resize(spec.size(), 0);
+        for (unsigned int i = 0; i < spec.size(); i++) {
+            random_real_part.at(i) = rng->normal(0, 1);
+            random_imag_part.at(i) = rng->normal(0, 1);
+        }
+    }
+    else {
+        const int shift1 = rng->uniform(0, random_real_part.size());
+        // replace certain percentage of the random number
+        const int step = 1. / replace;
+        for (int i = shift1; i < shift1 + int(spec.size()); i += step) {
+            if (i < int(spec.size())) {
+                random_real_part.at(i) = rng->normal(0, 1);
+                random_imag_part.at(i) = rng->normal(0, 1);
+            }
+            else {
+                random_real_part.at(i - spec.size()) = rng->normal(0, 1);
+                random_imag_part.at(i - spec.size()) = rng->normal(0, 1);
+            }
+        }
+    }
+
+    const int shift = rng->uniform(0, random_real_part.size());
+
+    WireCell::Waveform::compseq_t noise_freq(spec.size(), 0);
+
+    for (int i = shift; i < int(spec.size()); i++) {
+        const double amplitude = spec.at(i - shift) * sqrt(2. / 3.1415926);  // / units::mV;
+        noise_freq.at(i - shift).real(random_real_part.at(i) * amplitude);
+        noise_freq.at(i - shift).imag(random_imag_part.at(i) * amplitude);  //= complex_t(real_part,imag_part);
+    }
+    for (int i = 0; i < shift; i++) {
+        const double amplitude = spec.at(i + int(spec.size()) - shift) * sqrt(2. / 3.1415926);
+        noise_freq.at(i + int(spec.size()) - shift).real(random_real_part.at(i) * amplitude);
+        noise_freq.at(i + int(spec.size()) - shift).imag(random_imag_part.at(i) * amplitude);
+    }
+
+    return noise_freq;
 }
 
 
-// A progressive collector of average so we need not load all waves
-// into memory.
-class SpectralAverage {
-    IDFT::pointer dft;
-    real_vector_t total;
-    size_t count{0};
-  public:
-    SpectralAverage(IDFT::pointer dft, size_t nsamples) : dft(dft), total(nsamples, 0) { }
-    void operator()(const real_vector_t& wave) {
-        // "real" code would inject an IDFT.
-        auto spec = fwd_r2c(dft, wave);
-        const size_t nsamples = total.size(); 
-        for (size_t ind=0; ind<nsamples; ++ind) {
-            total[ind] += std::abs(spec[ind]); // ortho/nsamples-norm?
-        }
-        ++count;
+void test_time(IRandom::pointer rng,
+               IDFT::pointer dft,
+               size_t nsamples=1024, // frequency bins / ticks
+               size_t nwaves = 100000, // number of wavesforms to generate
+               size_t npoints = 128,
+               float Fnyquist=1.0)   // Nyquist frequency
+{
+    RecyclingNormals rn(rng);
+    FreshNormals fn(rng);
+
+    auto true_spectrum = make_true(rng, nsamples, npoints, Fnyquist);
+    WaveGenerator rwgen(dft, rn, true_spectrum);
+    WaveGenerator fwgen(dft, fn, true_spectrum);
+
+    TimeKeeper tk("wave generator");
+    for (size_t iwave=0; iwave<nwaves; ++iwave) {
+        auto spec = old_generate_spectrum(true_spectrum, rng);
+        auto wave = Aux::inv_c2r(dft, spec);
+        wave.clear();
     }
-    real_vector_t mean() {
-        real_vector_t avg(total.begin(), total.end());
-        const size_t nsamples = total.size(); 
-        for (size_t ind=0; ind<nsamples; ++ind) {
-            avg[ind] /= count;
-        }
-        return avg;
+    tk("old noise");
+
+    for (size_t iwave=0; iwave<nwaves; ++iwave) {
+        auto junk = rwgen.wave();
+        junk.clear();
     }
-};
+    tk("recycling");
+
+    for (size_t iwave=0; iwave<nwaves; ++iwave) {
+        auto junk = fwgen.wave();
+        junk.clear();
+    }
+// before closure:
+// default
+// TICK: 0 ms (this: 0 ms) wave generator
+// TICK: 183 ms (this: 183 ms) recycling
+// TICK: 749 ms (this: 565 ms) fresh
+// 
+// twister
+// TICK: 0 ms (this: 0 ms) wave generator
+// TICK: 186 ms (this: 186 ms) recycling
+// TICK: 1027 ms (this: 841 ms) fresh
+
+// after closure:
+// default
+// TICK: 0 ms (this: 0 ms) wave generator
+// TICK: 182 ms (this: 182 ms) recycling
+// TICK: 523 ms (this: 340 ms) fresh
+
+// twister
+// TICK: 0 ms (this: 0 ms) wave generator
+// TICK: 182 ms (this: 182 ms) recycling
+// TICK: 653 ms (this: 471 ms) fresh
+    
+// 1.6x speedup for default fresh.
+
+    tk("fresh");
+    std::cerr << tk.summary() << std::endl;
+
+
+}
+
 
 
 std::ostream& doit(std::ostream& os,     // dump results
-                   RNG& rng, IDFT::pointer dft,
+                   IRandom::pointer rng,
+                   IDFT::pointer dft,
                    size_t nsamples=1024, // frequency bins / ticks
                    size_t npoints=128,   // points in input spectrum
                    size_t nwaves = 1000, // number of wavesforms to generate
@@ -165,25 +227,74 @@ std::ostream& doit(std::ostream& os,     // dump results
     assert(true_spectrum.size() == nsamples);
     Stream::write(os, "true_spectrum.npy", true_spectrum);
 
-    for (size_t iwave=0; iwave<5; ++iwave) {
-        auto sampled_spectrum = generate_hermitian_spectrum(rng, true_spectrum);
-        auto wave = spec_to_wave(dft, sampled_spectrum);
-        Stream::write(os, format("example_wave%d.npy", iwave), wave);
+    // We want a ring buffer size which is larger than and coprime
+    // with the size we will eventually sample.  In this way each
+    // sampling will be at a "random" starting point.
+    const size_t not_nsamples = nearest_coprime(2*nsamples, 1.7*nsamples);
+    // const size_t not_nsamples = nsamples;
+    const double replacement_fraction = 0.02;
+    const size_t nexample = 100;
+    {
+        RecyclingNormals rn(rng, not_nsamples, replacement_fraction);
+        WaveGenerator wavegen(dft, rn, true_spectrum);
+        for (size_t iwave=0; iwave<nexample; ++iwave) {
+            auto wave = wavegen.wave();
+            Stream::write(os, format("recycled_wave%03d.npy", iwave), wave);
+        }
+
+        WaveCollector wavecol(dft);
+        for (size_t iwave=0; iwave<nwaves; ++iwave) {
+            wavecol.add(wavegen.wave());
+        }
+        Stream::write(os, "recycled_spectrum.npy", wavecol.mean());
     }
-    SpectralAverage sa(dft, nsamples);
-    for (size_t iwave=0; iwave<nwaves; ++iwave) {
-        auto sampled_spectrum = generate_hermitian_spectrum(rng, true_spectrum);
-        auto wave = spec_to_wave(dft, sampled_spectrum);
-        sa(wave);
+    {
+        FreshNormals fn(rng);
+        WaveGenerator wavegen(dft, fn, true_spectrum);
+        for (size_t iwave=0; iwave<nexample; ++iwave) {
+            auto wave = wavegen.wave();
+            Stream::write(os, format("fresh_wave%03d.npy", iwave), wave);
+        }
+
+        WaveCollector wavecol(dft);
+        for (size_t iwave=0; iwave<nwaves; ++iwave) {
+            wavecol.add(wavegen.wave());
+        }
+        Stream::write(os, "fresh_spectrum.npy", wavecol.mean());
     }
-    Stream::write(os, "average_spectrum.npy", sa.mean());
-    
+    { // old noise
+        for (size_t iwave=0; iwave<nexample; ++iwave) {
+            auto spec = old_generate_spectrum(true_spectrum, rng);
+            auto wave = Aux::inv_c2r(dft, spec);
+            Stream::write(os, format("oldnoise_wave%03d.npy", iwave), wave);
+        }
+        WaveCollector wavecol(dft);
+        for (size_t iwave=0; iwave<nwaves; ++iwave) {
+            auto spec = old_generate_spectrum(true_spectrum, rng);
+            auto wave = Aux::inv_c2r(dft, spec);
+            wavecol.add(wave);
+        }
+        Stream::write(os, "oldnoise_spectrum.npy", wavecol.mean());
+    }
+
     return os;
 }
 
+IRandom::pointer getran(std::string name)
+{
+    auto rngcfg = Factory::lookup<IConfigurable>("Random", name);
+    auto cfg = rngcfg->default_configuration();
+    cfg["generator"] = name;    // default or twister
+    rngcfg->configure(cfg);
+    return Factory::lookup<IRandom>("Random", name);
+}
 
 int main(int argc, char* argv[])
 {
+    PluginManager& pm = PluginManager::instance();
+    pm.add("WireCellGen");
+    auto rng = getran("default");
+    auto dft = Factory::lookup<IDFT>("FftwDFT");
 
     std::string outfile = argv[0];
     outfile += ".tar";          // fixme: need PR #163 merged to save as .npz
@@ -196,17 +307,26 @@ int main(int argc, char* argv[])
     
     const size_t nsamples = 1024;
     const size_t npoints = 128;
-    const size_t nwaves = 1000;
+    const size_t nwaves = 2000;
     const float Fnyquist = 1.0;
-
-    // Component code should NEVER explicitly make these kind of
-    // things.  Use IDFT and IRandom instead.
-    RNG rng(Fnyquist);
-    auto dft = std::make_shared<FftwDFT>();
 
     doit(out, rng, dft, nsamples, npoints, nwaves, Fnyquist);
 
+    // Note, I temporarily defined all those that the C++ standard
+    // gives us and default, which seems to be twister 64 is
+    // fastelst., "mt19937_64", "minstd0", "minstd", "ranlux24",
+    // "ranlux24_base", "ranlux48", "ranlux48_base", "knuth"
+    std::vector<std::string> rnames = {
+        "default", "twister"
+    };
+    const size_t nwaves_speed = 10000;
+    for (const auto& rname: rnames) {
+        auto rng2 = getran(rname);
+        std::cerr << rname << std::endl;
+        test_time(rng2, dft, nsamples, nwaves_speed, npoints, Fnyquist);
+    }
+
     out.pop();
-    std::cerr << outfile << std::endl;
+    std::cerr << "wirecell-test noise " << outfile << " test_noise.pdf" << std::endl;
     return 0;
 }

--- a/gen/test/test_noise.py
+++ b/gen/test/test_noise.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# this holds a few ugly hacks.  nicer stuff in wire-cell-python.
+
+import io
+import sys
+import numpy
+import pathlib
+import tarfile
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+
+try:
+    tfpath = sys.argv[1]
+except IndexError:
+    p = pathlib.Path(__file__)
+    tfpath = p.parent.parent.parent / "build" / "gen" / "test_noise.tar"
+assert(tfpath.exists())
+
+
+tf = tarfile.open(tfpath)
+def get(name):
+    dat = tf.extractfile(name + ".npy").read()
+    a = io.BytesIO()
+    a.write(dat)
+    a.seek(0)
+    return numpy.load(a)
+
+
+
+ss_freq = get("ss_freq")
+ss_spec = get("ss_spec")
+
+freqs = get("freqs")
+spec = get("true_spectrum")
+aspec = get("average_spectrum")
+
+pdfpath = tfpath.parent / (tfpath.stem + ".pdf")
+with PdfPages(pdfpath) as pdf:
+
+    fig,ax = plt.subplots(1,1)
+    ax.plot(freqs, spec)
+    ax.plot(ss_freq, ss_spec)
+    pdf.savefig(fig)
+    plt.close()
+
+    fig,ax = plt.subplots(1,1)
+    for ind in range(5):
+        w = get(f'example_wave{ind}')
+        plt.plot(w)
+    pdf.savefig(fig)
+    plt.close()
+
+    fig,ax = plt.subplots(1,1)
+    ax.plot(freqs, aspec, label="mean")
+    ax.plot(freqs, spec, label="true")
+    fig.legend()
+    pdf.savefig(fig)
+    plt.close()
+
+    
+print(str(pdfpath))

--- a/iface/inc/WireCellIface/IRandom.h
+++ b/iface/inc/WireCellIface/IRandom.h
@@ -1,3 +1,24 @@
+/** IRandom - interface to random number generators.
+
+    WCT code should be given an IRandom instead of directly using any
+    lower level random number services. 
+
+    The IRandom API provides generation of values from various
+    distributions.  Each distribution has a pair of methods:
+
+    The "immediate" methods directly return a random value and the
+    "callable" methods return function object that when called will
+    return a random value.
+
+    When a distribution with particular parameters must be sampled
+    repeatedly doing so through a "callable" may be faster than using
+    the corresponding "immediate" method.
+
+    Note, to gain any speed up, the IRandom implementation must
+    explicitly implement these "callable" methods.  
+
+ */
+
 #ifndef WIRECELL_IRANDOM
 #define WIRECELL_IRANDOM
 
@@ -10,23 +31,32 @@ namespace WireCell {
        public:
         virtual ~IRandom();
 
+        using int_func = std::function<int()>;
+        using double_func = std::function<double()>;
+
         /// Sample a binomial distribution
         virtual int binomial(int max, double prob) = 0;
+        virtual int_func make_binomial(int max, double prob);
 
         /// Sample a Poisson distribution.
         virtual int poisson(double mean) = 0;
+        virtual int_func make_poisson(double mean);
 
         /// Sample a normal distribution.
         virtual double normal(double mean, double sigma) = 0;
+        virtual double_func make_normal(double mean, double sigma);
 
         /// Sample a uniform distribution
         virtual double uniform(double begin, double end) = 0;
+        virtual double_func make_uniform(double begin, double end);
 
         /// Sample an exponential distribution
         virtual double exponential(double mean) = 0;
+        virtual double_func make_exponential(double mean);
 
         /// Sample a uniform integer range.
         virtual int range(int first, int last) = 0;
+        virtual int_func make_range(int first, int last);
     };
 
 }  // namespace WireCell

--- a/iface/src/IRandom.cxx
+++ b/iface/src/IRandom.cxx
@@ -1,0 +1,43 @@
+#include "WireCellIface/IRandom.h"
+
+#include <functional>
+
+using namespace WireCell;
+
+IRandom::~IRandom() {}
+
+// We implement default closures around the abstract implementation.
+// Concrete implementations (see Random) are encouraged to return
+// closures around a generator in order that subsequent calls need not
+// constantly construct it anew.
+
+IRandom::int_func IRandom::make_binomial(int max, double prob)
+{
+    return std::bind(&IRandom::binomial, this, max, prob);
+}
+
+IRandom::int_func IRandom::make_poisson(double mean)
+{
+    return std::bind(&IRandom::poisson, this, mean);
+}
+
+IRandom::double_func IRandom::make_normal(double mean, double sigma)
+{
+    return std::bind(&IRandom::normal, this, mean, sigma);
+}
+
+IRandom::double_func IRandom::make_uniform(double begin, double end)
+{
+    return std::bind(&IRandom::uniform, this, begin, end);
+}
+
+IRandom::double_func IRandom::make_exponential(double mean)
+{
+    return std::bind(&IRandom::exponential, this, mean);
+}
+    
+IRandom::int_func IRandom::make_range(int first, int last)
+{
+    return std::bind(&IRandom::range, this, first, last);
+}
+

--- a/iface/src/IfaceDesctructors.cxx
+++ b/iface/src/IfaceDesctructors.cxx
@@ -71,7 +71,6 @@
 #include "WireCellIface/IProcessor.h"
 #include "WireCellIface/IQueuedoutNode.h"
 #include "WireCellIface/IQueuedoutNode.h"
-#include "WireCellIface/IRandom.h"
 #include "WireCellIface/IRecombinationModel.h"
 #include "WireCellIface/IScalarFieldSink.h"
 #include "WireCellIface/ISemaphore.h"
@@ -171,7 +170,6 @@ IPlaneImpactResponse::~IPlaneImpactResponse() {}
 IPointFieldSink::~IPointFieldSink() {}
 IProcessor::~IProcessor() {}
 IQueuedoutNodeBase::~IQueuedoutNodeBase() {}
-IRandom::~IRandom() {}
 IRecombinationModel::~IRecombinationModel() {}
 IScalarFieldSink::~IScalarFieldSink() {}
 ISemaphore::~ISemaphore() {}

--- a/root/test/test_fieldresp.cxx
+++ b/root/test/test_fieldresp.cxx
@@ -110,7 +110,7 @@ int main(int argc, char* argv[])
 
         // do FFT for response ...
         // Array::array_xxc c_data = Array::dft_rc(arr, 0);
-        Array::array_xxc c_data = Aux::fwd(idft, arr.cast<IDFT::complex_t>(), 1);
+        Array::array_xxc c_data = Aux::fwd_r2c(idft, arr, 1);
         int nrows = c_data.rows();
         int ncols = c_data.cols();
 
@@ -121,7 +121,7 @@ int main(int argc, char* argv[])
         }
 
         // arr = Array::idft_cr(c_data, 0);
-        arr = Aux::inv(idft, c_data, 1).real();
+        arr = Aux::inv_c2r(idft, c_data, 1);
 
         // figure out how to do fine ... shift (good ...)
         auto arr1 = arr.block(0, 0, nrows, 100);

--- a/sig/src/Decon2DFilter.cxx
+++ b/sig/src/Decon2DFilter.cxx
@@ -118,8 +118,7 @@ bool Sig::Decon2DFilter::operator()(const ITensorSet::pointer &in, ITensorSet::p
     }
 
     // do the second round of inverse FFT on wire
-    Array::array_xxf tm_r_data = Aux::inv(m_dft, c_data_afterfilter, 1).real();
-
+    Array::array_xxf tm_r_data = Aux::inv_c2r(m_dft, c_data_afterfilter, 1);
     Array::array_xxf r_data = tm_r_data.block(m_pad_nwires, 0, m_nwires, m_nticks);
     Sig::restore_baseline(r_data);
 

--- a/util/inc/WireCellUtil/Configuration.h
+++ b/util/inc/WireCellUtil/Configuration.h
@@ -108,10 +108,19 @@ namespace WireCell {
         std::vector<int>
         convert<std::vector<int> >(const Configuration& cfg, const std::vector<int>& def)
     {
-        std::vector<int> ret;
-        for (auto v : cfg) {
-            ret.push_back(convert<int>(v));
-        }
+        std::vector<int> ret(cfg.size());
+        std::transform(cfg.begin(), cfg.end(), ret.begin(),
+                       [](const auto& e) { return e.asInt(); });
+        return ret;
+    }
+    template <>
+    inline  // fixme: ignores default
+        std::vector<float>
+        convert<std::vector<float> >(const Configuration& cfg, const std::vector<float>& def)
+    {
+        std::vector<float> ret(cfg.size());
+        std::transform(cfg.begin(), cfg.end(), ret.begin(),
+                       [](const auto& e) { return e.asFloat(); });
         return ret;
     }
     template <>
@@ -119,10 +128,9 @@ namespace WireCell {
         std::vector<double>
         convert<std::vector<double> >(const Configuration& cfg, const std::vector<double>& def)
     {
-        std::vector<double> ret;
-        for (auto v : cfg) {
-            ret.push_back(convert<double>(v));
-        }
+        std::vector<double> ret(cfg.size());
+        std::transform(cfg.begin(), cfg.end(), ret.begin(),
+                       [](const auto& e) { return e.asDouble(); });
         return ret;
     }
     // for Point and Ray converters, see Point.h

--- a/util/inc/WireCellUtil/Interpolate.h
+++ b/util/inc/WireCellUtil/Interpolate.h
@@ -1,54 +1,237 @@
 /**
    Interpolationn helpers.
 
+   - irrterp :: interpolate on irregular samples (note: slow for point interpolation, but okay for sequence)
+
+   - linterp :: interpolate on regular samples (fast for point or sequence).
+
+   Example usage:
+
+   // For either
+   using X = float;
+   using Y = float;
+
+   X xstart = 0.0;
+   X xstep = 1.0;
+
+   // for irrterp
+   using collection_t = std::map<X,Y>;
+   collection_t col = ...;
+   irrterp terp(col.begin(), col.end());
+
+   // for linterp
+   using collection_t = std::vector<Y>;
+   collection_t col = ...;
+   X x0=0, xstep=42;
+   linterp terp(col.begin(), col.end(), x0, xstep);
+
+   // for either - point interpolation
+   X x = 6.9;
+   Y y = terp(x);
+
+   // for either - sequence interpolation
+   std::vector<Y> ys;
+   size_t num=10;
+   X xstart=0, xstep=0.1;
+   terp(std::back_inserter(ys), num, xstart, xstep);
+   cerr << "filled " << std::distance(ys.begin(), end) << "\n";
+
    See test_interpolate.cxx.
  */
 
 #ifndef WIRECELLUTIL_INTERPOLATE
 #define WIRECELLUTIL_INTERPOLATE
 
+#include <map>
+#include <cmath>
 #include <vector>
+#include <stdexcept>
+	
+// c++20 has this defined in <cmath>.  For older language, here is the
+// naive implementation that has some corner cases.
+#if __cplusplus < 202000
+namespace std {
+    template<typename Real>
+    Real lerp(Real a, Real b, Real t) {
+        return a + t * (b - a);
+    }
+}
+#endif
 
 namespace WireCell {
+
+
+    /**
+       Linear interpolation on irregular sampling
+
+       Note, this is logarithmic in the number of points for single
+       point iteration.  
+
+     */
+    template <typename X, typename Y = X>
+    class irrterp {
+        std::map<X, Y> points;
+      public:
+        using xtype = X;
+        using ytype = Y;
+
+        template<typename PairIter>
+        irrterp(PairIter beg, PairIter end) : points(beg, end) {}
+
+        // This is logarithmic in #points.  Use sequence for faster
+        // regular sampling.
+        Y operator()(const X& x) {
+            if (points.empty()) {
+                throw std::logic_error("interpolation on empty sampling");
+            }
+            auto ub = points.upper_bound(x);
+            if (ub == points.begin()) {
+                return points.begin()->second;
+            }
+            if (ub == points.end()) {
+                return points.rbegin()->second;
+            }
+            auto lb = ub;
+            --lb;
+            const X dX = ub->first - lb->first;
+            const Y dY = ub->second - lb->second;
+            const X dx = x - lb->first;
+            return lb->second + dY * dx/dX;
+        }
+
+        // Insert num evenly spaced values between start and stop,
+        // inclusive.
+        template<typename OutputIterator>
+        OutputIterator operator()(OutputIterator out, size_t num,
+                                  const X& xstart, const X& xstep)
+        {
+            if (points.empty()) {
+                throw std::logic_error("interpolation on empty sampling");
+            }
+
+            // dispense with special cases
+            if (num == 0) {
+                return out;
+            }
+            if (num == 1) {
+                *out = (*this)(xstart);
+                ++out;
+                return out;
+            }
+
+            // Mark current X location
+            X xcur = xstart;
+
+            // We will assure loop always starts with ub above xcur.
+            auto ub = points.upper_bound(xcur);
+            while (num) {
+
+                // we are before the domain
+                if (ub == points.begin()) { 
+                    *out = ub->second;
+                    ++out;
+                    --num;
+                    xcur += xstep;
+                    while (xcur > ub->first) {
+                        ++ub;                        
+                        if (ub == points.end()) {
+                            break; // fell off domain
+                        }
+                    }
+                    continue;
+                }
+
+                // we are after the domain
+                if (ub == points.end()) { 
+                    *out = points.rbegin()->second;
+                    ++out; --num;
+                    xcur += xstep;
+                    continue;
+                }
+
+                // we are in the domain
+                auto lb = ub;
+                --lb;
+                // casts X to Y
+                Y delta = (xcur-lb->first) / (ub->first-lb->first);
+                *out = std::lerp(lb->second, ub->second, delta);
+                ++out; --num;
+                xcur += xstep;
+                while (xcur > ub->first) {
+                    ++ub;
+                    if (ub == points.end()) { 
+                        break;  // fell off domain
+                    } 
+                }
+            }
+            return out;
+        }
+    };
+    
+
 
     /**
        Use like:
 
-          linterp<double> lin(f.begin(), f.end(), x0, xstep);
+          linterp<double> lin(f.begin(), f.end(), x0, dx);
           ...
           double y = lin(42.0);
 
        where "f" is some kind of collection of doubles.
 
      */
-    template <class Real>
+    template <typename X, typename Y = X>
     class linterp {
        public:
-        template <class BidiIterator>
-        linterp(BidiIterator f, BidiIterator end_p, Real left_endpoint, Real step)
-          : m_dat(f, end_p)
-          , m_le(left_endpoint)
-          , m_step(step)
+        using xtype = X;
+        using ytype = Y;
+
+        template <class Iterator>
+        linterp(Iterator beg, Iterator end, X x0, X dx)
+          : m_dat(beg, end)
+          , m_le(x0)
+          , m_step(dx)
         {
             m_re = m_le + m_step * (m_dat.size() - 1);
         }
 
-        Real operator()(Real x) const
+        Y operator()(X x) const
         {
             if (x <= m_le) return m_dat.front();
             if (x >= m_re) return m_dat.back();
 
             int ind = int((x - m_le) / m_step);
-            Real y0 = m_dat[ind];
-            Real y1 = m_dat[ind + 1];
-            Real x0 = m_le + ind * m_step;
+            X x0 = m_le + ind * m_step;
+            // casts X to Y
+            Y delta = (x-x0)/m_step;
+            return std::lerp(m_dat[ind], m_dat[ind+1], delta);
+        }
 
-            return y0 + (x - x0) * (y1 - y0) / m_step;
+        template<typename OutputIterator>
+        OutputIterator operator()(OutputIterator out, size_t num,
+                                  const X& xstart, const X& xstep)
+        {
+            // dispense with special cases
+            if (num == 0) {
+                return out;
+            }
+            if (num == 1) {
+                *out = (*this)(xstart);
+                ++out;
+                return out;
+            }
+
+            for (size_t ind=0; ind<num; ++ind) {
+                const X xcur = xstart + ind*xstep;
+                *out = (*this)(xcur);
+                ++out;
+            }
+            return out;
         }
 
        private:
-        std::vector<Real> m_dat;
-        Real m_le, m_re, m_step;
+        std::vector<Y> m_dat;
+        X m_le, m_re, m_step;
     };
 
     /** You may also want to use Boost for fancier interpolation.

--- a/util/inc/WireCellUtil/Math.h
+++ b/util/inc/WireCellUtil/Math.h
@@ -1,0 +1,20 @@
+/** This API holds some general "mathy" stuff.
+ */
+
+#ifndef WIRECELL_UTIL_MATH
+#define WIRECELL_UTIL_MATH
+
+#include <algorithm>
+
+namespace WireCell {
+
+     // Return the greatest common denominator between a and b.
+     size_t GCD(size_t a, size_t b);
+
+     // Return coprime of number nearest to target or zero if none
+     // found smaller than number.  Search is bound by [0, number/2]
+     // or [number/2, number] depending on which half target is in.
+     size_t nearest_coprime(size_t number, size_t target);
+
+}
+#endif

--- a/util/inc/WireCellUtil/Stream.h
+++ b/util/inc/WireCellUtil/Stream.h
@@ -37,6 +37,11 @@ namespace WireCell::Stream {
     using custard::output_filters;
 
 
+    /// Short hand alias as most "ostream" and "istream" will be this
+    /// type in practice.
+    using boost::iostreams::filtering_istream;
+    using boost::iostreams::filtering_ostream;
+
     /// Stream Eigen array to custard stream.  Must have tar filter!
     template<typename ArrType>
     std::ostream& write(std::ostream& so, const std::string& fname, const ArrType& arr) {

--- a/util/src/Math.cxx
+++ b/util/src/Math.cxx
@@ -1,0 +1,44 @@
+#include "WireCellUtil/Math.h"
+
+size_t WireCell::GCD(size_t a, size_t b)
+{
+    while(true) {
+        a = a % b;
+        if (a == 0) {
+            return b;
+        }
+        b = b % a;
+        if (b == 0) {
+            return a;
+        }
+    }
+}
+
+size_t WireCell::nearest_coprime(size_t number, size_t target)
+{
+    size_t lo=0, hi=number/2;
+    if (target > number/2) {
+        lo = number/2;
+        hi = number;
+    }
+    const size_t maxstep = std::max(target-lo, hi-target);
+    for (size_t step = 0; step < maxstep; ++step) {
+        {
+            const size_t below = target - step;
+            if (below >= lo) {
+                if (1 == WireCell::GCD(number, below)) {
+                    return below;
+                }
+            }
+        }
+        {
+            const size_t above = target + step;
+            if (above < hi) {
+                if (1 == WireCell::GCD(number, above)) {
+                    return above;
+                }
+            }
+        }
+    }
+    return 0;
+}

--- a/util/test/test_coprime.cxx
+++ b/util/test/test_coprime.cxx
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <cmath>
+#include <cassert>
+#include <vector>
+
+#include "WireCellUtil/Math.h"
+
+using namespace WireCell;
+
+int main(void)
+{
+    const double fraction = 0.02;
+
+    //for (auto capacity : capacities) {
+    for (size_t capacity = 3; capacity < 10000; ++capacity) {
+        const size_t target = (1-fraction)*capacity;
+        auto got = nearest_coprime(capacity, target);
+        assert (got != 0);
+        int err = got-target;
+        std::cerr << "capacity=" << capacity
+                  << " target=" << target
+                  << " got=" << got
+                  << " error=" << err << "\n";
+    }
+    return 0;
+}

--- a/util/test/test_interpolate.cxx
+++ b/util/test/test_interpolate.cxx
@@ -10,7 +10,43 @@ using boost::math::interpolators::cardinal_cubic_b_spline;
 
 using namespace WireCell;
 
-int main()
+template<typename Terp>
+void do_terp(Terp& terp)
+{
+    assert(terp(0) == 0);
+    assert(terp(9) == 9);
+    assert(terp(-1) == 0);
+    assert(terp(10) == 9);
+
+    std::vector<typename Terp::ytype> terped;
+    const size_t num = 100 + 1;
+    terp(std::back_inserter(terped), num, 0, 0.1);
+    // for (size_t ind=0; ind<num; ++ind) {
+    //     std::cerr << "[" << ind << "] = " << terped[ind] << "\n";
+    // }
+    assert(terped.size() == num);
+    assert(terped[0] == 0);
+    assert(terped.back() == 9);
+    std::cerr << "terped[90]-9=" << terped[90]-9 << "\n";
+    assert(std::abs(terped[90]-9) < 2e-6);
+}
+
+template<typename X, typename Y=X>
+void test_linterp()
+{
+    std::vector<Y> ydata{0,1,2,3,4,5,6,7,8,9};
+    linterp<X,Y> terp(ydata.begin(), ydata.end(), 0, 1);
+    do_terp(terp);
+}
+template<typename X, typename Y=X>
+void test_irrterp()
+{
+    std::map<X,Y> data{{0,0},{1,1},{2,2},{3,3},{4,4},{5,5},{6,6},{7,7},{8,8},{9,9}};
+    irrterp<X,Y> terp(data.begin(), data.end());
+    do_terp(terp);
+}
+
+void test_boost()
 {
     std::vector<double> f{0.01, -0.02, 0.3, 0.8, 1.9, -8.78, -22.6};
     const double xstep = 0.01;
@@ -23,5 +59,23 @@ int main()
         std::cout << std::setprecision(3) << std::fixed << "x=" << x << "\tlin(x)=" << lin(x)
                   << "\tspline(x)=" << spline(x) << "\n";
     }
+}
+
+int main()
+{
+    std::cerr << "testing irrterp:\n";
+    test_irrterp<float>();
+    test_irrterp<double>();
+    test_irrterp<float,  float>();
+    test_irrterp<double, float>();
+    test_irrterp<float,  double>();
+    test_irrterp<double, double>();
+    std::cerr << "testing linterp:\n";
+    test_linterp<float>();
+    test_linterp<double>();
+    test_linterp<float,  float>();
+    test_linterp<double, float>();
+    test_linterp<float,  double>();
+    test_linterp<double, double>();
     return 0;
 }


### PR DESCRIPTION
Some details:

- Add Hermitian-symmetry functions, with unit tests.
- Use them on input inside the 1D Aux::inv_c2r().
- Remove the 2D/array versions of Aux::fwd_r2c() and Aux::inv_c2r().
  - They were not used and were not correct.
- Fix AddNoise and AddGroupNoise to use Aux::inv_c2r().
- Add gen/test/test_noise.{cxx,py} which is decribed below.
- Enlarge "linterp" API to support a sequence sampling in addition to the point sampling.
- Add "irrterp" to interpolate on irregular sampling, same sequence and point sampling api.
- Add unit tests for both in util/test/test_interpolate.cxx.

New test_noise.cxx and test_noise.py:

```
$ ./build/gen/test_noise
./build/gen/test_noise.tar
$ ./gen/test/test_noise.py
/home/bv/wrk/wct/noise/toolkit/build/gen/test_noise.pdf
$ evince build/gen/test_noise.pdf
```

Some of the guts of test_noise.cxx can be moved out to util or
aux and then used from gen/Noise.cxx etc once we are ready for
that next level of cleanup.