### PR TITLE
Update PlaneSelector to propagate trace summaries and support summary tags

### DIFF
--- a/aux/inc/WireCellAux/PlaneSelector.h
+++ b/aux/inc/WireCellAux/PlaneSelector.h
@@ -34,12 +34,12 @@ namespace WireCell::Aux {
 
       private:
         std::vector<std::string> m_tags;
+        std::vector<std::string> m_summary_tags;
         tagrules::Context m_ft;
         int m_count{0};
 
         // The channel ident numbers we will select
         std::unordered_set<int> m_chids;
-
     };
 
 }  // namespace WireCell::Aux

--- a/aux/src/PlaneSelector.cxx
+++ b/aux/src/PlaneSelector.cxx
@@ -7,6 +7,8 @@
 #include "WireCellUtil/NamedFactory.h"
 
 #include <sstream>
+#include <algorithm>
+#include <map>
 
 WIRECELL_FACTORY(PlaneSelector, WireCell::Aux::PlaneSelector,
                  WireCell::IFrameFilter, WireCell::IConfigurable)
@@ -51,13 +53,17 @@ WireCell::Configuration Aux::PlaneSelector::default_configuration() const
     /// tag.
     cfg["tag_rules"] = Json::arrayValue;
 
+    /// Optional summary source tags corresponding to "tags".
+    /// If empty, each trace tag will use its own summary tag.
+    cfg["summary_tags"] = Json::arrayValue;
+
     return cfg;
 }
 
 void Aux::PlaneSelector::configure(const WireCell::Configuration& cfg)
 {
     int wire_plane_index = get(cfg, "plane", 0);
-    
+
     // We only need the anode temporarily to build set of channel IDs
     // that we care about.
     std::string anode_tn = get<std::string>(cfg, "anode", "AnodePlane");
@@ -73,17 +79,26 @@ void Aux::PlaneSelector::configure(const WireCell::Configuration& cfg)
                    anode_tn, wire_plane_index, m_chids.size(),
                    *chmm.first, *chmm.second);
     }
-    
-    auto jtags = cfg["tags"];
+
     m_tags.clear();
     for (auto jtag : cfg["tags"]) {
         m_tags.push_back(jtag.asString());
     }
 
+    m_summary_tags.clear();
+    for (auto jtag : cfg["summary_tags"]) {
+        m_summary_tags.push_back(jtag.asString());
+    }
+
+    if (!m_summary_tags.empty() && m_summary_tags.size() != m_tags.size()) {
+        log->warn("summary_tags size ({}) differs from tags size ({}); "
+                  "missing entries will fall back to trace tag names",
+                  m_summary_tags.size(), m_tags.size());
+    }
+
     auto tr = cfg["tag_rules"];
     m_ft.configure(tr);
 }
-
 
 bool Aux::PlaneSelector::operator()(const input_pointer& in,
                                     output_pointer& out)
