### PR TITLE
add a perchannel resp correction 

### DIFF
--- a/sigproc/inc/WireCellSigProc/ParamsPerChannelResponse.h
+++ b/sigproc/inc/WireCellSigProc/ParamsPerChannelResponse.h
@@ -1,0 +1,39 @@
+/** This component provides per-channel responses based on a
+ * configuration data file. */
+
+#ifndef WIRECELLSIGPROC_PARAMSPERCHANNELRESPONSE
+#define WIRECELLSIGPROC_PARAMSPERCHANNELRESPONSE
+
+#include "WireCellIface/IChannelResponse.h"
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellUtil/Units.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace WireCell {
+    namespace SigProc {
+        class ParamsPerChannelResponse : public IChannelResponse, public IConfigurable {
+           public:
+            ParamsPerChannelResponse(const char* filename = "");
+
+            virtual ~ParamsPerChannelResponse();
+
+            // IChannelResponse
+            virtual const Waveform::realseq_t& channel_response(int channel_ident) const;
+            virtual Binning channel_response_binning() const;
+
+            // IConfigurable
+            virtual void configure(const WireCell::Configuration& config);
+            virtual WireCell::Configuration default_configuration() const;
+
+           private:
+            std::string m_filename;
+            std::unordered_map<int, Waveform::realseq_t> m_cr;
+            Binning m_bins;
+        };
+
+    }  // namespace SigProc
+
+}  // namespace WireCell
+#endif

--- a/sigproc/src/ParamsPerChannelResponse.cxx
+++ b/sigproc/src/ParamsPerChannelResponse.cxx
@@ -1,0 +1,84 @@
+#include "WireCellSigProc/ParamsPerChannelResponse.h"
+
+#include "WireCellUtil/Persist.h"
+#include "WireCellUtil/Exceptions.h"
+#include "WireCellUtil/String.h"
+#include "WireCellUtil/Response.h"
+
+#include "WireCellUtil/NamedFactory.h"
+
+WIRECELL_FACTORY(ParamsPerChannelResponse, WireCell::SigProc::ParamsPerChannelResponse, WireCell::IChannelResponse,
+                 WireCell::IConfigurable)
+
+using namespace WireCell;
+
+SigProc::ParamsPerChannelResponse::ParamsPerChannelResponse(const char* filename)
+  : m_filename(filename)
+{
+}
+
+SigProc::ParamsPerChannelResponse::~ParamsPerChannelResponse() {}
+
+WireCell::Configuration SigProc::ParamsPerChannelResponse::default_configuration() const
+{
+    Configuration cfg;
+    cfg["filename"] = m_filename;
+    return cfg;
+}
+
+void SigProc::ParamsPerChannelResponse::configure(const WireCell::Configuration& cfg)
+{
+    m_filename = get(cfg, "filename", m_filename);
+    if (m_filename.empty()) {
+        THROW(ValueError() << errmsg{"must supply a ParamsPerChannelResponse filename"});
+    }
+
+    auto top = Persist::load(m_filename);
+    const double tick = top["tick"].asFloat();
+    const double t0 = top["t0"].asFloat();
+    const int nsamp = top["nsamp"].asInt();
+    if (!m_bins.nbins()) {  // first time
+        m_bins = Binning(nsamp, t0, t0 + nsamp * tick);
+    }
+
+    auto jchannels = top["channel_info"];
+    if (jchannels.isNull()) {
+        THROW(ValueError() << errmsg{"no channels given in file " + m_filename});
+    }
+
+    for (auto jchinfo : jchannels) {
+        const double gain = jchinfo["gain"].asFloat();
+        const double shaping = jchinfo["shaping"].asFloat();
+        const double k3 = jchinfo["k3"].asFloat();
+        const double k4 = jchinfo["k4"].asFloat();
+        const double k5 = jchinfo["k5"].asFloat();
+        const double k6 = jchinfo["k6"].asFloat();
+        Response::ParamsColdElec ce(gain, shaping, k3, k4, k5, k6); // 14mV/fC, 2.0us, 0.1, 0.1, 0.0, 0.0
+        Waveform::realseq_t resp = ce.generate(m_bins);
+
+        if (jchinfo["channels"].isArray()) {
+          for (auto& ch: jchinfo["channels"]){
+            m_cr[ch.asInt()] = resp;
+            // std::cout << "[ParamsPerChannelResponse] channel: " << ch.asInt()
+            //           << " gain: " << gain
+            //           << " shaping: " << shaping
+            //           << " k3: " << k3
+            //           << " k4: " << k4
+            //           << " k5: " << k5
+            //           << " k6: " << k6
+            //           << std::endl;
+          }
+        }
+    }
+}
+
+const Waveform::realseq_t& SigProc::ParamsPerChannelResponse::channel_response(int channel_ident) const
+{
+    const auto& it = m_cr.find(channel_ident);
+    if (it == m_cr.end()) {
+        THROW(KeyError() << errmsg{String::format("no response for channel %d", channel_ident)});
+    }
+    return it->second;
+}
+
+Binning SigProc::ParamsPerChannelResponse::channel_response_binning() const { return m_bins; }

