### PR TITLE
get field response with function

### DIFF
--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -790,7 +790,7 @@ void OmnibusSigProc::init_overall_response(IFrame::pointer frame)
 
     // Convert each average FR to a 2D array
     for (int iplane = 0; iplane < 3; ++iplane) {
-        auto arr = Response::as_array(fravg.planes[iplane], fine_nwires, fine_nticks);
+        auto arr = Response::as_array(*(fravg.plane(iplane)), fine_nwires, fine_nticks);
 
 
         int nrows = 0;


### PR DESCRIPTION
This PR is for ProtoDUNE HD and is discussed in issue https://github.com/WireCell/wire-cell-toolkit/issues/322

This is a non-breaking change, other experiment should not feel any change.