### PR TITLE
Add DepoSetFilter module

### DIFF
--- a/cfg/pgrapher/experiment/icarus/icarus_tools.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/icarus_tools.jsonnet
@@ -1,0 +1,171 @@
+// This file provides a function which takes a params object (see
+// ../params/) and returns a data structure with a number of
+// sub-objects that may configure various WCT "tool" type componets
+// which are not INodes.
+
+// Some attributes are merely default and you may wish to override
+// them.  For example, the default IDFT FftwDFT and to instead ues
+// TorchDFT you may do something like:
+//
+// local default_tools = tools_maker(params)
+// local tools = std.mergePatch(default_tools,
+//   {dft: {type: "TorchDFT", data: {device: "gpu"}}});
+// 
+
+local wc = import "wirecell.jsonnet";
+
+function(params)
+{
+    // The IRandom pRNG
+    random : {
+        type: "Random",
+        data: {
+            generator: "default",
+            seeds: [0,1,2,3,4],
+        }
+    },
+    // The IDFT FFT implementation 
+    dft : {
+        type: "FftwDFT",
+    },
+
+    // One FR per field file.
+    fields : std.mapWithIndex(function (n, fname) {
+        type: "FieldResponse",
+        name: "field%d"%n,
+        data: { filename: fname }
+    }, params.files.fields),
+
+    field: $.fields[0],         // the nominal field
+
+    // The number of ticks for response waveforms.  For simulation
+    // this must be enlarged beyond what is wanted in the output
+    // readout in order to accept catch early activity into the first
+    // few readout ticks.  When responses are used to deconvolve then
+    // this should best be shortened.  Note: sigproc at time of
+    // writing did not use components for Elec or RC so are not
+    // currently subject to this config.
+    local sim_response_binning = {
+        tick: params.daq.tick,
+        nticks: params.sim.ductor.nticks, // MUST match ductor
+    },
+
+    perchanresp : {
+        type: "PerChannelResponse",
+        data: {
+            filename: params.files.chresp,
+        }
+    },
+    // It's a little awkward to NOT use PerChannelResponse because you
+    // need to give an empty string to a component that wants to use
+    // it an an empty list to the "uses".  Here we package that little
+    // "if" branch.  It's a general pattern not specific to this
+    // object.  Might want to make wc.tn() convert "null" into "" and
+    // g.uses() convert [null] into [].
+    perchanresp_nameuses : if std.type(params.files.chresp) == 'null'
+    then {name:"", uses:[]}
+    else {name:wc.tn(self.perchanresp), uses:[self.perchanresp]},
+
+
+    wires : {
+        type: "WireSchemaFile",
+        data: { filename: params.files.wires }
+    },
+
+    elec_resp : std.mapWithIndex(function (n, e) {
+        type: if std.objectHas(e, "type")
+              then e.type
+              else "ColdElecResponse", // default
+        name: "Plane%iElectronicsResponse" % n,
+        data: sim_response_binning {
+            shaping: e.shaping,
+            gain: e.gain,
+            postgain: e.postgain,
+            filename: if std.objectHas(e, "filename")
+                      then e.filename
+                      else ""
+        },
+    }, params.elec),
+
+    rc_resp : {
+        type: if std.objectHas(params, 'rc_resp') && std.objectHas(params.rc_resp, "type")
+              then params.rc_resp.type
+              else "RCResponse", // default
+        data: std.prune(sim_response_binning {
+            width: if std.objectHas(params, 'rc_resp') && std.objectHas(params.rc_resp, 'width')
+            then params.rc_resp.width else null,
+
+            filename: if std.objectHas(params, 'rc_resp') && std.objectHas(params.rc_resp, 'filename')
+            then params.rc_resp.filename else null,
+
+            postgain: if std.objectHas(params, 'rc_resp') && std.objectHas(params.rc_resp, 'postgain')
+            then params.rc_resp.postgain else null,
+
+            start: if std.objectHas(params, 'rc_resp') && std.objectHas(params.rc_resp, 'start')
+            then params.rc_resp.start else null,
+        })
+    },
+
+
+    sys_resp : {
+        type: "ResponseSys",
+        data: sim_response_binning {
+            start: params.sys_resp.start,
+            magnitude: params.sys_resp.magnitude,
+            time_smear: params.sys_resp.time_smear,
+        }
+    },
+
+    // there is one trio of PIRs (one per wire plane in a face) for
+    // each field response.  WARNING/fixme: this sets the default DFT
+    // with no way to override!  This config structure needs a redo!
+    pirs : std.mapWithIndex(function (n, fr) [
+        {
+            type: "PlaneImpactResponse",
+            name : "PIR%splane%d" % [fr.name, plane],
+            data : sim_response_binning {
+                plane: plane,
+                dft: wc.tn($.dft),
+                field_response: wc.tn(fr),
+                // note twice we give rc so we have rc^2 in the final convolution
+                short_responses: if params.sys_status == false
+                                    then [wc.tn($.elec_resp[plane])]
+                                    else [wc.tn($.elec_resp[plane]), wc.tn($.sys_resp)],
+		overall_short_padding: if std.objectHas(params, 'overall_short_padding')
+                                    then params.overall_short_padding
+                                    else if params.sys_status == false
+                                    then 0.1*wc.ms
+                                    // cover the full time range of the convolved short responses
+                                    else 0.1*wc.ms - params.sys_resp.start,
+		// long_responses: [wc.tn($.rc_resp), wc.tn($.rc_resp)],
+        long_responses: if std.objectHas(params, 'rc_resp')
+        then std.makeArray(params.rc_resp.rc_layers, function(x) wc.tn($.rc_resp))
+        else [wc.tn($.rc_resp), wc.tn($.rc_resp)],
+		long_padding: 1.5*wc.ms,
+	    },
+            uses: [$.dft, fr, $.elec_resp[plane], $.rc_resp, $.sys_resp],
+        } for plane in [0,1,2]], $.fields),
+
+    // One anode per detector "volume"
+    anodes : [{
+        type : "AnodePlane",
+        name : vol.name,
+        data : {
+            // This ID is used to pick out which wires in the
+            // WireSchema belong to this anode plane.
+            ident : vol.wires,
+            nimpacts: params.sim.nimpacts,
+            // The wire schema file
+            wire_schema: wc.tn($.wires),
+
+            faces : vol.faces,
+        },
+        uses: [$.wires],
+    } for vol in params.det.volumes],
+
+    // Arbitrarily call out the first anode to make single-anode
+    // detector config slightly cleaner.
+    anode: $.anodes[0],
+
+}
+

