### PR TITLE
bug fixes. removed one-sided FFT bin doubling and force 2128-tick noise configs

### DIFF
--- a/cfg/pgrapher/experiment/iceberg/wcls-sim-drift-simchannel-splusn-correlated.jsonnet
+++ b/cfg/pgrapher/experiment/iceberg/wcls-sim-drift-simchannel-splusn-correlated.jsonnet
@@ -34,10 +34,21 @@ local params = params_maker(fcl_params) {
   },
 };
 
-local tools = tools_maker(params);
+// define local nticks (since the noise model was built with 2128 ticks)
+local RUN_NTICKS = 2128;
+local RUN_TICK   = params.daq.tick;
+
+// override nticks and tick from params with local values
+local params_run = params {
+  daq: super.daq { nticks: RUN_NTICKS, tick: RUN_TICK },
+};
+
+//local tools = tools_maker(params);
+local tools = tools_maker(params_run);
 
 local sim_maker = import 'pgrapher/experiment/iceberg/sim.jsonnet';
-local sim = sim_maker(params, tools);
+//local sim = sim_maker(params, tools);
+local sim = sim_maker(params_run, tools);
 
 // Anode bookkeeping
 local nanodes = std.length(tools.anodes);
@@ -52,7 +63,8 @@ local noise_model = "/cvmfs/dune.osgstorage.org/pnfs/fnal.gov/usr/dune/persisten
 // (3) WCLS input + MegaAnode plane definition
 // ----------------------------------------------------------------------------
 local wcls_maker = import 'pgrapher/ui/wcls/nodes.jsonnet';
