### PR TITLE
Persist channel mask map 

### DIFF
--- a/gen/inc/WireCellGen/Retagger.h
+++ b/gen/inc/WireCellGen/Retagger.h
@@ -49,6 +49,7 @@ namespace WireCell {
 
            private:
             tagrules::Context m_trctx;
+            std::map<std::string, std::string> m_maskmap;
         };
     }  // namespace Gen
 }  // namespace WireCell

--- a/gen/src/FrameFanin.cxx
+++ b/gen/src/FrameFanin.cxx
@@ -98,6 +98,10 @@ bool Gen::FrameFanin::operator()(const input_vector& invec, output_pointer& out)
     tagrules::tagset_t fouttags;
     ITrace::vector out_traces;
     IFrame::pointer one = nullptr;
+    
+    Waveform::ChannelMaskMap out_cmm;
+    std::map<std::string, std::string> empty_name_map;
+
     for (size_t iport = 0; iport < m_multiplicity; ++iport) {
         const size_t trace_offset = out_traces.size();
 
@@ -108,6 +112,8 @@ bool Gen::FrameFanin::operator()(const input_vector& invec, output_pointer& out)
             one = fr;
         }
         auto traces = fr->traces();
+        auto masks = fr->masks();
+        Waveform::merge(out_cmm, masks, empty_name_map); 
 
         {  // collect output frame tags by tranforming each input frame
            // tag based on user rules.
@@ -147,7 +153,7 @@ bool Gen::FrameFanin::operator()(const input_vector& invec, output_pointer& out)
         out_traces.insert(out_traces.end(), traces->begin(), traces->end());
     }
 
-    auto sf = new Aux::SimpleFrame(one->ident(), one->time(), out_traces, one->tick());
+    auto sf = new Aux::SimpleFrame(one->ident(), one->time(), out_traces, one->tick(), out_cmm);
     for (size_t iport = 0; iport < m_multiplicity; ++iport) {
         if (m_tags[iport].size()) {
             sf->tag_traces(m_tags[iport], by_port[iport]);

--- a/gen/src/FrameFanin.cxx
+++ b/gen/src/FrameFanin.cxx
@@ -100,6 +100,7 @@ bool Gen::FrameFanin::operator()(const input_vector& invec, output_pointer& out)
     IFrame::pointer one = nullptr;
     
     Waveform::ChannelMaskMap out_cmm;
+    // creating an empty name map; only want combine the two maskmaps from each APA into a single maskmap, NOT merge masks
     std::map<std::string, std::string> empty_name_map;
 
     for (size_t iport = 0; iport < m_multiplicity; ++iport) {

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -1464,7 +1464,8 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
             if (och.plane < 0) {
                 continue;  // in case user gives us multi apa frame
             }
-            m_cmm[name][och.channel] = m.second;
+            // m_cmm[name][och.channel] = m.second;
+            m_cmm["bad"][och.channel] = m.second; // make sure load_data gets all the masked channels
         }
     }
 
@@ -1656,7 +1657,7 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
         }
     }
 
-    auto sframe = new Aux::SimpleFrame(in->ident(), in->time(), ITrace::shared_vector(itraces), in->tick(), m_cmm);
+    auto sframe = new Aux::SimpleFrame(in->ident(), in->time(), ITrace::shared_vector(itraces), in->tick(), in->masks());
     sframe->tag_frame(m_frame_tag);
 
     // this assumes save_data produces itraces in OSP channel order


### PR DESCRIPTION
PR to persist the channel mask map from noise filtering through signal processing, fanin, and retagger. 

1. **in OmnibusSigProc**: persist the cmm from the inframe by adding it to the outframe. 
2. **in FrameFanIn**: combine the two ChannelMaskMaps from each APA into a single ChannelMaskMap. To do this, I created an empty map of the mask names to make sure no ChannelMask merging would be performed at this stage. The single ChannelMaskMap is persisted into the outframe. 
3. **in Retagger**: similar to the configuration in OmnibusNoiseFilter for mapping "noisy" -> "bad", "ledge" -> bad, I added a configuration option that allows us to merge "bad0" -> "bad" and "bad1" -> "bad". The default configuration option should allow backwards compatibility. 