### PR TITLE
Config schema export

### DIFF
--- a/apps/inc/WireCellApps/ConfigSchema.h
+++ b/apps/inc/WireCellApps/ConfigSchema.h
@@ -1,0 +1,33 @@
+/** Produce a schema of all registered components.
+
+    Eg
+
+    wire-cell -a ConfigSchema -p WireCellApps -p WireCellGen
+
+ */
+
+#ifndef WIRECELLAPPS_CONFIGSCHEMA
+#define WIRECELLAPPS_CONFIGSCHEMA
+
+#include "WireCellIface/IApplication.h"
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellUtil/Configuration.h"
+
+namespace WireCellApps {
+
+    class ConfigSchema : public WireCell::IApplication, public WireCell::IConfigurable {
+        WireCell::Configuration m_cfg;
+
+       public:
+        ConfigSchema();
+        virtual ~ConfigSchema();
+
+        virtual void execute();
+
+        virtual void configure(const WireCell::Configuration& config);
+        virtual WireCell::Configuration default_configuration() const;
+    };
+
+}  // namespace WireCellApps
+
+#endif

--- a/apps/src/ConfigSchema.cxx
+++ b/apps/src/ConfigSchema.cxx
@@ -1,0 +1,253 @@
+#include "WireCellApps/ConfigSchema.h"
+
+#include "WireCellIface/INode.h"
+
+#include "WireCellUtil/String.h"
+#include "WireCellUtil/Type.h"
+#include "WireCellUtil/Persist.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/ConfigManager.h"
+#include "WireCellUtil/Logging.h"
+#include "WireCellUtil/Exceptions.h"
+
+
+WIRECELL_FACTORY(ConfigSchema,
+                 WireCellApps::ConfigSchema,
+                 WireCell::IApplication,
+                 WireCell::IConfigurable)
+
+using spdlog::info;
+using spdlog::warn;
+
+using namespace WireCell;
+using namespace WireCellApps;
+
+ConfigSchema::ConfigSchema()
+  : m_cfg(default_configuration())
+{
+}
+
+ConfigSchema::~ConfigSchema() {}
+
+void ConfigSchema::configure(const Configuration& config) { m_cfg = config; }
+
+WireCell::Configuration ConfigSchema::default_configuration() const
+{
+    // yo dawg, I heard you liked dumping so I made a dumper that dumps the dumper.
+    Configuration cfg;
+    cfg["filename"] = "/dev/stdout";
+    cfg["components"] = Json::arrayValue;
+    return cfg;
+}
+
+// the "name" is the local type name.  We don't really have that available so
+// instead if the cfg is a value of an object, the name will be the attribute
+// key name.  O.w., empty.  This is something to fix by hand after the dump.
+Configuration dump_schema(const Configuration& cfg, const std::string& name="");
+Configuration dump_object(const Configuration& cfg, const std::string& name="");
+Configuration dump_number(const Configuration& cfg, const std::string& name="");
+Configuration dump_string(const Configuration& cfg, const std::string& name="");
+Configuration dump_array(const Configuration& cfg, const std::string& name="");
+Configuration dump_bool(const Configuration& cfg, const std::string& name="");
+Configuration dump_null(const Configuration& cfg, const std::string& name="");
+
+static
+void maybe_name(Configuration& schema, const std::string& name)
+{
+    if (name.empty()) return;
+    schema["name"] = name;
+}
+
+Configuration dump_object(const Configuration& cfg, const std::string& name)
+{
+    Configuration schema;
+    schema["schema"] = "record";
+    maybe_name(schema, name);
+    schema["fields"] = Json::arrayValue;
+
+    for (const auto& key : cfg.getMemberNames()) {
+        auto val = cfg[key];
+        Configuration field;
+        field["name"] = key;
+        field["item"] = dump_schema(val, key);
+        if (! val.empty()) {
+            field["default"] = val;
+        }
+        schema["fields"].append(field);
+    }
+
+    return schema;
+}
+
+Configuration dump_number(const Configuration& cfg, const std::string& name)
+{
+    Configuration schema;
+    schema["schema"] = "number";
+    maybe_name(schema, name);
+    // omit: path, deps.
+
+    // How can we possibly guess these these distinctions?
+    if(cfg.isInt()) {
+        schema["dtype"] = "i4";
+    }
+    else {
+        schema["dtype"] = "f8";
+    }
+
+    return schema;
+}
+
+Configuration dump_string(const Configuration& cfg, const std::string& name)
+{
+    Configuration schema;
+    schema["schema"] = "string";
+    maybe_name(schema, name);
+    // omit: path, deps, pattern/format.
+
+    return schema;
+}
+
+Configuration dump_array(const Configuration& cfg, const std::string& name)
+{
+    Configuration schema;
+    schema["schema"] = "sequence";
+    maybe_name(schema, name);
+
+    if (cfg.empty()) {
+        schema["item"] = "null";
+    }
+    else {
+        schema["item"] = dump_schema(cfg[0]);
+    }
+    return schema;
+}
+
+Configuration dump_bool(const Configuration& cfg, const std::string& name)
+{
+    Configuration schema;
+    schema["schema"] = "boolean";
+    maybe_name(schema, name);
+
+    return schema;
+}
+
+Configuration dump_null(const Configuration& cfg, const std::string& name)
+{
+    Configuration schema;
+    schema["schema"] = "null";
+    maybe_name(schema, name);
+
+    return schema;
+}
+
+
+Configuration dump_schema(const Configuration& cfg, const std::string& name)
+{
+    if (cfg.isObject()) {
+        return dump_object(cfg);
+    }
+    if (cfg.isNumeric()) {
+        return dump_number(cfg);
+    }
+    if (cfg.isString()) {
+        return dump_string(cfg);
+    }
+    if (cfg.isArray()) {
+        return dump_array(cfg);
+    }
+    if (cfg.isBool()) {
+        return dump_bool(cfg);
+    }
+    if (cfg.isNull()) {
+        return dump_null(cfg);
+    }
+    raise<ValueError>("unknown type: %s", cfg);
+    // quell compiler warning about no return value.
+    return Configuration();
+}
+
+void ConfigSchema::execute()
+{
+    // ConfigManager cm;
+    int nfailed = 0;
+
+    std::vector<std::string> comps;
+    for (auto jone : m_cfg["components"]) {
+        comps.push_back(jone.asString());
+    }
+    
+    if (comps.empty()) {
+        comps = Factory::known_types<IConfigurable>();
+    }
+    
+    std::unordered_map<INode::NodeCategory, std::string> categories = {
+        { INode::unknown,"unknown" },
+        { INode::sourceNode, "source" },
+        { INode::sinkNode, "sink" },
+        { INode::functionNode, "function" }, 
+        { INode::queuedoutNode, "queuedout" },
+        { INode::joinNode, "join" },
+        { INode::splitNode, "split" },
+        { INode::faninNode, "fanin" },
+        { INode::fanoutNode, "fanout" },
+        { INode::multioutNode, "multiout" },
+        { INode::hydraNode, "hydra" },
+    };
+
+    Configuration all_schema;
+
+    for (auto const& [wctype, tinfo] : NamedFactoryRegistryBase::known_type_info()) {
+        Configuration schema;
+        schema["cppname"] = tinfo.cppname;
+
+        schema["interfaces"] = Json::arrayValue;
+        for (auto const& intname : tinfo.intnames) {
+            schema["interfaces"].append(intname);
+        }
+
+        auto inode = Factory::lookup_tn<INode>(wctype, true, true);
+        if (inode) {
+            Configuration node;
+
+            node["category"] = categories[inode->category()];
+            node["signature"]= demangle( inode->signature() );
+            node["concurrency"] = inode->concurrency();
+
+            {
+                Configuration ports = Json::arrayValue;
+                for (const auto& port : inode->input_types()) {
+                    ports.append( demangle(port) );
+                }
+                node["iports"] = ports;
+            }
+            {
+                Configuration ports = Json::arrayValue;
+                for (const auto& port : inode->output_types()) {
+                    ports.append( demangle(port) );
+                }
+                node["oports"] = ports;
+            }
+            schema["node"] = node;
+        }
+        all_schema[wctype] = schema;
+    }
+
+    for (auto c : comps) {
+        auto [wctype, instname] = String::parse_pair(convert<std::string>(c));
+
+        Configuration cfg;
+        try {
+            auto cfgobj = Factory::lookup<IConfigurable>(wctype, instname);
+            cfg = cfgobj->default_configuration();
+        }
+        catch (FactoryException& fe) {
+            warn("failed lookup component: \"{}\":\"{}\"", wctype, instname);
+            ++nfailed;
+            continue;
+        }
+
+        all_schema[wctype]["config"] = dump_schema(cfg);
+    }
+
+    Persist::dump(get<std::string>(m_cfg, "filename"), all_schema);
+}

