### PR TITLE
ExecMon Verbosity Check

### DIFF
--- a/pgraph/inc/WireCellPgraph/Graph.h
+++ b/pgraph/inc/WireCellPgraph/Graph.h
@@ -65,6 +65,9 @@ namespace WireCell {
             // Print out cumulated CPU time for executing each node
             void print_timers(bool include_execmon=false) const;
 
+            //Turn on/off using ExecMon
+            void set_enable_em(bool flag=false);
+
            private:
             std::vector<std::pair<Node*, Node*> > m_edges;
             std::unordered_set<Node*> m_nodes;
@@ -72,6 +75,7 @@ namespace WireCell {
             Log::logptr_t l;
             Log::logptr_t l_timer;
             std::unordered_map<Node*, double> m_nodes_timer;
+            bool m_enable_em = false;
             ExecMon m_em;
         };
     }  // namespace Pgraph

--- a/pgraph/src/Graph.cxx
+++ b/pgraph/src/Graph.cxx
@@ -19,6 +19,8 @@ Graph::Graph()
 
 void Graph::add_node(Node* node) { m_nodes.insert(node); }
 
+void Graph::set_enable_em(bool flag) { m_enable_em = flag; }
+
 bool Graph::connect(Node* tail, Node* head, size_t tpind, size_t hpind)
 {
     Port& tport = tail->output_ports()[tpind];
@@ -122,7 +124,9 @@ bool Graph::execute()
             m_nodes_timer[node] += (std::clock() - start) / (double) CLOCKS_PER_SEC;
 
             if (ok) {
-                m_em(format("called %d: %s", count, node->ident()));
+                if (m_enable_em) {
+                  m_em(format("called %d: %s", count, node->ident()));
+                }
                 SPDLOG_LOGGER_TRACE(l, "ran node {}: {}", count, node->ident());
                 did_something = true;
                 break;  // start again from bottom of graph

--- a/pgraph/src/Pgrapher.cxx
+++ b/pgraph/src/Pgrapher.cxx
@@ -50,6 +50,7 @@ void Pgrapher::configure(const WireCell::Configuration& cfg)
 
 {
     m_verbosity = get(cfg, "verbosity", m_verbosity);
+    m_graph.set_enable_em((m_verbosity == 2));
 
     Pgraph::Factory fac;
     log->debug("connecting: {} edges", cfg["edges"].size());


### PR DESCRIPTION
Wrapping ExecMon calls underneath Pgrapher//Graph with a verbosity check to prevent it running under production settings. This was causing memory issues in PDSP detsim