### PR TITLE
Feature/dnnsp mask negcharge

### DIFF
--- a/pytorch/inc/WireCellPytorch/DNNROIFinding.h
+++ b/pytorch/inc/WireCellPytorch/DNNROIFinding.h
@@ -136,7 +136,7 @@ namespace WireCell {
             IFrame::trace_summary_t get_summary_e(const IFrame::pointer& inframe, const std::string &tag) const;
 
             // Convert dense array to (dense) traces
-            ITrace::shared_vector eigen_to_traces(const Array::array_xxf& arr, bool set_negative_to_zero);
+            ITrace::shared_vector eigen_to_traces(const Array::array_xxf& arr, bool save_negative_charge);
 
             int m_save_count;  // count frames saved
         };

--- a/pytorch/inc/WireCellPytorch/DNNROIFinding.h
+++ b/pytorch/inc/WireCellPytorch/DNNROIFinding.h
@@ -58,7 +58,7 @@ namespace WireCell {
             // probability-like value.  It is tuned to balance efficiency and
             // noise reduction and strictly is best optimized for the given
             // model.
-            double mask_thresh{0.7};
+            double mask_thresh{0.5};
 
             // The IForward service to use
             std::string forward{"TorchService"};
@@ -87,6 +87,9 @@ namespace WireCell {
             std::string outtag{""};
 
             int nchunks{1};
+
+            // if true, save the negative parts of the charge traces
+            bool save_negative_charge{false};
         };
 
         class DNNROIFinding : public Aux::Logger,
@@ -133,7 +136,7 @@ namespace WireCell {
             IFrame::trace_summary_t get_summary_e(const IFrame::pointer& inframe, const std::string &tag) const;
 
             // Convert dense array to (dense) traces
-            ITrace::shared_vector eigen_to_traces(const Array::array_xxf& arr);
+            ITrace::shared_vector eigen_to_traces(const Array::array_xxf& arr, bool set_negative_to_zero);
 
             int m_save_count;  // count frames saved
         };

--- a/pytorch/src/DNNROIFinding.cxx
+++ b/pytorch/src/DNNROIFinding.cxx
@@ -28,7 +28,10 @@
 // become a dynamic option.
 
 #ifdef DNNROI_HDF5_DEBUG
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <h5cpp/all>
+#pragma GCC diagnostic pop
 #endif
 
 /// macro to register name - concrete pair in the NamedFactory
@@ -268,7 +271,10 @@ bool Pytorch::DNNROIFinding::operator()(const IFrame::pointer& inframe, IFrame::
     log->debug(tk(fmt::format("call={} calling model \"{}\" with {} chunks ",
                               m_save_count, m_cfg.forward, m_cfg.nchunks)));
     for (auto chunk : chunks) {
+        // G.P. If chunking is enabled, then the array is not contiguous in memory.
+        // To work around this, we need to clone the array.
         std::vector<torch::IValue> itens {(m_cfg.nchunks > 1) ? chunk.clone() : chunk};
+
         auto iitens = Pytorch::to_itensor(itens);
         auto oitens = m_forward->forward(iitens);
         torch::Tensor ochunk = Pytorch::from_itensor({oitens}).front().toTensor().cpu();

--- a/pytorch/src/DNNROIFinding.cxx
+++ b/pytorch/src/DNNROIFinding.cxx
@@ -210,7 +210,7 @@ IFrame::trace_summary_t Pytorch::DNNROIFinding::get_summary_e(const IFrame::poin
     return summary_e;
 }
 
-ITrace::shared_vector Pytorch::DNNROIFinding::eigen_to_traces(const Array::array_xxf& arr, bool set_negative_to_zero)
+ITrace::shared_vector Pytorch::DNNROIFinding::eigen_to_traces(const Array::array_xxf& arr, bool save_negative_charge)
 {
     ITrace::vector traces;
     ITrace::ChargeSequence charge(m_ncols, 0.0);
@@ -218,7 +218,7 @@ ITrace::shared_vector Pytorch::DNNROIFinding::eigen_to_traces(const Array::array
         auto wave = arr.row(irow);
         for (size_t icol=0; icol<m_ncols; ++icol) {
             charge[icol] = wave(icol);
-            if (set_negative_to_zero) {
+            if (!save_negative_charge) { // set negative charge to zero
                 charge[icol] = charge[icol] < 0 ? 0 : charge[icol];
             }
         }
@@ -327,7 +327,7 @@ bool Pytorch::DNNROIFinding::operator()(const IFrame::pointer& inframe, IFrame::
 #endif
 
     // eigen to frame
-    auto traces = eigen_to_traces(sp_charge, !m_cfg.save_negative_charge);
+    auto traces = eigen_to_traces(sp_charge, m_cfg.save_negative_charge);
     Aux::SimpleFrame* sframe = new Aux::SimpleFrame(
         inframe->ident(), inframe->time(),
         traces,


### PR DESCRIPTION
Add a configuration to zero-out negative charges in the DNN ROI applied decon traces. This need to be done in `pytorch`, separately from the nominal OmnibusSigProc.