### PR TITLE
Fix clang warning

### DIFF
--- a/aux/src/ClusterHelpersJsonify.cxx
+++ b/aux/src/ClusterHelpersJsonify.cxx
@@ -122,8 +122,6 @@ Json::Value slice_jsoner(const cluster_node_t& n)
     ret["start"] = islice->start();
     ret["span"] = islice->span();
 
-    double sigtot = 0;
-
     // note: used to be SOA, now AOS.
     Json::Value jsignal = Json::arrayValue;
     for (const auto& it : islice->activity()) {
@@ -131,7 +129,6 @@ Json::Value slice_jsoner(const cluster_node_t& n)
         jact["ident"] = it.first->ident();
         const double val = it.second.value();
         jact["val"] = val;
-        sigtot += val;
         jact["unc"] = it.second.uncertainty();
         jsignal.append(jact);
     }

--- a/aux/src/ClusterHelpersLoader.cxx
+++ b/aux/src/ClusterHelpersLoader.cxx
@@ -258,7 +258,7 @@ cluster_graph_t ClusterLoader::load(const Json::Value& jgraph,
     }
 
     frid2iframe_t frames;
-    for (const auto kf : known_frames) {
+    for (const auto &kf : known_frames) {
         frames[kf->ident()] = kf;
     }
     slid2islice_t slices;

--- a/aux/src/TensorCluster.cxx
+++ b/aux/src/TensorCluster.cxx
@@ -35,7 +35,7 @@ void TensorCluster::configure(const WireCell::Configuration& cfg)
     m_dpre = get(cfg, "dpre", default_dpre);
 
     m_anodes.clear();
-    for (const auto janode : cfg["anodes"]) {
+    for (const auto& janode : cfg["anodes"]) {
         m_anodes.push_back(Factory::find_tn<IAnodePlane>(janode.asString()));
     }
 }

--- a/gen/src/GaussianDiffusion.cxx
+++ b/gen/src/GaussianDiffusion.cxx
@@ -47,10 +47,8 @@ std::vector<double> Gen::GausDesc::binint(double start, double step, int nbins) 
             erfs[ind] = 0.5 * std::erf(x);
         }
 
-        double tot = 0.0;
         for (int ibin = 0; ibin < nbins; ++ibin) {
             const double val = erfs[ibin + 1] - erfs[ibin];
-            tot += val;
             bins[ibin] = val;
         }
     }
