### PR TITLE
refresh nticks for each event

### DIFF
--- a/sigproc/inc/WireCellSigProc/OmnibusNoiseFilter.h
+++ b/sigproc/inc/WireCellSigProc/OmnibusNoiseFilter.h
@@ -58,6 +58,8 @@ namespace WireCell {
            private:
             // number of time ticks in the waveforms processed.  Set to 0 and first input trace sets it.
             size_t m_nticks;
+            // allow user to refresh the nticks for each event
+            bool m_reload_nticks{false};
             std::string m_intag, m_outtag;
             std::vector<WireCell::IChannelFilter::pointer> m_perchan, m_grouped, m_perchan_status;
             WireCell::IChannelNoiseDatabase::pointer m_noisedb;

--- a/sigproc/src/OmnibusNoiseFilter.cxx
+++ b/sigproc/src/OmnibusNoiseFilter.cxx
@@ -41,6 +41,10 @@ void OmnibusNoiseFilter::configure(const WireCell::Configuration& cfg)
         log->warn("\"nsamples\" is an obsolete parameter, use \"nticks\"");
         // we don't throw here on assumption that nticks is still provided
     }
+    m_reload_nticks = get<bool>(cfg, "reload_nticks", m_reload_nticks);
+    if (m_reload_nticks) {
+        log->debug("will refresh nticks per event");
+    }
 
     auto jmm = cfg["maskmap"];
     for (auto name : jmm.getMemberNames()) {
@@ -77,6 +81,7 @@ WireCell::Configuration OmnibusNoiseFilter::default_configuration() const
 {
     Configuration cfg;
     cfg["nticks"] = (int) m_nticks;
+    cfg["reload_nticks"] = m_reload_nticks;
     cfg["maskmap"]["chirp"] = "bad";
     cfg["maskmap"]["noisy"] = "bad";
 
@@ -115,7 +120,7 @@ bool OmnibusNoiseFilter::operator()(const input_pointer& inframe, output_pointer
         return true;
     }
 
-    if (! m_nticks) {
+    if (! m_nticks or m_reload_nticks) {
         // Warning: this implicitly assumes a dense frame (ie, all tbin=0 and all waveforms same size).
         // It also won't stop triggering a warning inside OneChannelNoise if there is a mismatch.
         m_nticks = traces.at(0)->charge().size();


### PR DESCRIPTION
In ProtoDUNE HD, the lengths of raw::RawDigits are not fixed among different events. Currently, the OmnibusNoiseFilter will determine "nticks" at the beginning of configuration and will not update it later. The purpose of this PR is to refresh "nticks" for each event. 

To use it, just add `reload_nticks: true` in the nf.jsonnet (the default value is false).
```
   local obnf = g.pnode({
        type: 'OmnibusNoiseFilter',
        name: name,
        data: {

            // Nonzero forces the number of ticks in the waveform
            nticks: 0,
            reload_nticks: true,


```