--- a/util/inc/WireCellUtil/Response.h
+++ b/util/inc/WireCellUtil/Response.h
@@ -170,6 +170,9 @@ namespace WireCell {
         /// The cold electronics response function.
         double coldelec(double time, double gain = 7.8, double shaping = 1.0 * units::us);
 
+	/// The parameterized cold electronics response function.
+	double paramscoldelec(double time, double gain = 7.8, double shaping = 1.0 * units::us, double k3=0.1, double k4=0.1, double k5=0.0, double k6=0.0);
+
         /// The warm electronics response function.
         double warmelec(double time, double gain = 30, double shaping = 1.3 * units::us);
 
@@ -205,6 +208,23 @@ namespace WireCell {
             // system of units.
             virtual double operator()(double time) const;
         };
+
+        /// A functional object caching gain, shape and other params
+        class ParamsColdElec : public Generator {
+            const double _g, _s, _k3, _k4, _k5, _k6;
+
+           public:
+            // Create parameterized cold electronics response function.  Gain is an
+            // arbitrary scale, typically in [voltage/charge], and
+            // shaping time in WCT system of units.
+            ParamsColdElec(double gain = 14 * units::mV / units::fC, double shaping = 2.0 * units::us, double k3=0.1, double k4=0.1, double k5=0.0, double k6=0.0);
+            virtual ~ParamsColdElec();
+
+            // Return the response at given time.  Time is in WCT
+            // system of units.
+            virtual double operator()(double time) const;
+        };
+
 
         /// A functional object caching gain and shape.
         /// ICARUS warm electronics


### PR DESCRIPTION
It's similar to PerChannelResponse, except that it uses a parameterized cold electronics function based on Xin's formula. An example response function is below:
<img width="442" alt="image" src="https://github.com/WireCell/wire-cell-toolkit/assets/10663117/64903db8-b864-445c-b832-bd96c84d7284">

Parameters for such response can be read from a json input file with a format below:
```
{
    "tick": 500.0,
    "t0": -2750.0,
    "channel_info": [
      {
        "channels": [0,1,2, ...],
        "gain": 1,
        "shaping": 1,
        "k3": 1,
        "k4": 1,
        "k5": 1,
        "k6": 1
      }
      {
        "channels": [4,5,6, ...],
        "gain": 1,
        "shaping": 1,
        "k3": 1,
        "k4": 1,
        "k5": 1,
        "k6": 1
      }

    ]
}
```

To use this ParamsPerChannelResponse in the signal processing, one need to enable it in the local params.jsonnet:
```
chresp: "protodunevd-params-channel-responses-v0.json.bz2", // default: null
```