### PR TITLE
Profiling YZ Simulation 

### DIFF
--- a/gen/inc/WireCellGen/DepoSetFilterYZ.h
+++ b/gen/inc/WireCellGen/DepoSetFilterYZ.h
@@ -42,6 +42,8 @@ namespace WireCell::Gen {
     //Json::Value map = Json::arrayValue;
     //Json::arrayValue map;
     Json::Value jmap;
+    
+    std::vector<std::vector<int>> yzmap;
 
 
   };

--- a/gen/inc/WireCellGen/Scaler.h
+++ b/gen/inc/WireCellGen/Scaler.h
@@ -42,6 +42,8 @@ namespace WireCell {
       //Json::arrayValue map;
       Json::Value jmap;
 
+      std::vector<std::vector<double>> yzmap;
+
 
     };  // Scaler
 

--- a/gen/src/DepoSetFilterYZ.cxx
+++ b/gen/src/DepoSetFilterYZ.cxx
@@ -73,6 +73,16 @@ void DepoSetFilterYZ::configure(const WireCell::Configuration& cfg)
   anode_name = get<std::string>(cfg, "anode");
   jmap = WireCell::Persist::load(filename);
 
+  yzmap.resize(nbinsz);
+  for(int binz = 0; binz < nbinsz; binz++){
+    yzmap[binz].resize(nbinsy);
+    for(int biny = 0; biny < nbinsy; biny++){
+      yzmap[binz][biny] = jmap[anode_name][std::to_string(plane)][binz][biny].asInt();
+    }
+  }
+
+  jmap.clear();
+
 }
 
 bool DepoSetFilterYZ::operator()(const input_pointer& in, output_pointer& out)
@@ -121,7 +131,7 @@ bool DepoSetFilterYZ::operator()(const input_pointer& in, output_pointer& out)
     if(depo_bin_z > nbinsz)
       depo_bin_z = nbinsz;
 
-    if (jmap[anode_name][std::to_string(plane)][depo_bin_z][depo_bin_y].asInt() == resp+1) {pass_resp = true;}
+    if (yzmap[depo_bin_z][depo_bin_y] == resp+1) {pass_resp = true;}
 
     if (pass_resp && pass_anod) {
       //log->debug(" Passed! Resp {} at Y : {} and Z : {} on Plane {} and Anode {} ", resp+1, depo_y, depo_z, plane, anode_name);

--- a/gen/src/Scaler.cxx
+++ b/gen/src/Scaler.cxx
@@ -76,6 +76,17 @@ void Gen::Scaler::configure(const WireCell::Configuration& cfg)
 
   jmap = WireCell::Persist::load(filename);
 
+  yzmap.resize(180);
+  for(int binz = 0; binz < 180; binz++){
+    yzmap[binz].resize(31);
+    for(int biny = 0; biny < 31; biny++){
+      yzmap[binz][biny] = jmap[anode_name][std::to_string(plane)][binz][biny].asDouble();
+    }
+  }
+
+  jmap.clear();
+
+
 }
 
 void Gen::Scaler::reset() { }
@@ -126,8 +137,7 @@ bool Gen::Scaler::operator()(const input_pointer& depo, output_queue& outq)
     depo_bin_z = 180;
   }
 
-  //  double scale = (jmap[anode_name][std::to_string(plane)][depo_bin_y][depo_bin_z].asDouble());
-  double scale = (jmap[anode_name][std::to_string(plane)][depo_bin_z][depo_bin_y].asDouble());
+  double scale = yzmap[depo_bin_z][depo_bin_y];
 
   auto newdepo = make_shared<Aux::SimpleDepo>(depo->time(), depo->pos(), Qi*scale, depo, depo->extent_long(), depo->extent_tran());
 


### PR DESCRIPTION
The loading and memory usage of the YZ simulation was leading to challenges for production. 

Using `valgrind`, we found substantial memory usage just at the loading and accessing of the maps were being stored as `json::Array` when we converted this to an `std::vector<std::vector<int/double>>` this led to a 10 GB of memory savings. 