### PR TITLE
Generate a pkg-config file: wire-cell-toolkit.pc

### DIFF
--- a/waft/generic.py
+++ b/waft/generic.py
@@ -57,8 +57,6 @@ def _options(opt, name, incs=None, libs=None):
 def _configure(ctx, name, incs=(), libs=(), bins=(), pcname=None, mandatory=True, extuses=()):
     lower = name.lower()
     UPPER = name.upper()
-    if pcname is None:
-        pcname = lower
     extuses = list(extuses)
 
     instdir = getattr(ctx.options, 'with_'+lower, None)
@@ -81,7 +79,10 @@ def _configure(ctx, name, incs=(), libs=(), bins=(), pcname=None, mandatory=True
             return
 
     # rely on package config
-    if not any([instdir,incdir,libdir,bindir]) or (instdir and instdir.lower() in ['yes','on','true']):
+    no_dirs = not any([instdir,incdir,libdir,bindir])
+    have_instdir = (instdir and instdir.lower() in ['yes','on','true'])
+    have_pcname = pcname is not None
+    if have_pcname and (no_dirs or have_instdir):
         ctx.start_msg('Checking for %s in PKG_CONFIG_PATH' % name)
         args = "--cflags"
         if libs:                # things like eigen may not have libs
@@ -129,6 +130,8 @@ def _configure(ctx, name, incs=(), libs=(), bins=(), pcname=None, mandatory=True
         if ctx.is_defined('HAVE_'+UPPER+'_LIB'):
             ctx.env['HAVE_'+UPPER] = 1
             debug('%s: HAVE %s libs' % (lower, UPPER))
+            if pcname:
+                ctx.env.REQUIRES += [pcname]
         else:
             debug('%s: NO %s libs' % (lower, UPPER))
             
@@ -143,6 +146,8 @@ def _configure(ctx, name, incs=(), libs=(), bins=(), pcname=None, mandatory=True
         if ctx.is_defined('HAVE_'+UPPER+'_INC'):
             ctx.env['HAVE_'+UPPER] = 1
             debug('%s: HAVE %s includes' % (lower, UPPER))
+            if pcname:
+                ctx.env.REQUIRES += [pcname]
         else:
             debug('%s: NO %s includes' % (lower, UPPER))
 

--- a/waft/wcb.py
+++ b/waft/wcb.py
@@ -21,21 +21,21 @@ package_descriptions = [
     # spdlog is "header only" but use library version for faster recompilation
     # wire-cell-util and ZIO both use this
     # Need to build with -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-    ('spdlog',   dict(incs=['spdlog/spdlog.h'], libs=['spdlog'])),
+    ('spdlog',   dict(incs=['spdlog/spdlog.h'], libs=['spdlog'], pcname='spdlog')),
 
-    ('ZLib',     dict(incs=['zlib.h'], libs=['z'])),
+    ('ZLib',     dict(incs=['zlib.h'], libs=['z'], pcname='zlib')),
     ('FFTW',     dict(incs=['fftw3.h'], libs=['fftw3f'], pcname='fftw3f')),
     ('FFTWThreads', dict(libs=['fftw3f_threads'], pcname='fftw3f', mandatory=False)),
-    ('JsonCpp',  dict(incs=["json/json.h"], libs=['jsoncpp'])),
+    ('JsonCpp',  dict(incs=["json/json.h"], libs=['jsoncpp'], pcname='jsoncpp')),
 
     ('Eigen',    dict(incs=["Eigen/Dense"], pcname='eigen3')),
 
     # for faster parsing, consider:
     # ./wcb configure --with-jsonnet-libs=gojsonnet 
     ('Jsonnet',  dict(incs=["libjsonnet.h"], libs=['jsonnet'])),
-    ('TBB',      dict(incs=["tbb/parallel_for.h"], libs=['tbb'], mandatory=False)),
-    ('HDF5',     dict(incs=["hdf5.h"], libs=['hdf5'], mandatory=False)),
-    ('H5CPP',    dict(incs=["h5cpp/all"], mandatory=False, extuses=('HDF5',))),
+    ('TBB',      dict(incs=["tbb/parallel_for.h"], libs=['tbb'], pcname='tbb', mandatory=False)),
+    ('HDF5',     dict(incs=["hdf5.h"], libs=['hdf5'], pcname='hdf5', mandatory=False)),
+    ('H5CPP',    dict(incs=["h5cpp/all"], mandatory=False, extuses=('HDF5',), pcname='h5cpp')),
 
     ('ZMQ',      dict(incs=["zmq.h"], libs=['zmq'], pcname='libzmq', mandatory=False)),
     ('CZMQ',     dict(incs=["czmq.h"], libs=['czmq'], pcname='libczmq', mandatory=False)),
@@ -174,6 +174,8 @@ def configure(cfg):
     cfg.find_program("pandoc", var="PANDOC", mandatory=False)
     cfg.find_program("emacs", var="EMACS", mandatory=False)
 
+    cfg.env.REQUIRES = list(set(cfg.env.REQUIRES))
+
     debug("dump: " + str(cfg.env))
 
 
@@ -226,6 +228,17 @@ def build(bld):
             pdf  = bld.path.find_or_declare(f'wct-readme.pdf')
             bld(features="org2pdf", source=readme, target=pdf, name="wct-readme-pdf")
             bld.install_files('${PREFIX}/share/doc', pdf)
+
+    # Produce a pkg-config .pc file
+    bld(source='wire-cell-toolkit.pc.in',
+        name="pkg-config-file",
+        REQUIRES = ' '.join(bld.env.REQUIRES),
+        install_path = '${LIBDIR}/pkgconfig/')
+
+
+    # Produce a libtool .la file.  This needs one for each lib.
+    # bld(source='libWireCellXxxx.la.in', 
+    #     install_path = '${LIBDIR}')    
 
 def dumpenv(bld):
     'dump build environment to stdout'

--- a/wire-cell-toolkit.pc.in
+++ b/wire-cell-toolkit.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+libdir=@libdir@
+includedir=${prefix}/include
+
+Name: wire-cell-toolkit
+Description: Toolkit for Liquid Argon TPC Simulation and Reconstruction
+Version: @VERSION@
+Libs: -L${libdir} @LLIBS@
+Cflags: -I${includedir}
+Requires: @REQUIRES@


### PR DESCRIPTION
Fixes #203

This lets others find wire-cell-toolkit via `pkg-config`.