### PR TITLE
fix threshold related bugs

### DIFF
--- a/cfg/pgrapher/experiment/dune-vd-coldbox/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/dune-vd-coldbox/magnify-sinks.jsonnet
@@ -83,8 +83,8 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        summaries: ['threshold%d' % tools.anodes[n].data.ident],  // note that if tag set, each apa should have a tag set for FrameFanin
-        summary_operator: { ['threshold%d' % tools.anodes[n].data.ident]: 'set' },  // []: obj comprehension
+        summaries: ['wiener%d' % tools.anodes[n].data.ident],  // note that if tag set, each apa should have a tag set for FrameFanin
+        summary_operator: { ['wiener%d' % tools.anodes[n].data.ident]: 'set' },  // []: obj comprehension
         anode: wc.tn(tools.anodes[n]),
       },
     }, nin=1, nout=1)

--- a/cfg/pgrapher/experiment/dune-vd/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/dune-vd/magnify-sinks.jsonnet
@@ -83,8 +83,8 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        summaries: ['threshold%d' % anode.data.ident],  // note that if tag set, each apa should have a tag set for FrameFanin
-        summary_operator: { ['threshold%d' % anode.data.ident]: 'set' },  // []: obj comprehension
+        summaries: ['wiener%d' % anode.data.ident],  // note that if tag set, each apa should have a tag set for FrameFanin
+        summary_operator: { ['wiener%d' % anode.data.ident]: 'set' },  // []: obj comprehension
         anode: wc.tn(anode),
       },
     }, nin=1, nout=1)

--- a/cfg/pgrapher/experiment/dune10kt-1x2x6/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/dune10kt-1x2x6/magnify-sinks.jsonnet
@@ -83,8 +83,8 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        summaries: ['threshold%d' % n],  // note that if tag set, each apa should have a tag set for FrameFanin
-        summary_operator: { ['threshold%d' % n]: 'set' },  // []: obj comprehension
+        summaries: ['wiener%d' % n],  // note that if tag set, each apa should have a tag set for FrameFanin
+        summary_operator: { ['wiener%d' % n]: 'set' },  // []: obj comprehension
         anode: wc.tn(tools.anodes[n]),
       },
     }, nin=1, nout=1)

--- a/cfg/pgrapher/experiment/dunevd-crp2/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/dunevd-crp2/magnify-sinks.jsonnet
@@ -83,8 +83,8 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        summaries: ['threshold%d' % tools.anodes[n].data.ident],  // note that if tag set, each apa should have a tag set for FrameFanin
-        summary_operator: { ['threshold%d' % tools.anodes[n].data.ident]: 'set' },  // []: obj comprehension
+        summaries: ['wiener%d' % tools.anodes[n].data.ident],  // note that if tag set, each apa should have a tag set for FrameFanin
+        summary_operator: { ['wiener%d' % tools.anodes[n].data.ident]: 'set' },  // []: obj comprehension
         anode: wc.tn(tools.anodes[n]),
       },
     }, nin=1, nout=1)

--- a/cfg/pgrapher/experiment/icarus/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/magnify-sinks.jsonnet
@@ -83,8 +83,8 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        summaries: ['threshold%d' % tools.anodes[n].data.ident],  // note that if tag set, each apa should have a tag set for FrameFanin
-        summary_operator: { ['threshold%d' % tools.anodes[n].data.ident]: 'set' },  // []: obj comprehension
+        summaries: ['wiener%d' % tools.anodes[n].data.ident],  // note that if tag set, each apa should have a tag set for FrameFanin
+        summary_operator: { ['wiener%d' % tools.anodes[n].data.ident]: 'set' },  // []: obj comprehension
         anode: wc.tn(tools.anodes[n]),
       },
     }, nin=1, nout=1)

--- a/cfg/pgrapher/experiment/iceberg/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/iceberg/magnify-sinks.jsonnet
@@ -83,8 +83,8 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        summaries: ['threshold%d' % n],  // note that if tag set, each apa should have a tag set for FrameFanin
-        summary_operator: { ['threshold%d' % n]: 'set' },  // []: obj comprehension
+        summaries: ['wiener%d' % n],  // note that if tag set, each apa should have a tag set for FrameFanin
+        summary_operator: { ['wiener%d' % n]: 'set' },  // []: obj comprehension
         anode: wc.tn(tools.anodes[n]),
       },
     }, nin=1, nout=1)

--- a/cfg/pgrapher/experiment/pcbro-50liter/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/pcbro-50liter/magnify-sinks.jsonnet
@@ -83,8 +83,8 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        summaries: ['threshold%d' % n],  // note that if tag set, each apa should have a tag set for FrameFanin
-        summary_operator: { ['threshold%d' % n]: 'set' },  // []: obj comprehension
+        summaries: ['wiener%d' % n],  // note that if tag set, each apa should have a tag set for FrameFanin
+        summary_operator: { ['wiener%d' % n]: 'set' },  // []: obj comprehension
         anode: wc.tn(tools.anodes[n]),
       },
     }, nin=1, nout=1)

--- a/cfg/pgrapher/experiment/pdsp/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/pdsp/magnify-sinks.jsonnet
@@ -83,8 +83,8 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        summaries: ['threshold%d' % n],  // note that if tag set, each apa should have a tag set for FrameFanin
-        summary_operator: { ['threshold%d' % n]: 'set' },  // []: obj comprehension
+        summaries: ['wiener%d' % n],  // note that if tag set, each apa should have a tag set for FrameFanin
+        summary_operator: { ['wiener%d' % n]: 'set' },  // []: obj comprehension
         anode: wc.tn(tools.anodes[n]),
       },
     }, nin=1, nout=1)