-local wcls = wcls_maker(params, tools);
+//local wcls = wcls_maker(params, tools);
+local wcls = wcls_maker(params_run, tools);
 
 local wcls_input = {
   depos: wcls.input.depos(
@@ -129,11 +141,14 @@ local wcls_simchannel_sink = g.pnode({
     artlabel: 'simpleSC',
     anodes_tn: [wc.tn(anode) for anode in tools.anodes],
     rng: wc.tn(rng),
-    tick: 0.5 * wc.us,
+    // tick: 0.5 * wc.us,
+    tick: RUN_TICK,
     start_time: -0.25 * wc.ms,
-    readout_time: self.tick * 6000,
+    // readout_time: self.tick * 6000,
+    readout_time: RUN_NTICKS * RUN_TICK,
     nsigma: 3.0,
-    drift_speed: params.lar.drift_speed,
+    //drift_speed: params.lar.drift_speed,
+    drift_speed: params_run.lar.drift_speed,
     u_to_rp: 100 * wc.mm,
     v_to_rp: 100 * wc.mm,
     y_to_rp: 100 * wc.mm,
@@ -195,8 +210,10 @@ local noise_adders = [
       model_file: noise_model,
 
       // These are in WCT base units already:
-      nsamples: params.daq.nticks,
-      dt: params.daq.tick,       // ns (WCT base time units)
+      // nsamples: params.daq.nticks,
+      nsamples: RUN_NTICKS,
+      // dt: params.daq.tick,       // ns (WCT base time units)
+      dt: RUN_TICK,
 
       // Keep at 1.0 unless you need a quick normalization tweak
       ifft_scale: 1.0,

--- a/cfg/pgrapher/experiment/iceberg/wcls-sim-drift-simchannel-splusn-uncorrelated.jsonnet
+++ b/cfg/pgrapher/experiment/iceberg/wcls-sim-drift-simchannel-splusn-uncorrelated.jsonnet
@@ -34,10 +34,21 @@ local params = params_maker(fcl_params) {
   },
 };
 
-local tools = tools_maker(params);
+// define local nticks (since the noise model was built with 2128 ticks)
+local RUN_NTICKS = 2128;
+local RUN_TICK   = params.daq.tick;
+
+// override nticks and tick from params with local values
+local params_run = params {
+  daq: super.daq { nticks: RUN_NTICKS, tick: RUN_TICK },
+};
+
+//local tools = tools_maker(params);
+local tools = tools_maker(params_run);
 
 local sim_maker = import 'pgrapher/experiment/iceberg/sim.jsonnet';
-local sim = sim_maker(params, tools);
+//local sim = sim_maker(params, tools);
+local sim = sim_maker(params_run, tools);
 
 // Anode bookkeeping
 local nanodes = std.length(tools.anodes);
@@ -52,7 +63,8 @@ local noise_model = "/cvmfs/dune.osgstorage.org/pnfs/fnal.gov/usr/dune/persisten
 // (3) WCLS input + MegaAnode plane definition
 // ----------------------------------------------------------------------------
 local wcls_maker = import 'pgrapher/ui/wcls/nodes.jsonnet';
-local wcls = wcls_maker(params, tools);
+//local wcls = wcls_maker(params, tools);
+local wcls = wcls_maker(params_run, tools);
 
 local wcls_input = {
   depos: wcls.input.depos(
@@ -129,11 +141,14 @@ local wcls_simchannel_sink = g.pnode({
     artlabel: 'simpleSC',
     anodes_tn: [wc.tn(anode) for anode in tools.anodes],
     rng: wc.tn(rng),
-    tick: 0.5 * wc.us,
+    // tick: 0.5 * wc.us,
+    tick: RUN_TICK,
     start_time: -0.25 * wc.ms,
-    readout_time: self.tick * 6000,
+    // readout_time: self.tick * 6000,
+    readout_time: RUN_NTICKS * RUN_TICK,
     nsigma: 3.0,
-    drift_speed: params.lar.drift_speed,
+    //drift_speed: params.lar.drift_speed,
+    drift_speed: params_run.lar.drift_speed,
     u_to_rp: 100 * wc.mm,
     v_to_rp: 100 * wc.mm,
     y_to_rp: 100 * wc.mm,
@@ -195,8 +210,10 @@ local noise_adders = [
       model_file: noise_model,
 
       // These are in WCT base units already:
-      nsamples: params.daq.nticks,
-      dt: params.daq.tick,       // ns (WCT base time units)
+      // nsamples: params.daq.nticks,
+      nsamples: RUN_NTICKS,
+      // dt: params.daq.tick,       // ns (WCT base time units)
+      dt: RUN_TICK,
 
       // Keep at 1.0 unless you need a quick normalization tweak
       ifft_scale: 1.0,

--- a/gen/inc/WireCellGen/CorrelatedAddNoise.h
+++ b/gen/inc/WireCellGen/CorrelatedAddNoise.h
@@ -28,7 +28,7 @@
  *      using Rayleigh-mean scaling and the row-wise variance of A_b
  *   5) Handle DC (force to 0) and Nyquist (real-only if N even, correlated draw)
  *   6) Convert one-sided spectrum to time domain using NumPy-like irfft convention:
- *        - bin-doubling + 1/N + optional ifft_scale
+ *        - FFTW c2r + 1/N + optional ifft_scale
  *
  * IMPORTANT ASSUMPTION ABOUT CHANNEL ORDERING
  * ------------------------------------------

--- a/gen/inc/WireCellGen/UncorrelatedAddNoise.h
+++ b/gen/inc/WireCellGen/UncorrelatedAddNoise.h
@@ -22,10 +22,10 @@
  *   2) Scale Z so that E|scaled Z| matches the target mean magnitude avg_mag(w,f)
  *      using Rayleigh-mean scaling: E|CN(0,1)| = sqrt(pi)/2
  *   3) Handle DC (force to 0) and Nyquist (real-only if N is even)
- *   4) Convert one-sided spectrum to time-domain noise via a NumPy-like irfft convention:
- *        - double bins with conjugate partners
+ *   4) Convert one-sided spectrum to time-domain noise via FFTW c2r:
+ *        - provide the one-sided spectrum (DC..Nyquist)
  *        - FFTW c2r (unnormalized)
- *        - apply 1/N normalization
+ *        - apply 1/N normalization to match NumPy irfft
  *        - apply optional ifft_scale
  *
  * IMPORTANT ASSUMPTION ABOUT CHANNEL ORDERING

--- a/gen/src/CorrelatedAddNoise.cxx
+++ b/gen/src/CorrelatedAddNoise.cxx
@@ -14,7 +14,7 @@
  * - If N is even, Nyquist bin is handled as real-only and correlated via A_b on a
  *   real normal vector, with scaling based on E|N(0,1)|.
  * - One-sided spectrum -> time domain via NumPy-like irfft convention:
- *     bin-doubling + FFTW c2r + 1/N + optional ifft_scale.
+ *     FFTW c2r + 1/N + optional ifft_scale.
  *
  * @author Avik Ghosh
  * @version 1.0.0
@@ -150,18 +150,18 @@ inline Json::Value parse_json_string(const std::string& text,
 //
 // Same convention as in UncorrelatedAddNoise.
 // -----------------------------------------------------------------------------
-inline void irfft_numpy_like_fftwf(const std::vector<std::complex<float>>& Xpos,
-                                  std::vector<float>& x_time,
-                                  int N,
-                                  float final_scale)
+inline void irfft_fftwf(const std::vector<std::complex<float>>& Xpos,
+                        std::vector<float>& x_time,
+                        int N,
+                        float ifft_scale)
 {
     const int Kt = N / 2 + 1;
     if ((int)Xpos.size() != Kt) {
         THROW(WireCell::ValueError()
-              << WireCell::errmsg{"irfft_numpy_like_fftwf: Xpos size != N/2+1"});
+              << WireCell::errmsg{"irfft_fftwf: Xpos size != N/2+1"});
     }
 
-    x_time.assign((size_t)N, 0.0f);
+    x_time.resize((size_t)N);
 
     fftwf_complex* in  = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * (size_t)Kt);
     float*         out = (float*)fftwf_malloc(sizeof(float) * (size_t)N);
@@ -170,7 +170,7 @@ inline void irfft_numpy_like_fftwf(const std::vector<std::complex<float>>& Xpos,
         if (in)  fftwf_free(in);
         if (out) fftwf_free(out);
         THROW(WireCell::RuntimeError()
-              << WireCell::errmsg{"irfft_numpy_like_fftwf: fftwf_malloc failed"});
+              << WireCell::errmsg{"irfft_fftwf: fftwf_malloc failed"});
     }
 
     for (int k = 0; k < Kt; ++k) {
@@ -178,15 +178,9 @@ inline void irfft_numpy_like_fftwf(const std::vector<std::complex<float>>& Xpos,
         in[k][1] = Xpos[(size_t)k].imag();
     }
 
-    const bool is_even = ((N % 2) == 0);
-    if (is_even) {
-        in[Kt - 1][1] = 0.0f; // Nyquist imag must be 0
-    }
-
-    const int k_max = is_even ? (Kt - 2) : (Kt - 1);
-    for (int k = 1; k <= k_max; ++k) {
-        in[k][0] *= 2.0f;
-        in[k][1] *= 2.0f;
+    // Even-N Nyquist bin must be purely real
+    if ((N % 2) == 0) {
+        in[Kt - 1][1] = 0.0f;
     }
 
     fftwf_plan plan = fftwf_plan_dft_c2r_1d(N, in, out, FFTW_ESTIMATE);
@@ -194,14 +188,15 @@ inline void irfft_numpy_like_fftwf(const std::vector<std::complex<float>>& Xpos,
         fftwf_free(in);
         fftwf_free(out);
         THROW(WireCell::RuntimeError()
-              << WireCell::errmsg{"irfft_numpy_like_fftwf: fftwf_plan_dft_c2r_1d failed"});
+              << WireCell::errmsg{"irfft_fftwf: fftwf_plan_dft_c2r_1d failed"});
     }
 
     fftwf_execute(plan);
 
-    const float invN = 1.0f / (float)N;
+    // FFTW backward transform is unnormalized: apply 1/N to match NumPy irfft
+    const float norm = ifft_scale / (float)N;
     for (int t = 0; t < N; ++t) {
-        x_time[(size_t)t] = out[t] * invN * final_scale;
+        x_time[(size_t)t] = out[t] * norm;
     }
 
     fftwf_destroy_plan(plan);
@@ -677,7 +672,7 @@ Eigen::MatrixXd CorrelatedAddNoise::make_correlated_noise(int nwires_frame,
                 std::complex<float>(one_sided[(size_t)(Kt - 1)].real(), 0.0f);
         }
 
-        irfft_numpy_like_fftwf(one_sided, x_time, N, (float)m_ifft_scale);
+        irfft_fftwf(one_sided, x_time, N, (float)m_ifft_scale);
 
         for (int t = 0; t < N; ++t) {
             noise_time(w, t) = (double)x_time[(size_t)t];

--- a/gen/src/UncorrelatedAddNoise.cxx
+++ b/gen/src/UncorrelatedAddNoise.cxx
@@ -16,7 +16,7 @@
  * - DC is forced to zero.
  * - If N is even, Nyquist bin is real-only (required for real-valued time-domain signal).
  * - One-sided spectrum is converted to time domain using a NumPy-compatible irfft
- *   convention implemented via FFTW: bin-doubling + 1/N + optional ifft_scale.
+ *   convention implemented via FFTW: FFTW c2r + 1/N + optional ifft_scale.
  *
  * @author Avik Ghosh
  * @version 1.0.0
@@ -154,30 +154,37 @@ inline Json::Value parse_json_string(const std::string& text,
 // -----------------------------------------------------------------------------
 // FFTW helper: NumPy-like irfft with one-sided spectrum
 //
-// Implements a NumPy-compatible inverse real FFT convention:
+// Implements a NumPy-compatible inverse real FFT convention.
 //
 // Input:
-//   Xpos : one-sided spectrum of length K = N/2 + 1
-// Behavior:
-//   - If N even, enforce Nyquist bin imaginary part = 0
-//   - Double bins that have conjugate partners:
-//       * N even : k = 1 .. K-2
-//       * N odd  : k = 1 .. K-1
-//   - FFTW c2r is unnormalized => apply 1/N explicitly
-//   - Apply final_scale after 1/N (this corresponds to ifft_scale)
+//   Xpos : one-sided spectrum of length K = N/2 + 1, ordered as
+//          [DC, +f1, +f2, ..., +f_{N/2}] (Nyquist present only if N is even).
+//
+// Behavior / convention:
+//   - Enforce the constraints required for a real-valued time-domain signal:
+//       * DC bin is purely real (imag = 0)
+//       * If N is even, Nyquist bin is purely real (imag = 0)
+//   - Uses FFTW's complex-to-real inverse transform (c2r), which interprets the
+//     provided one-sided spectrum and implicitly supplies the conjugate negative-
+//     frequency half.
+//   - FFTW's backward transform is unnormalized, so we apply an explicit 1/N.
+//   - Apply an additional user knob `ifft_scale` after the 1/N normalization.
+//
+// Output:
+//   x_time[t] = (ifft_scale / N) * FFTW_c2r(Xpos)[t]
 // -----------------------------------------------------------------------------
-inline void irfft_numpy_like_fftwf(const std::vector<std::complex<float>>& Xpos,
-                                  std::vector<float>& x_time,
-                                  int N,
-                                  float final_scale)
+inline void irfft_fftwf(const std::vector<std::complex<float>>& Xpos,
+                        std::vector<float>& x_time,
+                        int N,
+                        float ifft_scale)
 {
     const int Kt = N / 2 + 1;
     if ((int)Xpos.size() != Kt) {
         THROW(WireCell::ValueError()
-              << WireCell::errmsg{"irfft_numpy_like_fftwf: Xpos size != N/2+1"});
+              << WireCell::errmsg{"irfft_fftwf: Xpos size != N/2+1"});
     }
 
-    x_time.assign((size_t)N, 0.0f);
+    x_time.resize((size_t)N);
 
     fftwf_complex* in  = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * (size_t)Kt);
     float*         out = (float*)fftwf_malloc(sizeof(float) * (size_t)N);
@@ -186,26 +193,16 @@ inline void irfft_numpy_like_fftwf(const std::vector<std::complex<float>>& Xpos,
         if (in)  fftwf_free(in);
         if (out) fftwf_free(out);
         THROW(WireCell::RuntimeError()
-              << WireCell::errmsg{"irfft_numpy_like_fftwf: fftwf_malloc failed"});
+              << WireCell::errmsg{"irfft_fftwf: fftwf_malloc failed"});
     }
 
-    // Copy one-sided spectrum into FFTW input layout.
     for (int k = 0; k < Kt; ++k) {
         in[k][0] = Xpos[(size_t)k].real();
         in[k][1] = Xpos[(size_t)k].imag();
     }
 
-    const bool is_even = ((N % 2) == 0);
-    if (is_even) {
-        // For real output, the Nyquist bin must be purely real when N is even.
-        in[Kt - 1][1] = 0.0f;
-    }
-
-    // Bin-doubling to account for omitted negative-frequency half.
-    const int k_max = is_even ? (Kt - 2) : (Kt - 1);
-    for (int k = 1; k <= k_max; ++k) {
-        in[k][0] *= 2.0f;
-        in[k][1] *= 2.0f;
+    if ((N % 2) == 0) {
+        in[Kt - 1][1] = 0.0f; // Nyquist imag must be 0
     }
 
     fftwf_plan plan = fftwf_plan_dft_c2r_1d(N, in, out, FFTW_ESTIMATE);
@@ -213,15 +210,14 @@ inline void irfft_numpy_like_fftwf(const std::vector<std::complex<float>>& Xpos,
         fftwf_free(in);
         fftwf_free(out);
         THROW(WireCell::RuntimeError()
-              << WireCell::errmsg{"irfft_numpy_like_fftwf: fftwf_plan_dft_c2r_1d failed"});
+              << WireCell::errmsg{"irfft_fftwf: fftwf_plan_dft_c2r_1d failed"});
     }
 
     fftwf_execute(plan);
 
-    // Explicit 1/N to match NumPy irfft conventions.
-    const float invN = 1.0f / (float)N;
+    const float norm = ifft_scale / (float)N;  // 1/N normalization (+ optional scale)
     for (int t = 0; t < N; ++t) {
-        x_time[(size_t)t] = out[t] * invN * final_scale;
+        x_time[(size_t)t] = out[t] * norm;
     }
 
     fftwf_destroy_plan(plan);
@@ -576,7 +572,7 @@ Eigen::MatrixXd UncorrelatedAddNoise::make_uncorrelated_noise(int nwires_frame,
                 std::complex<float>(one_sided[(size_t)(Kt - 1)].real(), 0.0f);
         }
 
-        irfft_numpy_like_fftwf(one_sided, x_time, N, (float)m_ifft_scale);
+        irfft_fftwf(one_sided, x_time, N, (float)m_ifft_scale);
 
         // Store into Eigen matrix
         for (int t = 0; t < N; ++t) {


### PR DESCRIPTION
Removed a bug in the AddNoise Components that was doing doubling of one-sided FFT amplitude per freq bin.

Config jsonnets are now set to simulate signal with 2128 ticks (same as noise model structure)