### PR TITLE
anode->face() needs ident, cleanups

### DIFF
--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -1521,9 +1521,9 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
                 for (const auto& f : m_anode->faces()) {
                     // mp3: 3 plane protection based on cleaup ROI
                     // f->which(): per-Anode face index
-                    roi_refine.MultiPlaneProtection(iplane, m_anode, m_roi_ch_ch_ident, roi_form, m_mp_th1, m_mp_th2, f->which(), m_mp_tick_resolution);
+                    roi_refine.MP3ROI(iplane, m_anode, f, m_roi_ch_ch_ident, roi_form, m_mp_th1, m_mp_th2, m_mp_tick_resolution);
                     // mp2: 2 plane protection based on cleaup ROI
-                    roi_refine.MultiPlaneROI(iplane, m_anode, m_roi_ch_ch_ident, roi_form, m_mp_th1, m_mp_th2, f->which(), m_mp_tick_resolution);
+                    roi_refine.MP2ROI(iplane, m_anode, f, m_roi_ch_ch_ident, roi_form, m_mp_th1, m_mp_th2, m_mp_tick_resolution);
                 }
                 save_mproi(*itraces, mp3_roi_traces, iplane, roi_refine.get_mp3_rois());
                 save_mproi(*itraces, mp2_roi_traces, iplane, roi_refine.get_mp2_rois());

--- a/sigproc/src/ROI_refinement.cxx
+++ b/sigproc/src/ROI_refinement.cxx
@@ -2585,12 +2585,13 @@ namespace {
 }  // namespace
 
 // mp3: 3 plane protection based on cleanup_roi_traces