@@ -185,12 +183,10 @@ void Gen::GaussianDiffusion::set_sampling(const Binning& tbin,  // overall time 
 
     double fluc_sum = 0;
     if (fluctuate) {
-        double unfluc_sum = 0;
 
         for (size_t ip = 0; ip < npss; ++ip) {
             for (size_t it = 0; it < ntss; ++it) {
                 const double oldval = ret(ip, it);
-                unfluc_sum += oldval;
                 // should be a multinomial distribution, n_i follows binomial distribution
                 // but n_i, n_j has covariance -n_tot * p_i * p_j
                 // normalize later to approximate this multinomial distribution (how precise?)
@@ -210,10 +206,6 @@ void Gen::GaussianDiffusion::set_sampling(const Binning& tbin,  // overall time 
             }
         }
         if (fluc_sum == 0) {
-            // cerr << "No net charge after fluctuation. Total unfluctuated = "
-            //      << unfluc_sum
-            //      << " Qdepo = " << m_deposition->charge()
-            //      << endl;
             return;
         }
         else {

--- a/gen/test/test-addnoise.bats
+++ b/gen/test/test-addnoise.bats
@@ -54,6 +54,12 @@ setup_file () {
     cd_tmp file
 
     local wcplot=$(wcb_env_value WCPLOT)
+    if [ -z "$wcplot" ] ; then  # fixme: foist up into wct-bats.sh
+        skip "No wirecell-plot.  Do you have wire-cell-python installed before configuring build?"
+    fi
+
+    echo "WCPLOT: $wcplot"
+    [[ -n "$wcplot" ]]
     for what in spec wave
     do
         local pout="comp1d-${what}.png"

--- a/img/inc/WireCellImg/ClusterFanout.h
+++ b/img/inc/WireCellImg/ClusterFanout.h
@@ -29,7 +29,6 @@ namespace WireCell::Img {
         size_t m_multiplicity{0};
         size_t m_count{0};
 
-        bool m_trivial{false};
         tagrules::Context m_ft;
 
     };

--- a/img/src/FrameQualityTagging.cxx
+++ b/img/src/FrameQualityTagging.cxx
@@ -252,7 +252,7 @@ bool FrameQualityTagging::operator()(const input_pointer& in, output_pointer& ou
       int n_fire = 0;
       int start_time =0;
       int end_time = 0;
-      int acc_cover = 0;
+      // int acc_cover = 0;
       int acc_total = 0;
       int acc_fire = 0;
 
@@ -271,7 +271,7 @@ bool FrameQualityTagging::operator()(const input_pointer& in, output_pointer& ou
 	  }
 	  n_cover = 0;
 	  n_fire = 0;
-	  acc_cover = 0;
+	  // acc_cover = 0;
 	  acc_total = 0;
 	  acc_fire = 0;
 	  start_time = time;
@@ -283,7 +283,7 @@ bool FrameQualityTagging::operator()(const input_pointer& in, output_pointer& ou
 	if (ncover * percentage > m_threshold2[iplane]){
 	  n_fire ++;
 	  acc_total += nchannels[iplane];
-	  acc_cover += ncover;
+	  // acc_cover += ncover;
 	  acc_fire  += ncover*percentage;
 	}
 	prev_time = time;

--- a/img/src/SlicesSink.cxx
+++ b/img/src/SlicesSink.cxx
@@ -27,14 +27,14 @@ bool Img::SlicesSink::operator()(const ISliceFrame::pointer& sf)
         return true;
     }
 
-    auto slices = sf->slices();
+    // auto slices = sf->slices();
 
-    for (auto slice : slices) {
-        auto cvmap = slice->activity();
-        double qtot = 0;
-        for (const auto& cv : cvmap) {
-            qtot += cv.second;
-        }
-    }
+    // for (auto slice : slices) {
+    //     auto cvmap = slice->activity();
+    //     double qtot = 0;
+    //     for (const auto& cv : cvmap) {
+    //         qtot += cv.second;
+    //     }
+    // }
     return true;
 }

--- a/sigproc/src/ChannelSelector.cxx
+++ b/sigproc/src/ChannelSelector.cxx
@@ -78,18 +78,18 @@ bool ChannelSelector::operator()(const input_pointer& in, output_pointer& out)
 
     std::vector<ITrace::vector> tracesvin;
 
-    size_t ntraces = 0;
+    // size_t ntraces = 0;
     size_t ntags = m_tags.size();
     if (!ntags) {
         tracesvin.push_back(Aux::untagged_traces(in));
-        ntraces += tracesvin[0].size();
+        // ntraces += tracesvin[0].size();
     }
     else {
         tracesvin.resize(ntags);
         for (size_t ind = 0; ind < ntags; ++ind) {
             std::string tag = m_tags[ind];
             tracesvin[ind] = Aux::tagged_traces(in, tag);
-            ntraces += tracesvin[ind].size();
+            // ntraces += tracesvin[ind].size();
         }
     }
     

--- a/sigproc/src/L1SPFilter.cxx
+++ b/sigproc/src/L1SPFilter.cxx
@@ -599,10 +599,10 @@ int L1SPFilter::L1_fit(std::shared_ptr<Aux::SimpleTrace>& newtrace,
         }
 
         double sum1 = 0;
-        double sum2 = 0;
+        // double sum2 = 0;
         for (int i = 0; i != nbin_fit; i++) {
             sum1 += final_beta(i);
-            sum2 += final_beta(nbin_fit + i);
+            // sum2 += final_beta(nbin_fit + i);
         }
 
         if (sum1 > adc_l1_threshold) {

--- a/sigproc/src/Microboone.cxx
+++ b/sigproc/src/Microboone.cxx
@@ -1183,7 +1183,7 @@ WireCell::Waveform::ChannelMaskMap Microboone::ADCBitShift::apply(int ch, signal
                 for (auto it = fillings.begin(); it != fillings.end(); it++) {
                     int y = WireCell::Bits::shift_right(x_orig[i], nshift, (*it), 12);
                     // when to switch ...
-                    if (fabs(y - exp_value) < fabs(x[i] - exp_value)) {
+                    if (std::abs(y - exp_value) < std::abs(x[i] - exp_value)) {
                         x[i] = y;  // hs->SetBinContent(i+1,y);
                     }
                 }

--- a/sigproc/src/Protodune.cxx
+++ b/sigproc/src/Protodune.cxx
@@ -652,12 +652,12 @@ WireCell::Waveform::ChannelMaskMap Protodune::StickyCodeMitig::apply(int ch, sig
         }
     }
 
-    int ent_stkylen = 0;
+    // int ent_stkylen = 0;
     for (auto rng : sticky_rng_list) {
         int stkylen = rng.second - rng.first;
         if (stkylen > m_stky_max_len) {
             ret["sticky"][ch].push_back(rng);
-            ent_stkylen += stkylen;
+            // ent_stkylen += stkylen;
         }
     }
     // std::cerr << "[wgu] ch: " << ch << " long_stkylen: " << long_stkylen << std::endl;

--- a/sigproc/src/ROI_formation.cxx
+++ b/sigproc/src/ROI_formation.cxx
@@ -262,7 +262,7 @@ void ROI_formation::create_ROI_connect_info(int plane)
                     int start2 = self_rois_u.at(i + 2).at(k).first;
                     int end2 = self_rois_u.at(i + 2).at(k).second;
                     int length2 = end2 - start2 + 1;
-                    if (fabs(length2 - length1) < (length2 + length1) * asy) {
+                    if (std::abs(length2 - length1) < (length2 + length1) * asy) {
                         int start3 = (start1 + start2) / 2.;
                         int end3 = (end1 + end2) / 2.;
                         if (start3 < end3 && start3 <= end1 && start3 <= end2 && end3 >= start1 && end3 >= start2) {
@@ -298,7 +298,7 @@ void ROI_formation::create_ROI_connect_info(int plane)
                     int start2 = self_rois_v.at(i + 2).at(k).first;
                     int end2 = self_rois_v.at(i + 2).at(k).second;
                     int length2 = end2 - start2 + 1;
-                    if (fabs(length2 - length1) < (length2 + length1) * asy) {
+                    if (std::abs(length2 - length1) < (length2 + length1) * asy) {
                         int start3 = (start1 + start2) / 2.;
                         int end3 = (end1 + end2) / 2.;
                         if (start3 < end3 && start3 <= end1 && start3 <= end2 && end3 >= start1 && end3 >= start2) {
@@ -334,7 +334,7 @@ void ROI_formation::create_ROI_connect_info(int plane)
                     int start2 = self_rois_w.at(i + 2).at(k).first;
                     int end2 = self_rois_w.at(i + 2).at(k).second;
                     int length2 = end2 - start2 + 1;
-                    if (fabs(length2 - length1) < (length2 + length1) * asy) {
+                    if (std::abs(length2 - length1) < (length2 + length1) * asy) {
                         int start3 = (start1 + start2) / 2.;
                         int end3 = (end1 + end2) / 2.;
                         if (start3 < end3 && start3 <= end1 && start3 <= end2 && end3 >= start1 && end3 >= start2) {

--- a/sio/src/TensorFileSource.cxx
+++ b/sio/src/TensorFileSource.cxx
@@ -151,7 +151,8 @@ struct TFSTensor : public WireCell::ITensor {
         , m_shape(pig.header().shape())
         , m_cfg(cfg)
     {
-        const std::byte* data = reinterpret_cast<const std::byte*>(pig.data().data());
+        auto vec = pig.data();
+        const std::byte* data = reinterpret_cast<const std::byte*>(vec.data());
         m_store.insert(m_store.end(), data, data + pig.data().size());
     }
 

--- a/test/test/history-comp1d.bats
+++ b/test/test/history-comp1d.bats
@@ -24,7 +24,7 @@ function comp1d () {
 
     declare -a args=( -s -n "$kind" --transform ac )
     args+=( --chmin ${chmins[$iplane]} --chmax ${chmaxs[$iplane]} )
-    if [ "$src" = noise ] ; then
+    if [ "$src" = "noise" ] ; then
         args+=( --tier '*' )
     else
         args+=( --tier 'orig' )
@@ -33,12 +33,19 @@ function comp1d () {
 
     yell "ARGS: ${args[@]}"
 
+    local deps=()
     for one in ${past[@]}
     do
         deps+=( -s "$one" )
+        [[ -s "$one" ]]
     done
 
+    yell "DEPS: ${deps[@]}"
+
     local wcplot=$(wcb_env_value WCPLOT)
+    if [ -z "$wcplot" ] ; then  # fixme: foist up into wct-bats.sh
+        skip "No wirecell-plot.  Do you have wire-cell-python installed before configuring build?"
+    fi
     run_idempotently ${deps[@]} -t "$fig" -- $wcplot comp1d "${args[@]}" ${past[@]}
     [[ -s "$fig" ]]
     saveout -c reports "$fig"
@@ -49,7 +56,7 @@ function comp1d () {
 
     # The list of files that can be comp1d'ed.  These must be PDSP APA0
     declare -A inputs
-    inputs[noise]="test-addnoise/test-addnoise-empno-6000.tar.gz"
+    inputs[noise]="test-addnoise/frames-adc.tar.gz"
     inputs[simsn]="test-pdsp-simsn/frames-adc.tar.gz"
 
     yell "INPUT KEYS: ${!inputs[@]}"
@@ -62,6 +69,7 @@ function comp1d () {
         do
             for ipln in 0 1 2
             do
+                yell "comp1d $src $infile $kind $ipln"
                 comp1d $src $infile $kind $ipln
             done
         done

--- a/util/inc/WireCellUtil/custard/custard.hpp
+++ b/util/inc/WireCellUtil/custard/custard.hpp
@@ -105,14 +105,19 @@ namespace custard {
         char mtime_[12];               /* 136 */
         char chksum_[8];               /* 148 */
         char typeflag_;                /* 156 */
+        [[maybe_unused]]
         char linkname_[100];           /* 157 */
         char magic_[6];                /* 257 */
         char version_[2];              /* 263 */
         char uname_[32];               /* 265 */
         char gname_[32];               /* 297 */
+        [[maybe_unused]]
         char devmajor_[8];             /* 329 */
+        [[maybe_unused]]
         char devminor_[8];             /* 337 */
+        [[maybe_unused]]
         char prefix_[155];             /* 345 */
+        [[maybe_unused]]
         char padding_[12];             /* 500 */
                                        /* 512 */
       public:

--- a/util/inc/WireCellUtil/svg.hpp
+++ b/util/inc/WireCellUtil/svg.hpp
@@ -635,7 +635,7 @@ namespace svg
     private:
         Stroke axis_stroke;
         Dimensions margin;
-        double scale;
+        [[maybe_unused]] double scale; // fixme: can we nuke this?
         std::vector<Polyline> polylines;
 
         optional<Dimensions> getDimensions() const

--- a/util/src/Response.cxx
+++ b/util/src/Response.cxx
@@ -187,11 +187,6 @@ Response::Schema::FieldResponse Response::wire_region_average(const Response::Sc
             int region = it.first;
             realseq_t& response = it.second;
 
-            double sum = 0;
-            for (int k = 0; k != nsamples; k++) {
-                sum += response.at(k);
-            }
-
             // pack up everything for return.
             newpaths.push_back(PathResponse(response, region * pitch, 0.0));
         }

--- a/util/test/test_median.cxx
+++ b/util/test/test_median.cxx
@@ -24,7 +24,7 @@ int main()
     const int ntimes = 10000;
     em("start scaling tests");
     int sizes[] = {100, 1000, 10000, 0};
-    float dummy = 0;  // don't optimize away
+    float dummy = 0;
     for (int ind = 0; sizes[ind]; ++ind) {
         auto size = sizes[ind];
         std::vector<float> chunk(data.begin(), data.begin() + size);
@@ -49,6 +49,6 @@ int main()
         em("done with chunked test");
     }
 
-    cerr << em.summary() << endl;
+    cerr << em.summary() << " dummy=" << dummy << endl;
     return 0;
 }

--- a/util/test/test_type.cxx
+++ b/util/test/test_type.cxx
@@ -17,10 +17,5 @@ int main()
     cerr << "int: " << type(i) << endl;
     cerr << "vector<int>: \"" << type(vi) << "\"\n";
 
-// the two don't give exactly the same pattern....
-#if defined(__clang__)
-    AssertMsg("std::__1::vector<int, std::__1::allocator<int> >" == type(vi), "Clang demangling fails");
-#else
     AssertMsg("std::vector<int, std::allocator<int> >" == type(vi), "GCC demangling fails");
-#endif
 }


### PR DESCRIPTION
This fixes a bunch of random compiler warnings that Clang uncovers.

Several bats tests fail, but I need to merge with my `apply-pointcloud` branch to check if they are not already fixed.