### PR TITLE
Address ICARUS YZ Non-Uniformity Bug

### DIFF
--- a/gen/src/Scaler.cxx
+++ b/gen/src/Scaler.cxx
@@ -137,7 +137,7 @@ bool Gen::Scaler::operator()(const input_pointer& depo, output_queue& outq)
 
   double scale = yzmap[depo_bin_z][depo_bin_y];
 
-  auto newdepo = make_shared<Aux::SimpleDepo>(depo->time(), depo->pos(), Qi*scale, depo, depo->extent_long(), depo->extent_tran());
+  auto newdepo = make_shared<Aux::SimpleDepo>(depo->time(), depo->pos(), Qi*scale, depo->prior(), depo->extent_long(), depo->extent_tran(), depo->prior()->id(), depo->prior()->pdg(), depo->prior()->energy());
 
   outq.push_back(newdepo);
 


### PR DESCRIPTION
Hi, implementing the change I suggested in https://github.com/WireCell/wire-cell-toolkit/issues/405 fixes the bug.

Before this fix, there is a clear discrepancy between the visible energy and nhits when comparing a recent MC validation sample to a previous production.
![NoFix_0](https://github.com/user-attachments/assets/1e3dd6fe-7f70-41b8-8a6a-796b1f158347)


After this fix, this is resolved. Note that the difference in the number of points comes from using different samples sizes.
![Fix](https://github.com/user-attachments/assets/8b340cce-7e40-43da-94b5-aa31e254179b)

In general, since the prior is "before drifting", in Scaler.cxx we should still be using the same prior that we used in Drifter.cxx.