### PR TITLE
Bug Fix: Adjust distance to cathode calculation

### DIFF
--- a/cfg/pgrapher/experiment/icarus/params.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/params.jsonnet
@@ -4,6 +4,10 @@
 local wc = import "wirecell.jsonnet";
 local base = import "pgrapher/common/params.jsonnet";
 
+local cathode_input_format = std.extVar('cathode_input_format'); // scalar, array
+local east = import "cathode-east.jsonnet";
+local west = import "cathode-west.jsonnet";
+
 base {
     det : {
 
@@ -50,7 +54,13 @@ base {
                         {
                             anode: xanode[a],
                             response: xresponse[a],
-                            cathode: xcathode[a],
+                            //cathode: xcathode[a],
+			    cathode: if cathode_input_format == 'scalar' then xcathode[a]
+                                     else {
+                                       x: if anode<2 then [v*wc.cm for v in east.x] else [v*wc.cm for v in west.x],
+                                       y: if anode<2 then [v*wc.cm for v in east.y] else [v*wc.cm for v in west.y],
+                                       z: if anode<2 then [v*wc.cm for v in east.z] else [v*wc.cm for v in west.z],
+                                     },
                         },
 
                         null

--- a/util/inc/WireCellUtil/CoordRegion.h
+++ b/util/inc/WireCellUtil/CoordRegion.h
@@ -121,14 +121,8 @@ namespace WireCell {
             const auto res = m_kd.knn(3, pt);
 
             const Point a = m_kd.point3d(res[0].first);
-            const Point b = m_kd.point3d(res[1].first);
-            const Point c = m_kd.point3d(res[2].first);
 
-            const auto v0 = pt - a; // relative vector from a to test point
-            const auto v1 = b - a;  // relative vector in plane
-            const auto v2 = c - a;  // relative vector in plane
-            const auto norm = v1.cross(v2);
-            return norm.dot(v0) * (norm[m_axes[0]] < 0 ? -1.0 : 1.0);
+            return pt[m_axes[0]] - a[m_axes[0]];
         }
         virtual double location() const { return m_location; }
 


### PR DESCRIPTION
We found that in ICARUS when using the bent cathode simulation we were getting incorrect distances to the cathode. When we updated the function to follow the scalar calculation it more closely matches our expectation. 

After our fix:
<img width="2084" height="1180" alt="image" src="https://github.com/user-attachments/assets/19debea5-9a18-4e0a-aef4-db08158e27c2" />
