### PR TITLE
Add configurables in `Subtract_WScaling` (coherent noise removal)

### DIFF
--- a/sigproc/inc/WireCellSigProc/Microboone.h
+++ b/sigproc/inc/WireCellSigProc/Microboone.h
@@ -40,7 +40,8 @@ namespace WireCell {
                                    std::vector<std::vector<int> >& rois,
                                    const IDFT::pointer& dft,
                                    float upper_decon_limit1 = 0.08,
-                                   float roi_min_max_ratio = 0.8, float rms_threshold = 0.);
+                                   float roi_min_max_ratio = 0.8, float rms_threshold = 0.,
+                                   float correlation_threshold = 4.0, float default_scaling = 0.);
 
             // hold common config stuff
             class ConfigFilterBase : public WireCell::IConfigurable {
@@ -75,7 +76,10 @@ namespace WireCell {
             class CoherentNoiseSub : public WireCell::IChannelFilter, public ConfigFilterBase {
                public:
                 CoherentNoiseSub(const std::string& anode = "AnodePlane",
-                                 const std::string& noisedb = "OmniChannelNoiseDB", float rms_threshold = 0.);
+                                 const std::string& noisedb = "OmniChannelNoiseDB", 
+                                 float rms_threshold = 0., 
+                                 float correlation_threshold = 4.,
+                                 float default_scaling = 0.);
                 virtual ~CoherentNoiseSub();
 
                 virtual void configure(const WireCell::Configuration& config);
@@ -91,6 +95,8 @@ namespace WireCell {
 
                private:
                 float m_rms_threshold;
+                float m_correlation_threshold;
+                float m_default_scaling;
             };
 
             /** Microboone style single channel noise subtraction.


### PR DESCRIPTION
The existing threshold used to determine the correlation coefficient (`signal/rms < 4`) leads to significant non-uniformities within channel groups during coherent noise removal in SBND. This PR adds a configuration, with default value `4` (as to not modify other experiments' configuration), to allows us to set a user-defined threshold. Different experiments may expect different thresholds depending on their S/N ratios, channel rms, etc. For SBND, `signal/rms < 2` mitigates the non-uniformity issue. 

Another workaround for this issue is to avoid using a `scaling` based on the correlation coefficient in the first place. Another configurable is added to set a default scaling value. 

Both of these new configurables are global for all channel groups, meaning they are not part of the channel database and cannot be overridden for particular groups of channels. 