@@ -103,23 +118,50 @@ bool Aux::PlaneSelector::operator()(const input_pointer& in,
 
     ITrace::vector out_traces;
     std::map<std::string, IFrame::trace_list_t> tagged_indices;
+    std::map<std::string, IFrame::trace_summary_t> tagged_summaries;
 
-    for (const auto& my_tag : my_tags) {
+    for (size_t itag = 0; itag < my_tags.size(); ++itag) {
+        const auto& my_tag = my_tags[itag];
+
         ITrace::vector traces;
+        IFrame::trace_summary_t summaries;
+
         if (my_tag.empty()) {
             traces = Aux::untagged_traces(in);
+            log->warn("Untagged summary not supported, summary will be dropped.");
         }
         else {
             traces = Aux::tagged_traces(in, my_tag);
+
+            std::string summary_tag = my_tag;
+            if (itag < m_summary_tags.size() && !m_summary_tags[itag].empty()) {
+                summary_tag = m_summary_tags[itag];
+            }
+
+            summaries = in->trace_summary(summary_tag);
+
+            if (!summaries.empty() && summaries.size() != traces.size()) {
+                log->warn("summary size mismatch for trace tag \"{}\" using summary tag \"{}\": trace={}, summary={}",
+                          my_tag, summary_tag, traces.size(), summaries.size());
+            }
         }
 
         IFrame::trace_list_t indices;
-        for (auto itrace : traces) {
+        IFrame::trace_summary_t selected_summaries;
+
+        for (size_t trind = 0; trind < traces.size(); ++trind) {
+            auto itrace = traces[trind];
             int chid = itrace->channel();
             if (m_chids.find(chid) == m_chids.end()) {
                 continue;
             }
+
             indices.push_back(out_traces.size());
+
+            if (!summaries.empty() && trind < summaries.size()) {
+                selected_summaries.push_back(summaries[trind]);
+            }
+
             out_traces.push_back(itrace);
         }
 
@@ -128,27 +170,78 @@ bool Aux::PlaneSelector::operator()(const input_pointer& in,
             log->debug("call={} no transform, keeping input tag: {}", m_count, my_tag);
             new_tags.insert(my_tag);
         }
-        for (auto new_tag : new_tags) {
-            tagged_indices[new_tag] = indices;
+
+        for (const auto& new_tag : new_tags) {
+            auto& out_indices = tagged_indices[new_tag];
+            const size_t old_size = out_indices.size();
+            out_indices.insert(out_indices.end(), indices.begin(), indices.end());
+
+            auto found = tagged_summaries.find(new_tag);
+            if (found != tagged_summaries.end()) {
+                auto& out_summaries = found->second;
+
+                if (!selected_summaries.empty()) {
+                    if (out_summaries.size() == old_size) {
+                        out_summaries.insert(out_summaries.end(),
+                                             selected_summaries.begin(),
+                                             selected_summaries.end());
+                    }
+                    else {
+                        log->warn("dropping summary propagation for merged tag \"{}\" due to inconsistent existing summary size: trace={}, summary={}",
+                                  new_tag, old_size, out_summaries.size());
+                        tagged_summaries.erase(new_tag);
+                    }
+                }
+            }
+            else if (!selected_summaries.empty()) {
+                if (old_size == 0) {
+                    tagged_summaries[new_tag] = selected_summaries;
+                }
+                else {
+                    log->warn("skipping partial summary propagation for merged tag \"{}\": existing trace={}, added summary={}",
+                              new_tag, old_size, selected_summaries.size());
+                }
+            }
         }
     }
 
-    auto sf = new SimpleFrame(in->ident(), in->time(), out_traces, in->tick());
-    for (auto& [new_tag,indices] : tagged_indices) {
-        sf->tag_traces(new_tag, indices);
+    auto sf = new SimpleFrame(in->ident(), in->time(), out_traces, in->tick(), in->masks());
+
+    for (auto& [new_tag, indices] : tagged_indices) {
+        auto found = tagged_summaries.find(new_tag);
+        if (found != tagged_summaries.end() &&
+            !found->second.empty() &&
+            found->second.size() == indices.size()) {
+            sf->tag_traces(new_tag, indices, found->second);
+        }
+        else {
+            if (found != tagged_summaries.end() &&
+                !found->second.empty() &&
+                found->second.size() != indices.size()) {
+                log->warn("summary/trace size mismatch after selection for tag \"{}\": trace={}, summary={}",
+                          new_tag, indices.size(), found->second.size());
+            }
+            sf->tag_traces(new_tag, indices);
+        }
     }
 
     std::vector<std::string> frame_tags = in->frame_tags();
     if (frame_tags.empty()) {
         frame_tags.push_back("");
     }
+
     auto new_tags = m_ft.transform(0, "frame", frame_tags);
-    for (auto new_tag : new_tags) {
+    if (new_tags.empty()) {
+        new_tags.insert(new_tags.end(), frame_tags.begin(), frame_tags.end());
+    }
+
+    for (const auto& new_tag : new_tags) {
         if (new_tag.empty()) {
             continue;
         }
         sf->tag_frame(new_tag);
     }
+
     out = IFrame::pointer(sf);
 
     log->debug("call={} input {}", m_count, Aux::taginfo(in));
@@ -157,4 +250,3 @@ bool Aux::PlaneSelector::operator()(const input_pointer& in,
     ++m_count;
     return true;
 }
-


### PR DESCRIPTION
PlaneSelector previously discarded trace summaries when copying traces
from the input frame to the output frame.

This caused mismatches between trace tag sizes and summary sizes in
downstream processing (eg Wire Cell Imaging), particularly when
PlaneSelector is used after signal processing steps that produce
trace summaries.

This PR propagates summaries through PlaneSelector in a manner similar
to ChannelSelector.

Key changes:
- Preserve trace summaries for selected traces
- Add optional "summary_tags" configuration to allow specifying the
  summary source tag corresponding to each trace tag
- Preserve input masks when creating the output frame
- Add safety checks for summary/trace size mismatches