### PR TITLE
Use IAnodePlane::which() or index

### DIFF
--- a/gen/src/AnodePlane.cxx
+++ b/gen/src/AnodePlane.cxx
@@ -148,6 +148,8 @@ void Gen::AnodePlane::configure(const WireCell::Configuration& cfg)
 
     m_faces.resize(nfaces);
     // note, WireSchema requires front/back face ordering in an anode
+    // note, iface is a per-anode index and can be different with the per-anode ident
+    // it will be used as WirePlandID::face() and IAnodeFace::which()
     for (size_t iface = 0; iface < nfaces; ++iface) {
         const auto& ws_face = ws_faces[iface];
         std::vector<WireSchema::Plane> ws_planes = ws_store.planes(ws_face);

--- a/iface/inc/WireCellIface/IAnodeFace.h
+++ b/iface/inc/WireCellIface/IAnodeFace.h
@@ -32,7 +32,9 @@ namespace WireCell {
         /// Return the ident number of this face.
         virtual int ident() const = 0;
 
-        /// Return which face: 0/1.  Face 0 is toward the positive,
+        /// Note, return the "iface" or per-anode index.
+        /// FIXME: remove the following comment sometime
+        /// Original design: is to be 0/1.  Face 0 is toward the positive,
         /// global X-axis.  IOW, electrons drift toward face 0 in the
         /// negative-X direction.
         virtual int which() const = 0;

--- a/iface/inc/WireCellIface/WirePlaneId.h
+++ b/iface/inc/WireCellIface/WirePlaneId.h
@@ -29,7 +29,7 @@ namespace WireCell {
         /// Layer as index number (0,1 or 2).  -1 if unknown
         int index() const;
 
-        /// APA face number
+        /// per-Anode face index NOT ident!
         int face() const;
 
         /// APA number

--- a/img/src/GridTiling.cxx
+++ b/img/src/GridTiling.cxx
@@ -60,7 +60,7 @@ bool Img::GridTiling::operator()(const input_pointer& slice, output_pointer& out
     }
 
     const auto anodeid = m_anode->ident();
-    const auto faceid = m_face->ident();
+    const auto faceid = m_face->which(); // per-Anode face index
 
     auto chvs = slice->activity();
 

--- a/img/test/doctest_clustering_prototype.cxx
+++ b/img/test/doctest_clustering_prototype.cxx
@@ -43,7 +43,8 @@ Points::node_ptr make_simple_pctree()
 
     // Insert a child with a set of named points clouds with one point
     // cloud from a track.
-    /// TODO: can only do this on construction?
+    /// QUESTION: can only do this on construction?
+    /// QUESTION: units?
     auto* n1 = root->insert(Points({
         {"center", make_janky_track(Ray(Point(0.5, 0, 0), Point(0.7, 0, 0)))},
         {"3d", make_janky_track(Ray(Point(0, 0, 0), Point(1, 0, 0)))}
@@ -111,7 +112,8 @@ TEST_CASE("PointCloudFacade test")
     const auto& kd = rval.scoped_kd(scope);
     // CHECK(&kd.pointclouds() == &pc3d);
 
-    auto knn = kd.knn(2, {0.5, 0, 0});
+    /// QUESTION: how to get it -> node?
+    auto knn = kd.knn(2, {1, 0, 0});
     for (auto [it,dist] : knn) {
         auto& pt = *it;
         debug("knn: pt=({},{},{}) dist={}",
@@ -120,7 +122,7 @@ TEST_CASE("PointCloudFacade test")
     CHECK(knn.size() == 2);
 
 
-    auto rad = kd.radius(.01, {0.5, 0, 0});
+    auto rad = kd.radius(.01, {1, 0, 0});
     for (auto [it,dist] : rad) {
         auto& pt = *it;
         debug("rad: pt=({},{},{}) dist={}",

--- a/img/test/doctest_clustering_prototype.cxx
+++ b/img/test/doctest_clustering_prototype.cxx
@@ -1,0 +1,131 @@
+#include "WireCellUtil/PointTree.h"
+#include "WireCellUtil/PointTesting.h"
+
+#include "WireCellUtil/doctest.h"
+
+#include "WireCellUtil/Logging.h"
+
+#include <unordered_map>
+
+using namespace WireCell;
+using namespace WireCell::PointTesting;
+using namespace WireCell::PointCloud;
+using namespace WireCell::PointCloud::Tree;
+using spdlog::debug;
+
+using node_ptr = std::unique_ptr<Points::node_t>;
+
+static void print_dds(const DisjointDataset& dds) {
+    for (size_t idx=0; idx<dds.values().size(); ++idx) {
+        const Dataset& ds = dds.values()[idx];
+        std::stringstream ss;
+        ss << "ds: " << idx << std::endl;
+        const size_t len = ds.size_major();
+        for (const auto& key : ds.keys()) {
+            auto arr = ds.get(key).elements<double>();
+            ss << key << ": ";
+            for(auto elem : arr) {
+                ss << elem << " ";
+            }
+            ss << std::endl;
+        }
+        std::cout << ss.str() << std::endl;
+    }
+}
+
+static
+Points::node_ptr make_simple_pctree()
+{
+    spdlog::set_level(spdlog::level::debug); // Set global log level to debug
+
+    // empty root node
+    Points::node_ptr root = std::make_unique<Points::node_t>();
+
+    // Insert a child with a set of named points clouds with one point
+    // cloud from a track.
+    /// TODO: can only do this on construction?
+    auto* n1 = root->insert(Points({
+        {"center", make_janky_track(Ray(Point(0.5, 0, 0), Point(0.7, 0, 0)))},
+        {"3d", make_janky_track(Ray(Point(0, 0, 0), Point(1, 0, 0)))}
+        }));
+
+    const Dataset& pc1 = n1->value.local_pcs().at("3d");
+    debug("pc1: {}", pc1.size_major());
+    
+
+    // Ibid from a different track
+    auto* n2 = root->insert(Points({
+        {"center", make_janky_track(Ray(Point(1.5, 0, 0), Point(1.7, 0, 0)))},
+        {"3d", make_janky_track(Ray(Point(1, 0, 0), Point(2, 0, 0)))}
+        }));
+
+    const Dataset& pc2 = n2->value.local_pcs().at("3d");
+    debug("pc2: {}", pc2.size_major());
+
+    REQUIRE(pc1 != pc2);
+    REQUIRE_FALSE(pc1 == pc2);
+
+    return root;
+}
+
+TEST_CASE("PointCloudFacade test")
+{
+    spdlog::set_level(spdlog::level::debug); // Set global log level to debug
+    auto root = make_simple_pctree();
+    CHECK(root.get());
+
+    // from WireCell::NaryTree::Node to WireCell::PointCloud::Tree::Points
+    auto& rval = root->value;
+
+    CHECK(root->children().size() == 2);
+    CHECK(root.get() == rval.node()); // node raw pointer == point's node
+    CHECK(rval.local_pcs().empty());
+    
+    {
+        auto& cval = *(root->child_values().begin());
+        const auto& pcs = cval.local_pcs();
+        CHECK(pcs.size() > 0);
+        // using pointcloud_t = Dataset;
+        // key: std::string, val: Dataset
+        for (const auto& [key,val] : pcs) {
+            debug("child has pc named \"{}\" with {} points", key, val.size_major());
+        }
+        const auto& pc3d = pcs.at("3d");
+        debug("got child PC named \"3d\" with {} points", pc3d.size_major());
+        CHECK(pc3d.size_major() > 0);
+        CHECK(pc3d.has("x"));
+        CHECK(pc3d.has("y"));
+        CHECK(pc3d.has("z"));
+        CHECK(pc3d.has("q"));
+    }
+
+    // name, coords, [depth]
+    Scope scope{ "3d", {"x","y","z"}};
+    const DisjointDataset& pc3d = rval.scoped_pc(scope);
+    CHECK(pc3d.values().size() == 2);
+    print_dds(pc3d);
+
+    const DisjointDataset& pccenter = rval.scoped_pc({ "center", {"x","y","z"}});
+    print_dds(pccenter);
+
+    const auto& kd = rval.scoped_kd(scope);
+    // CHECK(&kd.pointclouds() == &pc3d);
+
+    auto knn = kd.knn(2, {0.5, 0, 0});
+    for (auto [it,dist] : knn) {
+        auto& pt = *it;
+        debug("knn: pt=({},{},{}) dist={}",
+              pt[0], pt[1], pt[2], dist);
+    }
+    CHECK(knn.size() == 2);
+
+
+    auto rad = kd.radius(.01, {0.5, 0, 0});
+    for (auto [it,dist] : rad) {
+        auto& pt = *it;
+        debug("rad: pt=({},{},{}) dist={}",
+              pt[0], pt[1], pt[2], dist);
+    }
+    CHECK(rad.size() == 2);
+
+}

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -1520,9 +1520,10 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
             if (m_use_multi_plane_protection) {
                 for (const auto& f : m_anode->faces()) {
                     // mp3: 3 plane protection based on cleaup ROI
-                    roi_refine.MultiPlaneProtection(iplane, m_anode, m_roi_ch_ch_ident, roi_form, m_mp_th1, m_mp_th2, f->ident(), m_mp_tick_resolution);
+                    // f->which(): per-Anode face index
+                    roi_refine.MultiPlaneProtection(iplane, m_anode, m_roi_ch_ch_ident, roi_form, m_mp_th1, m_mp_th2, f->which(), m_mp_tick_resolution);
                     // mp2: 2 plane protection based on cleaup ROI
-                    roi_refine.MultiPlaneROI(iplane, m_anode, m_roi_ch_ch_ident, roi_form, m_mp_th1, m_mp_th2, f->ident(), m_mp_tick_resolution);
+                    roi_refine.MultiPlaneROI(iplane, m_anode, m_roi_ch_ch_ident, roi_form, m_mp_th1, m_mp_th2, f->which(), m_mp_tick_resolution);
                 }
                 save_mproi(*itraces, mp3_roi_traces, iplane, roi_refine.get_mp3_rois());
                 save_mproi(*itraces, mp2_roi_traces, iplane, roi_refine.get_mp2_rois());


### PR DESCRIPTION
ref: #250 #251
https://indico.bnl.gov/event/20839/contributions/81872/attachments/50370/86134/2023-10-12.pdf

Conclusion is
- we should use index not ident.
- seems the `which()` drifting direction convention is not used before and should be removed in the future

Testing with DUNE-VD genie:
https://www.phy.bnl.gov/twister/bee/set/c2160ad0-dfa5-4183-a0e8-24ea76217cb0/event/0/