--- a/util/docs/namedfactory-classes.plantuml
+++ b/util/docs/namedfactory-classes.plantuml
@@ -1,0 +1,52 @@
+@startuml
+
+class Interface
+class "IComponent<InterfaceType>" as IComponent_t
+class "IComponent<IFactory>" as IComponent_factory
+class "IComponent<InterfaceA>" as IComponent_A
+class "IComponent<InterfaceB>" as IComponent_B
+class IFactory
+class INamedFactory
+class Concrete
+
+Interface <|-- IComponent_t
+IComponent_t <|-- IComponent_factory
+
+IComponent_factory <|-- IFactory
+IFactory <|-- INamedFactory
+
+
+class "NamedFactory<Concrete>" as NamedFactory_Concrete
+class NamedFactory_Concrete {
+        Interface::pointer find(name);
+        Interface::pointer create(name);
+
+
+}
+
+class "NamedFactoryRegistry<InterfaceType>" as NamedFactoryRegistry_t
+class NamedFactoryRegistry_t {
+        size_t hello(wctname, cppname, intname);
+        const std::string& interface_name();
+        known_type_set known_types();
+        wct_to_cpp_map known_classes();
+        bool associate(classname, factory);
+        factory_ptr lookup_factory(classname);
+        interface_ptr instance(classname, instname, create, nullok)
+        std::vector<std::string> known_classes()
+}
+
+IComponent_t <|-- IComponent_A
+IComponent_t <|-- IComponent_B
+
+IComponent_A <|-- InterfaceA
+IComponent_B <|-- InterfaceB
+
+InterfaceA <|-- Concrete
+InterfaceB <|-- Concrete
+
+INamedFactory <|-- NamedFactory_Concrete
+
+        
+
+@enduml

