### PR TITLE
Proposed copyright and license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+The contents of wire-cell-toolkit project, unless otherwise stated,
+are distributed according to the following.
+
+Copyright 2015-2023 Brookhaven National Laboratory for the benefit of
+the Wire-Cell Team.
+
+This project is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+A copy of the GNU Lesser General Public is provided with the project
+files and may also be found at <https://www.gnu.org/licenses/>.

--- a/wscript
+++ b/wscript
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+# Copyright 2015-2023 Brookhaven National Laboratory for the benefit
+# of the Wire-Cell Team.
+# 
+# This file is part of the wire-cell-toolkit project and distributed
+# according to the LICENSE file provided as also part of this project.
+
 import os
 
 TOP = '.'


### PR DESCRIPTION
This project lacks a copyright and license statement.  

Technically, this is needed for anyone to legally use WCT.  Specifically, DUNE now has guidelines[1] and requirements for what software may be used by the collaboration and is what motivates making this PR now to fix this long-standing omission.

This PR proposes assigning BNL as the copyright holder.  I think this is the only available choice.  Added is the phrase "for the benefit of the Wire-Cell Team" which follows guidance from HSF[2].

This PR proposes licensing WCT according to the GNU LGPL.  I believe this license is consistent with software WCT uses as well as WCT's main user (larsoft) while assuring the use and development of WCT by other people remains open.  Note, ROOT also uses LGPL.

The PR itself adds a `LICENSE` file and one example file "header" in the `wscript` file.  We can add the header to more files once this PR is merged, marking general agreement by the team.


[1] https://docs.dunescience.org/cgi-bin/sso/ShowDocument?docid=27141
[2] https://hepsoftwarefoundation.org/notes/HSF-TN-2016-01.pdf