--- a/cfg/pgrapher/experiment/icarus/params.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/params.jsonnet
@@ -77,20 +77,22 @@ base {
 
     adc: super.adc {
         // fix baseline at 2048 (induction), 400 (collection)
-        baselines: [1650.0*wc.millivolt, 1650.0*wc.millivolt, 322.3*wc.millivolt],
-
+       baselines: [1650.0*wc.millivolt, 1650.0*wc.millivolt, 322.3*wc.millivolt],
         // From ICARUS paper: https://iopscience.iop.org/article/10.1088/1748-0221/13/12/P12007/pdf
         //check (values taken from the FE calibration shown in pg. 7 of the paper)
-        fullscale: [0*wc.volt, 3.3*wc.volt],
+        fullscale: [0.8*wc.millivolt, 3.3*wc.volt],
     },
 
-    elec: super.elec {
+    elec: [super.elec {
         type: "WarmElecResponse",
-        gain: 17.8075*wc.mV/wc.fC, // 0.027 fC/(ADC*us)
+        // Old values:
+        //   ICARUS nominal: 17.8075*wc.mV/wc.fC // 0.027 fC/(ADC*us)
+        //   Match data ADC values (docdb 25161): 14.9654*wc.mV/wc.fC, // 0.0321 fC/(ADC*us)
+        gain: 14.9654*wc.mV/wc.fC, // 0.0321 fC/(ADC*us)
         shaping: 1.3*wc.us,
         postgain: 1.0,
         start: 0,
-    },
+    }, for _ in [0, 1, 2]],
 
 
     sim: super.sim {
@@ -127,10 +129,10 @@ base {
 
         fields: ["garfield-icarus-fnal-rev1.json.bz2"],
 
-       noise: ["icarus_noise_model_int_TPCEE.json.bz2","icarus_noise_model_int_TPCEW.json.bz2","icarus_noise_model_int_TPCWE.json.bz2","icarus_noise_model_int_TPCWW.json.bz2"],
-       // coherent_noise: ["icarus_noise_model_coh_TPCEE.json.bz2","icarus_noise_model_coh_TPCEW.json.bz2","icarus_noise_model_coh_TPCWE.json.bz2","icarus_noise_model_coh_TPCWW.json.bz2"],
+       // noise: ["icarus_noise_model_int_TPCEE.json.bz2","icarus_noise_model_int_TPCEW.json.bz2","icarus_noise_model_int_TPCWE.json.bz2","icarus_noise_model_int_TPCWW.json.bz2"],
+       // coherent_noise: ["icarus_noise_model_coh_TPCEE.json.bz2","icarus_noise_model_coh_TPCEW.json.bz2","icarus_noise_model_coh_TPCWE.json.bz2","icarus_noise_model_coh_TPCWW.json.bz2"],	
 	wiregroups: "icarus_group_to_channel_map.json.bz2",
-	noisegroups: ["icarus_noise_model_coh_by_board_TPCEE.json.bz2","icarus_noise_model_coh_by_board_TPCEW.json.bz2","icarus_noise_model_coh_by_board_TPCWE.json.bz2","icarus_noise_model_coh_by_board_TPCWW.json.bz2"],
+	noisegroups: ["icarus_noise_model_int_by_board_TPCEE.json.bz2","icarus_noise_model_int_by_board_TPCEW.json.bz2","icarus_noise_model_int_by_board_TPCWE.json.bz2","icarus_noise_model_int_by_board_TPCWW.json.bz2","icarus_noise_model_coh_by_board_TPCEE.json.bz2","icarus_noise_model_coh_by_board_TPCEW.json.bz2","icarus_noise_model_coh_by_board_TPCWE.json.bz2","icarus_noise_model_coh_by_board_TPCWW.json.bz2"],
         chresp: null,
     },
 

--- a/cfg/pgrapher/experiment/icarus/simparams.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/simparams.jsonnet
@@ -10,9 +10,9 @@ base {
     // Transverse diffusion constant
     DT :  8.8 * wc.cm2/wc.s,
     // Electron lifetime
-    lifetime : 9.6*wc.ms,
+    lifetime : 3.5*wc.ms,
     // Electron drift speed, assumes a certain applied E-field
-    drift_speed : 1.6*wc.mm/wc.us, // at 500 V/cm
+    drift_speed : 1.5756*wc.mm/wc.us, // at 500 V/cm
   },
   daq: super.daq {
 
@@ -39,15 +39,6 @@ base {
   //    chresp: null,
   //},
 
-  // This sets a relative gain at the input to the ADC.  Note, if
-  // you are looking to fix SimDepoSource, you are in the wrong
-  // place.  See the "scale" parameter of wcls.input.depos() defined
-  // in pgrapher/common/ui/wcls/nodes.jsonnet.
-  elec: super.elec {
-    // postgain: 1.0,
-    // shaping: 2.2 * wc.us,
-  },
-
   sys_status: false,
   sys_resp: {
     // overall_short_padding should take into account this offset "start".
@@ -56,8 +47,8 @@ base {
     time_smear: 1.0 * wc.us,
   },
 
-  rc_resp: {
-    width: 1.1*wc.ms,
-    rc_layers: 1,
-  }
+   rc_resp: {
+     width: 1.1*wc.ms,
+     rc_layers: 1,
+   }
 }

--- a/cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-omit-noise.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-omit-noise.jsonnet
@@ -7,7 +7,7 @@ local f = import 'pgrapher/common/funcs.jsonnet';
 local wc = import 'wirecell.jsonnet';
 
 local io = import 'pgrapher/common/fileio.jsonnet';
-local tools_maker = import 'pgrapher/common/tools.jsonnet';
+local tools_maker = import 'pgrapher/experiment/icarus/tools.jsonnet';
 // local params = import 'pgrapher/experiment/icarus/simparams.jsonnet';
 local base = import 'pgrapher/experiment/icarus/simparams.jsonnet';
 local params = base {
@@ -124,7 +124,7 @@ local chndb = [{
   type: 'OmniChannelNoiseDB',
   name: 'ocndbperfect%d' % n,
   data: perfect(params, tools.anodes[n], tools.field, n){dft:wc.tn(tools.dft)},
-  uses: [tools.anodes[n], tools.field, tools.dft],
+  uses: [tools.anodes[n], tools.field, tools.dft],  // pnode extension
 } for n in anode_iota];
 
 
@@ -152,10 +152,20 @@ local wcls_simchannel_sink = g.pnode({
     u_to_rp: 100 * wc.mm,
     v_to_rp: 100 * wc.mm,
     y_to_rp: 100 * wc.mm,
-    u_time_offset: 0.0 * wc.us,
-    v_time_offset: 0.0 * wc.us,
-    y_time_offset: 0.0 * wc.us,
-    g4_ref_time: -1150 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
+
+    // GP: The shaping time of the electronics response (1.3us) shifts the peak
+    //     of the field response time. Eyeballing simulation times, it does this
+    //     by a bit less than the 1.3us.
+    //
+    //     N.B. for future: there is likely an additional offset on the two induction
+    //     planes due to where the deconvolution precisely defines where the "peak"
+    //     of the pulse is. One may want to refine these parameters to account for that.
+    //     This perturbation shouldn't be more than a tick or two.
+    u_time_offset: 1.0 * wc.us,
+    v_time_offset: 1.0 * wc.us,
+    y_time_offset: 1.0 * wc.us,
+
+    g4_ref_time: -1500 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
     use_energy: true,
   },
 }, nin=1, nout=1, uses=tools.anodes);

--- a/cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel.jsonnet
@@ -7,9 +7,28 @@ local f = import 'pgrapher/common/funcs.jsonnet';
 local wc = import 'wirecell.jsonnet';
 
 local io = import 'pgrapher/common/fileio.jsonnet';
-local tools_maker = import 'pgrapher/common/tools.jsonnet';
+local tools_maker = import 'pgrapher/experiment/icarus/icarus_tools.jsonnet';
 // local params = import 'pgrapher/experiment/icarus/simparams.jsonnet';
 local base = import 'pgrapher/experiment/icarus/simparams.jsonnet';
+
+// load the electronics response parameters
+local er_params = [
+  {
+    gain: std.extVar('gain0')*wc.mV/wc.fC,
+    shaping: std.extVar('shaping0')*wc.us,
+  },
+
+  {
+    gain: std.extVar('gain1')*wc.mV/wc.fC,
+    shaping: std.extVar('shaping1')*wc.us,
+  },
+
+  {
+    gain: std.extVar('gain2')*wc.mV/wc.fC,
+    shaping: std.extVar('shaping2')*wc.us,
+  },
+];
+
 local params = base {
   lar: super.lar {
     // Longitudinal diffusion constant
@@ -21,6 +40,28 @@ local params = base {
     // Electron drift speed, assumes a certain applied E-field
     // drift_speed: std.extVar('driftSpeed') * wc.mm / wc.us,
   },
+  files: super.files {
+    fields: [ std.extVar('files_fields'), ],
+  },
+
+  rc_resp: if std.extVar('file_rcresp') != "" then
+  {
+    // "icarus_fnal_rc_tail.json"
+    filename: std.extVar('file_rcresp'),
+    postgain: 1.0,
+    start: 0.0,
+    tick: 0.4*wc.us,
+    nticks: 4255,
+    type: "JsonElecResponse",
+    rc_layers: 1
+  }
+  else super.rc_resp,
+
+  elec: std.mapWithIndex(function (n, eparam)
+    super.elec[n] + {
+      gain: eparam.gain,
+      shaping: eparam.shaping,
+    }, er_params),
 };
 
 local tools = tools_maker(params);
@@ -41,9 +82,24 @@ local output = 'wct-sim-ideal-sig.npz';
 
 local wcls_maker = import 'pgrapher/ui/wcls/nodes.jsonnet';
 local wcls = wcls_maker(params, tools);
+//local wcls_input = {
+//  // depos: wcls.input.depos(name="", art_tag="ionization"),
+//  depos: wcls.input.depos(name='electron', art_tag='ionization'),  // default art_tag="blopper"
+//};
+
+//Haiwang DepoSetSource Implementation:
 local wcls_input = {
-  // depos: wcls.input.depos(name="", art_tag="ionization"),
-  depos: wcls.input.depos(name='electron', art_tag='ionization'),  // default art_tag="blopper"
+	depos: wcls.input.depos(name="", art_tag="IonAndScint"),
+	deposet: g.pnode({
+        	type: 'wclsSimDepoSetSource',
+        	name: "electron",
+        	data: {
+            	model: "",
+            	scale: -1, //scale is -1 to correct a sign error in the SimDepoSource converter.
+            	art_tag: "ionization", //name of upstream art producer of depos "label:instance:processName"
+            	assn_art_tag: "",
+        	},
+    	}, nin=0, nout=1),
 };
 
 // Collect all the wc/ls output converters for use below.  Note the
@@ -112,7 +168,38 @@ local wcls_output = {
 };
 
 //local deposio = io.numpy.depos(output);
-local drifter = sim.drifter;
+//local drifter = sim.drifter;
+local localeLiftime = [std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us];
+local drifters = [{
+        local xregions = wc.unique_list(std.flattenArrays([v.faces for v in params.det.volumes])),
+
+        type: "Drifter",
+	name: "drifter%d" %n,
+        data: params.lar {
+            rng: wc.tn(tools.random),
+            xregions: xregions,
+            time_offset: params.sim.depo_toffset,
+
+            drift_speed: params.lar.drift_speed,
+            fluctuate: params.sim.fluctuate,
+
+            DL: params.lar.DL,
+            DT: params.lar.DT,
+            lifetime: localeLiftime[n],
+
+        },
+    } 
+	for n in std.range(0,7)];
+
+local setdrifter = [g.pnode({
+            type: 'DepoSetDrifter',
+	    name: 'setdrifter%d' %n,
+            data: {
+                drifter: wc.tn(drifters[n])
+            }
+        }, nin=1, nout=1,
+        uses=[drifters[n]])
+	for n in std.range(0,7)];
 local bagger = sim.make_bagger();
 
 // signal plus noise pipelines
@@ -138,12 +225,12 @@ local sp = sp_maker(params, tools);
 local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
 
 local rng = tools.random;
-local wcls_simchannel_sink = g.pnode({
-  type: 'wclsSimChannelSink',
-  name: 'postdrift',
+local wcls_simchannel_sink = [ g.pnode({
+  type: 'wclsDepoSetSimChannelSink',
+  name: 'postdrift%d' %n,
   data: {
-    artlabel: 'simpleSC',  // where to save in art::Event
-    anodes_tn: [wc.tn(anode) for anode in tools.anodes],
+    artlabel: 'simpleSC%d' %n,  // where to save in art::Event
+    anode: wc.tn(tools.anodes[n]),//[wc.tn(anode) for anode in tools.anodes],
     rng: wc.tn(rng),
     tick: params.daq.tick,
     start_time: -0.34 * wc.ms, // TriggerOffsetTPC from detectorclocks_icarus.fcl
@@ -153,54 +240,53 @@ local wcls_simchannel_sink = g.pnode({
     u_to_rp: 100 * wc.mm,
     v_to_rp: 100 * wc.mm,
     y_to_rp: 100 * wc.mm,
-    u_time_offset: 0.0 * wc.us,
-    v_time_offset: 0.0 * wc.us,
-    y_time_offset: 0.0 * wc.us,
-    g4_ref_time: -1150 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
+
+    // GP: The shaping time of the electronics response (1.3us) shifts the peak
+    //     of the field response time. Eyeballing simulation times, it does this
+    //     by a bit less than the 1.3us (1us).
+    //
+    //     N.B. for future: there is likely an additional offset on the two induction
+    //     planes due to where the deconvolution precisely defines where the "peak"
+    //     of the pulse is. One may want to refine these parameters to account for that.
+    //     This perturbation shouldn't be more than a tick or two.
+    u_time_offset: std.extVar('time_offset_u') * wc.us,
+    v_time_offset: std.extVar('time_offset_v') * wc.us,
+    y_time_offset: std.extVar('time_offset_y') * wc.us,
+
+    g4_ref_time: -1500 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
     use_energy: true,
   },
-}, nin=1, nout=1, uses=tools.anodes);
+}, nin=1, nout=1, uses=tools.anodes)
+for n in std.range(0,7)];
 
-local make_noise_model = function(anode,n, csdb=null) {
-    type: "EmpiricalNoiseModel",
-    name: "empericalnoise-" + anode.name,
-    data: {
-        anode: wc.tn(anode),
-        dft: wc.tn(tools.dft),
-        chanstat: if std.type(csdb) == "null" then "" else wc.tn(csdb),
-        spectra_file: params.files.noise[n],
-        nsamples: params.daq.nticks,
-        period: params.daq.tick,
-        wire_length_scale: 1.0*wc.cm, // optimization binning
-    },
-    uses: [anode, tools.dft] + if std.type(csdb) == "null" then [] else [csdb],
-};
+local nicks = ["incoTPCEE","incoTPCEW","incoTPCWE","incoTPCWW", "coheTPCEE","coheTPCEW","coheTPCWE","coheTPCWW"];
+local scale_int = std.extVar('int_noise_scale');
+local scale_coh = std.extVar('coh_noise_scale');
+local models = [
+    {
+        type: "GroupNoiseModel",
+        name: nicks[n],
+        data: {
+            // This can also be given as a JSON/Jsonnet file
+            spectra: params.files.noisegroups[n],
+            groups: params.files.wiregroups,
+            scale: if n<4 then scale_int else scale_coh,
+            nsamples: params.daq.nticks,
+            tick: params.daq.tick,
+        }
+    } for n in std.range(0,7)];
 
-local noise_model = [make_noise_model(mega_anode,n) for n in std.range(0,3)];
-local add_noise = function(model, n) g.pnode({
-    type: "AddNoise",
+local add_noise = function(model, n,t) g.pnode({
+    type: t,
     name: "addnoise%d-" %n + model.name,
     data: {
         rng: wc.tn(tools.random),
-        dfg: wc.tn(tools.dft),
+        dft: wc.tn(tools.dft),
         model: wc.tn(model),
-  nsamples: params.daq.nticks,
-        replacement_percentage: 0.02, // random optimization
+        nsamples: params.daq.nticks,
     }}, nin=1, nout=1, uses=[tools.random, tools.dft, model]);
-local noises = [add_noise(noise_model[n], n) for n in std.range(0,3)];
-
-local add_coherent_noise = function(n) g.pnode({
-      type: "AddGroupNoise",
-      name: "addgroupnoise%d" %n,
-      data: {
-          spectra_file: params.files.noisegroups[n],
-	  map_file: params.files.wiregroups,
-          rng: wc.tn(tools.random),
-          dft: wc.tn(tools.dft),
-          nsamples: params.daq.nticks,
-	  spec_scale: 1.1,
-      }}, nin=1, nout=1, uses=[tools.random, tools.dft]);
-local coherent_noises = [add_coherent_noise(n) for n in std.range(0,3)];
+local noises = [add_noise(models[n], n,"IncoherentAddNoise") for n in std.range(0,3)];
+local coh_noises = [add_noise(models[n],n,"CoherentAddNoise") for n in std.range(4,7)];
 
 // local digitizer = sim.digitizer(mega_anode, name="digitizer", tag="orig");
 local digitizers = [
@@ -237,10 +323,24 @@ local frame_summers = [
         },
     }, nin=2, nout=1) for n in std.range(0, 3)];
 
-local actpipes = [g.pipeline([noises[n], coherent_noises[n], digitizers[n], /*retaggers[n],*/ wcls_output.sim_digits[n]], name="noise-digitizer%d" %n) for n in std.range(0,3)];
+local deposetfilter = [ g.pnode({
+            type: 'DepoSetFilter',
+   	    name: 'deposetfilter%d' %n,
+            data: {
+                anode: wc.tn(tools.anodes[n])
+            }
+        }, nin=1, nout=1,
+        uses=tools.anodes)
+	for n in std.range(0,7)];
+
+local actpipes = [g.pipeline([noises[n], coh_noises[n], digitizers[n], /*retaggers[n],*/ wcls_output.sim_digits[n]], name="noise-digitizer%d" %n) for n in std.range(0,3)];
 local util = import 'pgrapher/experiment/icarus/funcs.jsonnet';
 local outtags = ['orig%d' % n for n in std.range(0, 3)];
 local pipe_reducer = util.fansummer('DepoSetFanout', analog_pipes, frame_summers, actpipes, 'FrameFanin', 'fansummer', outtags);
+
+local driftpipes = [g.pipeline([deposetfilter[n],setdrifter[n], wcls_simchannel_sink[n]], name="depo-set-drifter%d" %n) for n in std.range(0,7)];
+
+local pipe_drift = util.fandrifter('DepoSetFanout',driftpipes,analog_pipes, frame_summers, actpipes, 'FrameFanin', 'fandrifter', outtags);
 
 // local retagger = g.pnode({
 //   type: 'Retagger',
@@ -263,8 +363,12 @@ local pipe_reducer = util.fansummer('DepoSetFanout', analog_pipes, frame_summers
 local sink = sim.frame_sink;
 
 // local graph = g.pipeline([wcls_input.depos, drifter,  wcls_simchannel_sink, bagger, pipe_reducer, retagger, wcls_output.sim_digits, sink]);
-local graph = g.pipeline([wcls_input.depos, drifter,  wcls_simchannel_sink, bagger, pipe_reducer, sink]);
+//local graph = g.pipeline([wcls_input.depos, drifter,  wcls_simchannel_sink, bagger, pipe_reducer, sink]);
 
+
+
+local graph = g.pipeline([wcls_input.deposet,pipe_drift, sink]);
+//local graph = g.pipeline([depos,pipe_drift, sink]);
 local app = {
   type: 'Pgrapher',
   data: {

--- a/gen/inc/WireCellGen/DepoSetFilter.h
+++ b/gen/inc/WireCellGen/DepoSetFilter.h
@@ -1,0 +1,35 @@
+//  Module is designed to filter depos based on provided APA dimentions.
+//  It takes pointer to full stack of depos from DepoFanout and outputs
+//  a poonter to only ones contained in a given volume
+
+#ifndef WIRECELLGEN_DEPOSETFILTER
+#define WIRECELLGEN_DEPOSETFILTER
+
+#include "WireCellIface/IDepoSetFilter.h"
+#include "WireCellIface/INamed.h"
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellAux/Logger.h"
+#include "WireCellUtil/BoundingBox.h"
+
+namespace WireCell::Gen {
+
+    class DepoSetFilter : public Aux::Logger, public IDepoSetFilter, public IConfigurable {
+       public:
+        DepoSetFilter();
+        virtual ~DepoSetFilter();
+
+        // IDepoSetFilter
+        virtual bool operator()(const input_pointer& in, output_pointer& out);
+
+        /// WireCell::IConfigurable interface.
+        virtual void configure(const WireCell::Configuration& config);
+        virtual WireCell::Configuration default_configuration() const;
+
+       private:
+        std::vector<WireCell::BoundingBox> m_boxes;
+        std::size_t m_count{0};
+    };
+
+}  // namespace WireCell::Gen
+
+#endif

--- a/gen/src/DepoSetFilter.cxx
+++ b/gen/src/DepoSetFilter.cxx
@@ -1,0 +1,65 @@
+#include "WireCellGen/DepoSetFilter.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellAux/SimpleDepoSet.h"
+#include "WireCellIface/IAnodePlane.h"
+#include "WireCellIface/IDepo.h"
+
+WIRECELL_FACTORY(DepoSetFilter, WireCell::Gen::DepoSetFilter, WireCell::INamed, WireCell::IDepoSetFilter,
+                 WireCell::IConfigurable)
+
+using namespace WireCell;
+using namespace WireCell::Gen;
+
+DepoSetFilter::DepoSetFilter()
+  : Aux::Logger("DepoSetFilter", "gen")
+{
+}
+DepoSetFilter::~DepoSetFilter() {}
+
+WireCell::Configuration DepoSetFilter::default_configuration() const
+{
+    Configuration cfg;
+    cfg["anode"] = "AnodePlane";
+    return cfg;
+}
+
+void DepoSetFilter::configure(const WireCell::Configuration& cfg)
+{
+    const std::string anode_tn = cfg["anode"].asString();
+    if (anode_tn.empty()) {
+        THROW(ValueError() << errmsg{"DepoSetFilter requires an anode plane"});
+    }
+    WireCell::IAnodePlane::pointer anode = Factory::find_tn<IAnodePlane>(anode_tn);
+    IAnodeFace::vector abode_faces = anode->faces();
+    for (auto face : abode_faces) {
+        m_boxes.push_back(face->sensitive());
+    }
+}
+
+bool DepoSetFilter::operator()(const input_pointer& in, output_pointer& out)
+{
+    out = nullptr;
+    if (!in) {
+        log->debug("DepoSetFilter fail with no input on call = {}", m_count);
+        return true;
+    }
+    IDepo::vector output_depos;
+    for (auto idepo : *(in->depos())) {
+        bool pass = false;
+        for (auto box : m_boxes) {
+            WireCell::Ray r = box.bounds();
+
+            if (box.inside(idepo->pos())) {
+                pass = true;
+                break;
+            }
+        }
+        if (pass) {
+            output_depos.push_back(idepo);
+        }
+    }
+    log->debug("call={} Number of Depos for a give APA={}", m_count, output_depos.size());
+    out = std::make_shared<WireCell::Aux::SimpleDepoSet>(m_count, output_depos);
+    ++m_count;
+    return true;
+}

--- a/gen/src/DepoSetFilter.cxx
+++ b/gen/src/DepoSetFilter.cxx
@@ -30,6 +30,9 @@ void DepoSetFilter::configure(const WireCell::Configuration& cfg)
         THROW(ValueError() << errmsg{"DepoSetFilter requires an anode plane"});
     }
     WireCell::IAnodePlane::pointer anode = Factory::find_tn<IAnodePlane>(anode_tn);
+    if (anode == nullptr) {
+        THROW(ValueError() << errmsg{"Input anode is a nullptr"});
+    }
     IAnodeFace::vector abode_faces = anode->faces();
     for (auto face : abode_faces) {
         m_boxes.push_back(face->sensitive());


### PR DESCRIPTION
1. Add DepoSetFilter module to split depos between APAs. Module is configured based on APA's dimentions and checkes if a give depo is positioned inside it

2. Add configurations for icarus to support the module with different eLifetime for each APA [currently hardcoded]

3. Make various configurations for icarus up-to-date with current icaruscode [work from Gray on field response and rc response]