--- a/cfg/pgrapher/experiment/sbnd/magnify-sinks.jsonnet
+++ b/cfg/pgrapher/experiment/sbnd/magnify-sinks.jsonnet
@@ -83,8 +83,8 @@ function(tools, outputfile) {
       data: {
         output_filename: outputfile,
         root_file_mode: 'UPDATE',
-        summaries: ['threshold%d' % n],  // note that if tag set, each apa should have a tag set for FrameFanin
-        summary_operator: { ['threshold%d' % n]: 'set' },  // []: obj comprehension
+        summaries: ['wiener%d' % n],  // note that if tag set, each apa should have a tag set for FrameFanin
+        summary_operator: { ['wiener%d' % n]: 'set' },  // []: obj comprehension
         anode: wc.tn(tools.anodes[n]),
       },
     }, nin=1, nout=1)

--- a/root/src/MagnifySink.cxx
+++ b/root/src/MagnifySink.cxx
@@ -397,7 +397,7 @@ bool Root::MagnifySink::operator()(const IFrame::pointer& frame, IFrame::pointer
             continue;
         }
 
-        std::string oper = get<std::string>(m_cfg["summary_operator"], tag, "sum");
+        std::string oper = get<std::string>(m_cfg["summary_operator"], tag, "set");
 
         log->debug("MagnifySink: saving summaries tagged with \"{}\" into per-plane hists", tag);
 

--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -1467,8 +1467,9 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
         }
         check_data(iplane, "after 2D tight ROI");
 
-        // [wgu] save decon result after tight LF
+        // save_data passes perwire_rmses to dummy, which will not be used
         std::vector<double> dummy;
+        // [wgu] save decon result after tight LF
         if (m_use_roi_debug_mode and !m_tight_lf_tag.empty()) {
             save_data(*itraces, tight_lf_traces, iplane, perwire_rmses, dummy, "tight_lf");
         }
@@ -1507,7 +1508,7 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
             // special case to dump decon without needs of ROIs
             if (m_use_roi_debug_mode and !m_decon_charge_tag.empty()) {
                 decon_2D_charge(iplane);
-                save_data(*itraces, decon_charge_traces, iplane, perwire_rmses, thresholds, "decon");
+                save_data(*itraces, decon_charge_traces, iplane, perwire_rmses, dummy, "decon");
             }
             m_c_data[iplane].resize(0, 0);  // clear memory
             m_r_data[iplane].resize(0, 0);  // clear memory
@@ -1591,7 +1592,7 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
             roi_refine.apply_roi(iplane, m_r_data[iplane]);
             check_data(iplane, "after roi refine apply");
             // roi_form.apply_roi(iplane, m_r_data[plane],1);
-            if (!m_gauss_tag.empty()) {
+            if (!m_wiener_tag.empty()) {
                 // We only use an intermediate index list here to give
                 // some clarity to log msg about range added
                 IFrame::trace_list_t perframe;
@@ -1602,11 +1603,11 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
             decon_2D_charge(iplane);
             std::vector<double> dummy_thresholds;
             if (m_use_roi_debug_mode and !m_decon_charge_tag.empty()) {
-                save_data(*itraces, decon_charge_traces, iplane, perwire_rmses, thresholds, "decon");
+                save_data(*itraces, decon_charge_traces, iplane, perwire_rmses, dummy_thresholds, "decon");
             }
             roi_refine.apply_roi(iplane, m_r_data[iplane]);
             // roi_form.apply_roi(iplane, m_r_data[plane],1);
-            if (!m_wiener_tag.empty()) {
+            if (!m_gauss_tag.empty()) {
                 // We only use an intermediate index list here to give
                 // some clarity to log msg about range added
                 IFrame::trace_list_t perframe;
@@ -1616,8 +1617,8 @@ bool OmnibusSigProc::operator()(const input_pointer& in, output_pointer& out)
 
             m_c_data[iplane].resize(0, 0);  // clear memory
             m_r_data[iplane].resize(0, 0);  // clear memory
-        }
-    }
+        } // loop over planes
+    } // m_use_roi_refinement
 
     // clear the overall response
     // for (int i = 0; i != 3; i++) {

--- a/sigproc/test/check_pdsp_sim_sp.jsonnet
+++ b/sigproc/test/check_pdsp_sim_sp.jsonnet
@@ -78,7 +78,7 @@ local nf_maker = import 'pgrapher/experiment/pdsp/nf.jsonnet';
 local nf_pipes = [nf_maker(params, tools.anodes[n], chndb[n], n, name='nf%d' % n) for n in anode_iota];
 
 local sp_maker = import 'pgrapher/experiment/pdsp/sp.jsonnet';
-local sp = sp_maker(params, tools);
+local sp = sp_maker(params, tools, {sparse: false});
 local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
 
 local magoutput = 'protodune-sim-check-wct.root';
@@ -101,6 +101,8 @@ local multipass = [
         // sio_sinks[n],
         // nf_pipes[n],
         sp_pipes[n],
+        // sinks.decon_pipe[n],
+        // sinks.threshold_pipe[n],
     ], 'multipass%d' % n)
   for n in anode_iota
 ];


### PR DESCRIPTION
Some are not bugs. But some are. Simple note attached. May need a better one.
[2024-03-12_threshold.pdf](https://github.com/WireCell/wire-cell-toolkit/files/14631032/2024-03-12_threshold.pdf)

- fix typo, switch `wiener` `gauss`
- only save to `threshold` for `wiener`
- change default `Magnify` summary op to `set` as we only used it for `RMS`
- change default `magnify.jsonnet` threshold label.


