### PR TITLE
bugfix: missing include of unordered_map

### DIFF
--- a/aux/inc/WireCellAux/TensorDMdataset.h
+++ b/aux/inc/WireCellAux/TensorDMdataset.h
@@ -7,6 +7,8 @@
 #include "WireCellUtil/PointCloudDataset.h"
 #include "WireCellIface/ITensorSet.h"
 
+#include <unordered_map>
+
 namespace WireCell::Aux::TensorDM {
 
     /// PointCloud support

--- a/gen/test/test_empiricalnoisemodel.cxx
+++ b/gen/test/test_empiricalnoisemodel.cxx
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
         auto ienm = Factory::lookup<IConfigurable>("EmpiricalNoiseModel");
         auto cfg = ienm->default_configuration();
         cfg["spectra_file"] = spectra_file;
-        cfg["nsamples"] = nsamples;
+        cfg["nsamples"] = (unsigned int)nsamples;
         cfg["period"] = 0.5*units::us;
         cfg["wire_length_scale"] = units::cm,
         cfg["anode"] = "AnodePlane:0";


### PR DESCRIPTION
This fixes a bug where
`spack install wire-cell-toolkit`
fails with
`
 >> 129    ../aux/src/TensorDMdataset.cxx:113:10: error: no member named 'unordered_map' in namespa
            ce 'std'
`
