### PR TITLE
gcc 13 compatability fix

### DIFF
--- a/util/inc/WireCellUtil/Dtype.h
+++ b/util/inc/WireCellUtil/Dtype.h
@@ -7,6 +7,7 @@
 #ifndef WIRECELL_UTIL_DTYPE
 #define WIRECELL_UTIL_DTYPE
 
+#include <cstdint>
 #include <complex>
 #include <typeinfo>
 #include <cstddef>


### PR DESCRIPTION
Avoid undefined int64_t / uint64_t errors in gcc 13.x