--- a/util/inc/WireCellUtil/String.h
+++ b/util/inc/WireCellUtil/String.h
@@ -27,6 +27,9 @@ namespace WireCell {
 
         std::vector<std::string> split(const std::string& in, const std::string& delim = ":");
 
+        // Return s with any leading or trailing white space removed.
+        std::string strip(std::string s);
+
         std::pair<std::string, std::string> parse_pair(const std::string& in, const std::string& delim = ":");
 
         // format_flatten converts from "%"-list to variadic function call.

--- a/util/src/String.cxx
+++ b/util/src/String.cxx
@@ -11,6 +11,27 @@ std::vector<std::string> WireCell::String::split(const std::string& in, const st
     return chunks;
 }
 
+std::string WireCell::String::strip(std::string s)
+{
+    size_t beg = 0;
+    size_t end = s.size();
+
+    while (beg < end && (s[beg] == ' ' || s[beg] == '\t' || s[beg] == '\n')) {
+        ++beg;
+    }
+    if (beg == end) {
+        return "";
+    }
+    --end;
+    while (end > beg && (s[end] == ' ' || s[end] == '\t' || s[end] == '\n')) {
+        --end;
+    }
+    if (beg == end) {
+        return "";
+    }
+    return s.substr(beg, end+1-beg);
+}
+
 std::pair<std::string, std::string> WireCell::String::parse_pair(const std::string& in, const std::string& delim)
 {
     std::vector<std::string> chunks = split(in, delim);

--- a/util/test/doctest_string.cxx
+++ b/util/test/doctest_string.cxx
@@ -1,0 +1,19 @@
+#include "WireCellUtil/Logging.h"
+#include "WireCellUtil/String.h"
+
+#include "WireCellUtil/doctest.h"
+
+using namespace WireCell::String;
+
+TEST_CASE("string strip") {
+    
+    CHECK(strip("") == "");
+    CHECK(strip(" ") == "");
+    CHECK(strip("blah") == "blah");
+    CHECK(strip("blah ") == "blah");
+    CHECK(strip(" blah") == "blah");
+    CHECK(strip(" blah ") == "blah");
+    CHECK(strip(" \t\nblah\n\t \t\n") == "blah");
+    CHECK(strip(" \t\nblah blah\n\t \t\n") == "blah blah");
+}
+


### PR DESCRIPTION
This is the start of an idea to better handle configuration.  It's in the same vein as the moribund #105 but with more of an adiabatic plan.  To start with, all this does is dump a JSON representation of component metadata:

```
wire-cell -a ConfigSchema \
    -p WireCellApps -p WireCellGen -p WireCellAux -p WireCellSigProc -p WireCellImg \
    | json_pp > schema.json
```

The JSON representation includes:

- The WCT "type" name, C++ class name and names of all the interfaces
- If the component is an `IConfigurable` then the schema describing the object returned by `default_configuration()` is generated, with the default values included.  
- If the component is an `INode` then the category, signature and data types passed by the input/output ports are included.

Note: since not all `IConfigurable` implementations return a full object from `default_configuration()` the dumped schema will not be complete.


Long term, the idea is that this dump can turn around and become human-developed and used to generate c++ config structs a'la #105.  Until then there are plans to exploit the dump to generate some added value: documentation, Jsonnet helpers, graph validation.