-void ROI_refinement::MultiPlaneProtection(const int plane, const IAnodePlane::pointer anode,
-                                          const std::map<int, int> &map_ch, ROI_formation &roi_form,
-                                          const double mp_th1, const double mp_th2, const int faceid, const int tick_resolution,
-                                          const int wire_resolution, const int nbounds_layers)
+void ROI_refinement::MP3ROI(const int plane, const IAnodePlane::pointer anode, const IAnodeFace::pointer face,
+                            const std::map<int, int>& map_ch, ROI_formation& roi_form,
+                            const double mp_th1, const double mp_th2,
+                            const int tick_resolution, const int wire_resolution,
+                            const int nbounds_layers)
 {
-    //log->info("ROI_refinement::MultiPlaneProtection:");
+    //log->info("ROI_refinement::MP3ROI:");
     LogDebug("mp_th1: " << mp_th1 << ", mp_th2: " << mp_th2);
     std::set<int> print_chids = {1441, 875};
 
@@ -2610,7 +2611,7 @@ void ROI_refinement::MultiPlaneProtection(const int plane, const IAnodePlane::po
                 auto ch = anode->channel(chid);
                 auto wires = ch->wires();
                 for (auto wire : wires) {
-                    if (faceid != wire->planeid().face()) continue;
+                    if (face->which() != wire->planeid().face()) continue;
                     auto pit_id = wire->index();
                     coord.grid = pit_id;
                     coord.layer = iplane + nbounds_layers;
@@ -2662,7 +2663,6 @@ void ROI_refinement::MultiPlaneProtection(const int plane, const IAnodePlane::po
                 << " map_tick_pitch_roi: " << map_tick_pitch_roi[iplane].size());
     }
 
-    auto face = anode->face(faceid);
     WireCell::RayGrid::layer_index_t layer = plane + nbounds_layers;
     for (auto tc1 : map_tick_coord[ref_planes[0]]) {
         for (auto tc2 : map_tick_coord[ref_planes[1]]) {
@@ -2740,12 +2740,13 @@ void ROI_refinement::MultiPlaneProtection(const int plane, const IAnodePlane::po
 }
 
 // mp2: 2 plane protection based on cleaup ROI
-void ROI_refinement::MultiPlaneROI(const int target_plane, const IAnodePlane::pointer anode,
-                                   const std::map<int, int> &map_roichid_anodechid,  // ROI chid -> Anode chid
-                                   ROI_formation &roi_form, const double mp_th1, const double mp_th2, const int faceid,
-                                   const int tick_resolution, const int wire_resolution, const int nbounds_layers)
+void ROI_refinement::MP2ROI(const int target_plane, const IAnodePlane::pointer anode, const IAnodeFace::pointer face,
+                            const std::map<int, int>& map_roichid_anodechid, ROI_formation& roi_form,
+                            const double mp_th1, const double mp_th2,
+                            const int tick_resolution, const int wire_resolution,
+                            const int nbounds_layers)
 {
-    //log->info("ROI_refinement::MultiPlaneROI:");
+    //log->info("ROI_refinement::MP2ROI:");
     LogDebug("mp_th1: " << mp_th1 << ", mp_th2: " << mp_th2);
     std::set<int> print_chids = {1441, 875};
 
@@ -2762,7 +2763,7 @@ void ROI_refinement::MultiPlaneROI(const int target_plane, const IAnodePlane::po
         auto ch = anode->channel(chident);
         auto wires = ch->wires();
         for (auto wire : wires) {
-            if (faceid != wire->planeid().face()) continue;
+            if (face->which() != wire->planeid().face()) continue;
             auto wireid = wire->index();
             map_wireid_roichid[iplane][wireid] = roichid;
         }
@@ -2784,7 +2785,7 @@ void ROI_refinement::MultiPlaneROI(const int target_plane, const IAnodePlane::po
                 auto ch = anode->channel(chid);
                 auto wires = ch->wires();
                 for (auto wire : wires) {
-                    if (faceid != wire->planeid().face()) continue;
+                    if (face->which() != wire->planeid().face()) continue;
                     auto pit_id = wire->index();
                     coord.grid = pit_id;
                     coord.layer = iplane + nbounds_layers;
@@ -2830,7 +2831,6 @@ void ROI_refinement::MultiPlaneROI(const int target_plane, const IAnodePlane::po
                 << " map_tick_pitch_roi: " << map_tick_pitch_roi[iplane].size());
     }
 
-    auto face = anode->face(faceid);
     WireCell::RayGrid::layer_index_t layer = target_plane + nbounds_layers;
     for (auto tc1 : map_tick_coord[ref_planes[0]]) {
         for (auto tc2 : map_tick_coord[ref_planes[1]]) {

--- a/sigproc/src/ROI_refinement.h
+++ b/sigproc/src/ROI_refinement.h
@@ -32,15 +32,15 @@ namespace WireCell {
             void refine_data(int plane, ROI_formation& roi_form);
             void refine_data_debug_mode(int plane, ROI_formation& roi_form, const std::string& cmd);
 
-            void MultiPlaneProtection(const int plane, const IAnodePlane::pointer anode,
-                                      const std::map<int, int>& map_ch, ROI_formation& roi_form,
-                                      const double mp_th1 = 0., const double mp_th2 = 0., const int faceid = 1, const int tick_resolution = 10,
-                                      const int wire_resolution = 2, const int nbounds_layers = 2);
+            void MP3ROI(const int plane, const IAnodePlane::pointer anode, const IAnodeFace::pointer face,
+                        const std::map<int, int>& map_ch, ROI_formation& roi_form, const double mp_th1 = 0.,
+                        const double mp_th2 = 0., const int tick_resolution = 10, const int wire_resolution = 2,
+                        const int nbounds_layers = 2);
 
-            void MultiPlaneROI(const int plane, const IAnodePlane::pointer anode, const std::map<int, int>& map_ch,
-                               ROI_formation& roi_form, const double mp_th1 = 0., const double mp_th2 = 0., const int faceid = 1,
-                               const int tick_resolution = 10, const int wire_resolution = 2,
-                               const int nbounds_layers = 2);
+            void MP2ROI(const int plane, const IAnodePlane::pointer anode, const IAnodeFace::pointer face,
+                        const std::map<int, int>& map_ch, ROI_formation& roi_form, const double mp_th1 = 0.,
+                        const double mp_th2 = 0., const int tick_resolution = 10, const int wire_resolution = 2,
+                        const int nbounds_layers = 2);
 
             typedef std::multimap<std::pair<int, int>, std::pair<int, int>> MapMPROI;
             MapMPROI get_mp2_rois() const { return mp_rois; }


### PR DESCRIPTION
Avinay found a bug in `ROI_refinement` that `anode->face(faceid)` needs `face->ident`, but current `faceid` is `face->which`. Brief search shows similar API calls are only found in `GridTiling`, so with this fix and cares taken in `GridTiling`, we should be fine. Some sanity checks running `TrackDepo` DNN-ROI:

[2023-11-29 DNN-ROI4 anode2face bug.pdf](https://github.com/WireCell/wire-cell-toolkit/files/13504651/2023-11-29.DNN-ROI4.anode2face.bug.pdf)
