### PR TITLE
add protections for xregion configuration

### DIFF
--- a/cfg/pgrapher/common/sim/nodes.jsonnet
+++ b/cfg/pgrapher/common/sim/nodes.jsonnet
@@ -10,7 +10,9 @@ function(params, tools)
 {
     // Create a drifter Pnode.
     drifter: g.pnode({
-        local xregions = wc.unique_list(std.flattenArrays([v.faces for v in params.det.volumes])),
+        // local xregions = wc.unique_list(std.flattenArrays([v.faces for v in params.det.volumes])),
+        // Filter out any null values in xregions
+        local xregions = std.filter(function(x) x!= null, wc.unique_list(std.flattenArrays([v.faces for v in params.det.volumes]))),
 
         type: "Drifter",
         data: params.lar {

--- a/gen/src/AnodePlane.cxx
+++ b/gen/src/AnodePlane.cxx
@@ -162,9 +162,16 @@ void Gen::AnodePlane::configure(const WireCell::Configuration& cfg)
             sensitive_face = false;
             log->debug("anode {} face {} is not sensitive", m_ident, iface);
         }
-        const double response_x = jface["response"].asDouble();
-        const double anode_x = get(jface, "anode", response_x);
-        const double cathode_x = jface["cathode"].asDouble();
+        // const double response_x = jface["response"].asDouble();
+        // const double anode_x = get(jface, "anode", response_x);
+        // const double cathode_x = jface["cathode"].asDouble();
+        // FIXME: Due to a recent change in the xregion configuration (see
+        // https://github.com/WireCell/wire-cell-toolkit/pull/336), the
+        // fields (cathode, anode, response) may no longer be scalar values.
+        // In such cases, a backup scalar input is required.
+        const double response_x = jface["response"].isNumeric() ? jface["response"].asDouble() : jface["response_ref"].asDouble();
+        const double anode_x = jface["anode"].isNumeric() ? jface["anode"].asDouble() : jface["anode_ref"].asDouble();
+        const double cathode_x = jface["cathode"].isNumeric() ? jface["cathode"].asDouble() : jface["cathode_ref"].asDouble();
         log->debug("X planes: \"cathode\"@ {}m, \"response\"@{}m, \"anode\"@{}m", cathode_x / units::m,
                  response_x / units::m, anode_x / units::m);
 

--- a/gen/src/AnodePlane.cxx
+++ b/gen/src/AnodePlane.cxx
@@ -163,14 +163,23 @@ void Gen::AnodePlane::configure(const WireCell::Configuration& cfg)
             log->debug("anode {} face {} is not sensitive", m_ident, iface);
         }
         if (!jface["response"].isNumeric() or !jface["anode"].isNumeric()) {
-            log->critical("Non-scalar value for response_x or anode_x is not allowed.");
+            log->critical("Non-scalar value for response_x or anode_x is not supported.");
             THROW(ValueError() << errmsg{"AnodePlane: error in configuration, expect scalar values for response_x and anode_x."});
         }
         const double response_x = jface["response"].asDouble();
         const double anode_x = get(jface, "anode", response_x);
         // const double cathode_x = jface["cathode"].asDouble();
-        int sign = response_x > anode_x ? 1 : -1;
-        const double cathode_x = jface["cathode"].isNumeric() ? jface["cathode"].asDouble() : response_x + sign * 0.01*units::mm;
+        double cathode_xref;
+        if (jface["cathode"].isNumeric()) {
+            cathode_xref = jface["cathode"].asDouble();
+        }
+        if (jface["cathode"].isMember("x")) {
+            auto xvec = get<std::vector<double>>(jface["cathode"], "x");
+            const auto [vmin, vmax] = std::minmax_element(xvec.begin(), xvec.end());
+            cathode_xref = *vmin < response_x ? *vmin : *vmax;
+        }
+        const double cathode_x = cathode_xref;
+
         log->debug("X planes: \"cathode\"@ {}m, \"response\"@{}m, \"anode\"@{}m", cathode_x / units::m,
                  response_x / units::m, anode_x / units::m);
 

--- a/gen/src/AnodePlane.cxx
+++ b/gen/src/AnodePlane.cxx
@@ -162,16 +162,15 @@ void Gen::AnodePlane::configure(const WireCell::Configuration& cfg)
             sensitive_face = false;
             log->debug("anode {} face {} is not sensitive", m_ident, iface);
         }
-        // const double response_x = jface["response"].asDouble();
-        // const double anode_x = get(jface, "anode", response_x);
+        if (!jface["response"].isNumeric() or !jface["anode"].isNumeric()) {
+            log->critical("Non-scalar value for response_x or anode_x is not allowed.");
+            THROW(ValueError() << errmsg{"AnodePlane: error in configuration, expect scalar values for response_x and anode_x."});
+        }
+        const double response_x = jface["response"].asDouble();
+        const double anode_x = get(jface, "anode", response_x);
         // const double cathode_x = jface["cathode"].asDouble();
-        // FIXME: Due to a recent change in the xregion configuration (see
-        // https://github.com/WireCell/wire-cell-toolkit/pull/336), the
-        // fields (cathode, anode, response) may no longer be scalar values.
-        // In such cases, a backup scalar input is required.
-        const double response_x = jface["response"].isNumeric() ? jface["response"].asDouble() : jface["response_ref"].asDouble();
-        const double anode_x = jface["anode"].isNumeric() ? jface["anode"].asDouble() : jface["anode_ref"].asDouble();
-        const double cathode_x = jface["cathode"].isNumeric() ? jface["cathode"].asDouble() : jface["cathode_ref"].asDouble();
+        int sign = response_x > anode_x ? 1 : -1;
+        const double cathode_x = jface["cathode"].isNumeric() ? jface["cathode"].asDouble() : response_x + sign * 0.01*units::mm;
         log->debug("X planes: \"cathode\"@ {}m, \"response\"@{}m, \"anode\"@{}m", cathode_x / units::m,
                  response_x / units::m, anode_x / units::m);
 

--- a/gen/src/Drifter.cxx
+++ b/gen/src/Drifter.cxx
@@ -93,7 +93,9 @@ void Gen::Drifter::configure(const WireCell::Configuration& cfg)
         THROW(ValueError() << errmsg{"no xregions given"});
     }
     for (auto jone : jxregions) {
-        m_xregions.emplace_back(Xregion(jone));
+        if (!jone.isNull()) {
+          m_xregions.emplace_back(Xregion(jone));
+        }
     }
     log->debug("time offset: {} ms, drift speed: {} mm/us", m_toffset / units::ms,
              m_speed / (units::mm / units::us));


### PR DESCRIPTION
@brettviren I added two protections related to the new xregion:

First, sometimes "null" values in the faces would introduce a problem because `Xregion(null)` would be undefined.

Second, `AnodePlane` requires scalar values (cathode, anode, response) for definition of the BoundingBox of a face's sensitive volume. In such case, we need a backup scalar input, for example:
```
faces: [
    {
        response: ...,
        anode: ...,
        cathode: {
            x: [...], y:[...], z:[...],  // non-scalar cathode
        },
       cathode_ref: -200*wc.cm, // scalar
    },
    null,
],
```

