### PR TITLE
fix a bug for set_difference()

### DIFF
--- a/aux/src/FrameTools.cxx
+++ b/aux/src/FrameTools.cxx
@@ -109,10 +109,10 @@ ITrace::vector Aux::untagged_traces(IFrame::pointer frame)
     auto traces = frame->traces();
     size_t ntraces = traces->size();
 
-    std::unordered_set<size_t> tagged;
+    std::vector<size_t> tagged;
     for (auto tag : frame->trace_tags()) {
         const auto& taglist = frame->tagged_traces(tag);
-        tagged.insert(taglist.begin(), taglist.end());
+        tagged.insert(tagged.end(), taglist.begin(), taglist.end());
     }
     std::vector<size_t> all(ntraces), untagged;
     std::iota(all.begin(), all.end(), 0);


### PR DESCRIPTION
@brettviren I found that, in the function `Aux::untagged_traces()`, the `std::set_difference` was given a `std::unordered_set`. However, the elements are actually assumed to be sorted in the std according to [cppreference](https://en.cppreference.com/w/cpp/algorithm/set_difference).

Here is a quick test:

```
  std::vector<size_t> all={0,1,2,3};

  std::unordered_set<size_t> tagged={0,1,2,3};  // fail
  // std::set<size_t> tagged={0,1,2,3};         // success, but maybe not recommended?
  // std::vector<size_t> tagged={0,1,2,3};      // success

  std::vector<size_t> untagged;
  std::set_difference(all.begin(), all.end(), tagged.begin(), tagged.end(), std::inserter(untagged, untagged.begin()));
```

Note that `untagged_traces` is used in `Drifter`, `ChannelSelector`, `ManifySInk` and `FrameMerger`. Given that most of our use cases are just retrieving all traces when the upstream simulation/data has no tag for traces. Therefore, this bug should not make an actual difference. 

It makes a difference only when the upstream frame does have tagged traces, but we still want to retrieve some untagged traces. As an example in the above test, we have traces 0,1,2,3 and all of them are tagged. If we implement it properly, there should be no untagged traces, but the bug would give us untagged traces 0,1,2,3.



