### PR TITLE
Shared noise model

### DIFF
--- a/cfg/pgrapher/experiment/dune-vd/sim.jsonnet
+++ b/cfg/pgrapher/experiment/dune-vd/sim.jsonnet
@@ -42,21 +42,30 @@ function(params, tools) {
         },
         uses: [anode, tools.dft] + if std.type(csdb) == "null" then [] else [csdb],
     },
-    local noise_models = [make_noise_model(anode) for anode in tools.anodes],
 
+    local mega_anode = {
+        type: 'MegaAnodePlane',
+        name: 'meganodes',
+        data: {
+            anodes_tn: [wc.tn(anode) for anode in tools.anodes],
+        },
+    },
 
-    local add_noise = function(model) g.pnode({
+    local add_noise = function(model, name="") g.pnode({
         type: "AddNoise",
-        name: "addnoise%s"%[model.name],
+        name: "addnoise%s"%[name],
         data: {
             rng: wc.tn(tools.random),
             dft: wc.tn(tools.dft),
             model: wc.tn(model),
-	    nsamples: params.daq.nticks,
+            nsamples: params.daq.nticks,
             replacement_percentage: 0.02, // random optimization
         }}, nin=1, nout=1, uses=[tools.random, tools.dft, model]),
 
-    local noises = [add_noise(model) for model in noise_models],
+    // multi model
+    // local noises = [add_noise(make_noise_model(anode), anode.name) for anode in tools.anodes],
+    // single model
+    local noises = [add_noise(make_noise_model(mega_anode), anode.name) for anode in tools.anodes],
 
     local digitizers = [
         sim.digitizer(anode, name="digitizer%d"%anode.data.ident, tag="orig%d"%anode.data.ident)

--- a/cfg/pgrapher/experiment/dune-vd/sim.jsonnet
+++ b/cfg/pgrapher/experiment/dune-vd/sim.jsonnet
@@ -62,10 +62,11 @@ function(params, tools) {
             replacement_percentage: 0.02, // random optimization
         }}, nin=1, nout=1, uses=[tools.random, tools.dft, model]),
 
-    // multi model
-    // local noises = [add_noise(make_noise_model(anode), anode.name) for anode in tools.anodes],
-    // single model
-    local noises = [add_noise(make_noise_model(mega_anode), anode.name) for anode in tools.anodes],
+    // TODO: make this an option?
+    local use_shared_model = true,
+    local noises = if use_shared_model == true
+    then [add_noise(make_noise_model(mega_anode), anode.name) for anode in tools.anodes]
+    else [add_noise(make_noise_model(anode), anode.name) for anode in tools.anodes],
 
     local digitizers = [
         sim.digitizer(anode, name="digitizer%d"%anode.data.ident, tag="orig%d"%anode.data.ident)

--- a/gen/inc/WireCellGen/EmpiricalNoiseModel.h
+++ b/gen/inc/WireCellGen/EmpiricalNoiseModel.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <mutex>
 
 namespace WireCell {
     namespace Gen {
@@ -90,6 +91,7 @@ namespace WireCell {
             int get_nsamples() { return m_nsamples; };
 
            private:
+            mutable std::mutex m_mutex_cache;
             IAnodePlane::pointer m_anode;
             IChannelStatus::pointer m_chanstat;
             IDFT::pointer m_dft;

--- a/gen/src/EmpiricalNoiseModel.cxx
+++ b/gen/src/EmpiricalNoiseModel.cxx
@@ -334,6 +334,7 @@ Gen::EmpiricalNoiseModel::channel_spectrum(int chid) const
         }
     }
 
+    std::lock_guard<std::mutex> lock(m_mutex_cache);
     // get truncated wire length for cache
     int ilen = 0;
     auto chlen = m_chid_to_intlen.find(chid);


### PR DESCRIPTION
To reduce duplicated caching memory. Ref: https://indico.fnal.gov/event/61879/

Example in [cfg/pgrapher/experiment/dune-vd/sim.jsonnet](https://github.com/WireCell/wire-cell-toolkit/compare/master...HaiwangYu:wire-cell-toolkit:clustering?expand=1#diff-aee67b6144112508c69c54befda7917043d853827bf288990594a2ab23664cc7)

individual models:
[wct-sim-fans (1).pdf](https://github.com/WireCell/wire-cell-toolkit/files/13310857/wct-sim-fans.1.pdf)

shared models:
[wct-sim-fans.pdf](https://github.com/WireCell/wire-cell-toolkit/files/13310858/wct-sim-fans.pdf)

