### PR TITLE
Apply blob threshold configuration in charge solving

### DIFF
--- a/cfg/layers/low/img.jsonnet
+++ b/cfg/layers/low/img.jsonnet
@@ -122,7 +122,7 @@ function (anode) {
     }, nin=1, nout=1),
 
     // The recommended charge solving
-    charge_solving :: function(meas_val_thresh=10.0,
+    charge_solving :: function(meas_val_thresh=0.0,
                                meas_err_thresh=1.0e9,
                                blob_val_thresh=0,
                                whiten=true)

--- a/img/inc/WireCellImg/CSGraph.h
+++ b/img/inc/WireCellImg/CSGraph.h
@@ -108,7 +108,8 @@ namespace WireCell::Img::CS {
                              std::back_insert_iterator<graph_vector_t> subgraphs_out);
 
     // Break a cluster_graph into a vector of connected subgraphs
-    // represented by a CS graph_t.
+    // represented by a CS graph_t.  Measurements with value less than
+    // meas_thresh are ignored.
     void unpack(const cluster_graph_t& cgraph,
                 std::back_insert_iterator<graph_vector_t> subgraphs,
                 const value_t& meas_thresh);
@@ -128,8 +129,9 @@ namespace WireCell::Img::CS {
     };
     graph_t solve(const graph_t& csg, const SolveParams& params);
 
-    // Return a copy of the input retaining only blobs with charge
-    // above threshold.  Any blobless measures are also removed.
+    // Return a copy of the input retaining only blobs with signal
+    // value above or equal to threshold.  Any blobless measures are
+    // also removed.
     graph_t prune(const graph_t& csg, float threshold=0);
 }
 

--- a/img/inc/WireCellImg/ChargeSolving.h
+++ b/img/inc/WireCellImg/ChargeSolving.h
@@ -47,21 +47,30 @@ namespace WireCell {
             // (central+uncertainty).
             using value_t = ISlice::value_t;
 
-            // Config: meas_{value,error}_threshold. Only measures
-            // with central value strictly less than this or with
-            // uncertainty greater than this are not considered.
-            // Note, this threshold is placed on the sum of channels
-            // in a measure, not on the individual channel values.
-            // Units are numbers of electrons.
+            // Config: meas_{value,error}_threshold.  The value
+            // threshold is a lower bound and the error threshold is
+            // an upper bound to which measures are accepted for
+            // solving.  The bound is inclusive.  A threshold of 0
+            // will retain measures of value 0.  Note, this threshold
+            // is placed on the sum of channels in a measure, not on
+            // the individual channel components.  Units are numbers
+            // of electrons.
             value_t m_meas_thresh{0,1e9};
-            // Config: blob_{value,error}_threshold. A blob with
-            // central value less than this is dropped.  The
-            // uncertainty is not currently considered.
-            value_t m_blob_thresh{0,1};
+
+            // Config: blob_{value,error}_threshold. The value
+            // threshold is a lower bound on the solved blob charge
+            // for that blob to be output.  The value threshold is
+            // inclusive.  Blobs with signal value equal or larger
+            // than the threshold are output.  Note, the uncertainty
+            // is not currently considered.
+            value_t m_blob_thresh{-1,0};
+
             // config. The tolerance passed to LassoModel solver.
             double m_lasso_tolerance{1e-3};
+
             // config. The minimum norm passed to LassoModel solver.
             double m_lasso_minnorm{1e-6};
+
             // config. The blob weighting strategies for each of a
             // number of solving rounds.  This is an arbitrary long
             // sequence of strategy names from the set: "uniform" (all
@@ -73,6 +82,7 @@ namespace WireCell {
             // m_minimum_charge.
             //std::vector<std::string> m_weighting_strategies{"uniform", "simple"};
             std::vector<std::string> m_weighting_strategies{"uniform"};
+
             // Config: if false, any measurement uncertainty is
             // ignored.  If true, the measurement covariance matrix is
             // formed on the measurement uncertainties and is

--- a/img/src/CSGraph.cxx
+++ b/img/src/CSGraph.cxx
@@ -167,7 +167,7 @@ graph_t CS::prune(const graph_t& csg, float threshold)
     for (auto oldv : vertex_range(csg)) {
         const auto& node = csg[oldv];
         if (node.kind == node_t::blob) {
-            if (node.value.value() <= threshold) {
+            if (node.value.value() < threshold) {
                 continue;
             }
             ++nblobs;

--- a/img/src/ChargeSolving.cxx
+++ b/img/src/ChargeSolving.cxx
@@ -204,7 +204,8 @@ bool Img::ChargeSolving::operator()(const input_pointer& in, output_pointer& out
     // }
 
     const size_t nstrats = m_weighting_strategies.size();
-    std::vector<float> blob_threshold(nstrats, 0); // fixme make configurable
+
+    std::vector<float> blob_threshold(nstrats, m_blob_thresh.value());
 
     SolveParams sparams{Ress::Params{Ress::lasso}, 1000, m_whiten};
     for (size_t ind = 0; ind < nstrats; ++ind) {


### PR DESCRIPTION
The blob threshold configuration parameter is no longer ignored.  

When set to zero the `depo-ssi-viz` test outputs all blobs so that the number of blobs matches the "depo blob fill" branch produces.  

Even with the measure threshold set to zero a few measures get removed compared to the "depo blob fill" branch.  I guess some measures are negative?