### PR TITLE
Modal build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ styles
 *.svg
 AutoDict_*
 spng
+version.txt

--- a/waft/wcb.py
+++ b/waft/wcb.py
@@ -128,6 +128,23 @@ def configure(cfg):
     submodules = find_submodules(cfg)
     debug(f'wcb: {submodules=}')
 
+    # List any packages that may exist in the source but are not ready for
+    # release builds.  Development builds will include them.  
+    pre_release_packages = ["patrec"]
+    if cfg.env.IS_DEVELOPMENT:
+        # add any development-only config
+        debug("wcb: development build options")
+    else:
+
+        strict_flags = "-Werror -Wall -Werror=return-type -pedantic -Wno-unused-local-typedefs"
+        info(f'Adding strict compiler flags for release: "{strict_flags}"')
+        cfg.env.CXXFLAGS += strict_flags.split()
+
+        for notyet in pre_release_packages:
+            if notyet in submodules:
+                info(f'Removing package "{notyet}" due to not yet being ready for release')
+                submodules.remove(notyet)
+
     # Remove WCT packages if they an optional dependency wasn't found
     for pkg,ext in [
             ("root","HAVE_ROOTSYS"),

--- a/wscript
+++ b/wscript
@@ -22,7 +22,12 @@ def determine_version():
         if os.path.exists("version.txt"):
             return open("version.txt", "r").readlines()[0].strip()
         raise FileNotFoundError("Wire-Cell Toolkit must either be built from a git clone or a version.txt must be provided in the source distribution")
-    return proc.stdout.decode().strip()
+    version = proc.stdout.decode().strip()
+    proc = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True)
+    branch = proc.stdout.decode().strip()
+    if branch == "master" or branch[0].isdecimal():
+        return version
+    return f'{branch}-{version}'
 
 VERSION = determine_version()
 


### PR DESCRIPTION
Make the build modal depending on git branch.

If "master" or a release branch then the build is "release mode" else it is "development mode".

In release mode, disable any packages not ready for release (eg patrec) and make the compiler more strict.  Fixes #305.

Currently, development mode (building in a feature branch) has no changes from nominal.

This commit improves setting VERSION and adds support for providing the version in a "version.txt" file when the source is not under git control.  Fixes #112.  

But, note, we must do something new in order to assure `version.txt` exists in pure-source releases.  We do not typically make tarball source releases and I do not know how to inject this file in the tarballs that GitHub makes automatically so this feature will likely remain vestigial.