### PR TITLE
Extract yzmap to shared IYZMap service, reducing 720 local maps to 2 …

### DIFF
--- a/cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-yzsim-shifted-refactored.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-yzsim-shifted-refactored.jsonnet
@@ -227,19 +227,41 @@ local setdrifters = [g.pnode({
                      #uses=[drifter])  
 		     for n in std.range(0,359)];
 
-local scalers = [{
+local yzmap_filter = {
+    type: "YZMap", name: "yzmap_filter",
+    data: {
+        filename: 'yzmap_icarus_v1.json',
+        bin_width:  10*wc.cm,
+        bin_height: 10*wc.cm,
+        yoffset: 180*wc.cm,
+        zoffset: 900*wc.cm,
+        nbinsy: 31,
+        nbinsz: 180,
+    }
+};
 
+local yzmap_gain = {
+    type: "YZMap", name: "yzmap_gain",
+    data: {
+        filename: 'yzmap_gain_icarus_v1.json',
+        bin_width:  10*wc.cm,
+        bin_height: 10*wc.cm,
+        yoffset: 180*wc.cm,
+        zoffset: 900*wc.cm,
+        nbinsy: 31,
+        nbinsz: 180,
+    }
+};
+
+local scalers = [{
         type: "Scaler",
-	name: "scaler%d" %n, //%std.floor(n/45),
-        data: params.lar {
-	        	 yzmap_scale_filename: 'yzmap_gain_icarus_v1.json',
-			 bin_width:  10*wc.cm,
-			 tpc_width: 1500*wc.mm,
-			 bin_height: 10*wc.cm,
-                	 anode: wc.tn(tools.anodes[std.floor(n/45)]),
-		         plane: std.mod(std.floor(n/15),3)	
-        	       	 },
-		} 
+	name: "scaler%d" %n,
+        data: {
+                 yzmap: wc.tn(yzmap_gain),
+                 anode: wc.tn(tools.anodes[std.floor(n/45)]),
+		 plane: std.mod(std.floor(n/15),3)
+        },
+	}
          for n in std.range(0,359)];
 
 local setscaler = [g.pnode({
@@ -249,7 +271,7 @@ local setscaler = [g.pnode({
                 	      scaler: wc.tn(scalers[n])
            		       }
         	  }, nin=1, nout=1,
-        	  uses=[scalers[n]])
+        	  uses=[scalers[n], yzmap_gain])
 		  for n in std.range(0,359)];
 
 
@@ -427,20 +449,13 @@ local deposetfilteryz = [ g.pnode({
             type: 'DepoSetFilterYZ',
    	    name: 'deposetfilteryz_resp%d-'%std.mod(r,15)+'plane%d-'%std.mod(std.floor(r/15),3)+tools.anodes[std.floor(r/45)].name,
             data: {
-	    	  yzmap_filename: 'yzmap_icarus_v1.json',
-		  bin_width:  10*wc.cm,
-		  tpc_width: 1500*wc.mm,
-		  bin_height: 10*wc.cm,
-		  yoffset: 180*wc.cm,
-		  zoffset: 900*wc.cm,
-		  nbinsy: 31,
-		  nbinsz: 180,
-		  resp: std.mod(r,15),	
+	    	  yzmap: wc.tn(yzmap_filter),
+		  resp: std.mod(r,15),
                   anode: wc.tn(tools.anodes[std.floor(r/45)]),
-		  plane: std.mod(std.floor(r/15),3)	
+		  plane: std.mod(std.floor(r/15),3)
             	  }
         }, nin=1, nout=1,
-        uses=tools.anodes)
+        uses=tools.anodes + [yzmap_filter])
 	for r in std.range(0,359)];
 
 local util = import 'pgrapher/experiment/icarus/funcs.jsonnet';

--- a/cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-yzsim.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-yzsim.jsonnet
@@ -207,19 +207,41 @@ local setdrifters = [g.pnode({
 	             uses=[drifters[n]])
 		     for n in std.range(0,359)];
 
-local scalers = [{
+local yzmap_filter = {
+    type: "YZMap", name: "yzmap_filter",
+    data: {
+        filename: 'yzmap_icarus_v0.json',
+        bin_width:  10*wc.cm,
+        bin_height: 10*wc.cm,
+        yoffset: 180*wc.cm,
+        zoffset: 900*wc.cm,
+        nbinsy: 31,
+        nbinsz: 180,
+    }
+};
 
+local yzmap_gain = {
+    type: "YZMap", name: "yzmap_gain",
+    data: {
+        filename: 'yzmap_gain_icarus_v0.json',
+        bin_width:  10*wc.cm,
+        bin_height: 10*wc.cm,
+        yoffset: 180*wc.cm,
+        zoffset: 900*wc.cm,
+        nbinsy: 31,
+        nbinsz: 180,
+    }
+};
+
+local scalers = [{
         type: "Scaler",
 	name: "scaler%d" %std.floor(n/45),
-        data: params.lar {
-	        	 yzmap_scale_filename: 'yzmap_gain_icarus_v0.json',
-			 bin_width:  10*wc.cm,
-			 tpc_width: 1500*wc.mm,
-			 bin_height: 10*wc.cm,
-                	 anode: wc.tn(tools.anodes[std.floor(n/45)]),
-		         plane: std.mod(std.floor(n/15),3)	
-        	       	 },
-		} 
+        data: {
+                 yzmap: wc.tn(yzmap_gain),
+                 anode: wc.tn(tools.anodes[std.floor(n/45)]),
+		 plane: std.mod(std.floor(n/15),3)
+        },
+	}
          for n in std.range(0,359)];
 
 local setscaler = [g.pnode({
@@ -229,7 +251,7 @@ local setscaler = [g.pnode({
                 	      scaler: wc.tn(scalers[n])
            		       }
         	  }, nin=1, nout=1,
-        	  uses=[scalers[n]])
+        	  uses=[scalers[n], yzmap_gain])
 		  for n in std.range(0,359)];
 
 
@@ -404,16 +426,13 @@ local deposetfilteryz = [ g.pnode({
             type: 'DepoSetFilterYZ',
    	    name: 'deposetfilteryz_resp%d-'%std.mod(r,15)+'plane%d-'%std.mod(std.floor(r/15),3)+tools.anodes[std.floor(r/45)].name,
             data: {
-	    	  yzmap_filename: 'yzmap_icarus_v0.json',
-		  bin_width:  10*wc.cm,
-		  tpc_width: 1500*wc.mm,
-		  bin_height: 10*wc.cm,
-		  resp: std.mod(r,15),	
+	    	  yzmap: wc.tn(yzmap_filter),
+		  resp: std.mod(r,15),
                   anode: wc.tn(tools.anodes[std.floor(r/45)]),
-		  plane: std.mod(std.floor(r/15),3)	
+		  plane: std.mod(std.floor(r/15),3)
             	  }
         }, nin=1, nout=1,
-        uses=tools.anodes)
+        uses=tools.anodes + [yzmap_filter])
 	for r in std.range(0,359)];
 
 local util = import 'pgrapher/experiment/icarus/funcs.jsonnet';

--- a/gen/inc/WireCellGen/DepoSetFilterYZ.h
+++ b/gen/inc/WireCellGen/DepoSetFilterYZ.h
@@ -8,6 +8,7 @@
 #include "WireCellIface/IDepoSetFilter.h"
 #include "WireCellIface/INamed.h"
 #include "WireCellIface/IConfigurable.h"
+#include "WireCellIface/IYZMap.h"
 #include "WireCellAux/Logger.h"
 #include "WireCellUtil/BoundingBox.h"
 
@@ -29,21 +30,10 @@ namespace WireCell::Gen {
     std::vector<WireCell::BoundingBox> m_boxes;
     std::size_t m_count{0};
 
-    double bin_width;
-    double tpc_width;
-    double bin_height;
-    double yoffset;
-    double zoffset;    
-    int nbinsy;
-    int nbinsz;
-    int resp;
-    int plane;
+    int resp{0};
+    int plane{0};
     std::string anode_name;
-    //Json::Value map = Json::arrayValue;
-    //Json::arrayValue map;
-    Json::Value jmap;
-    
-    std::vector<std::vector<int>> yzmap;
+    IYZMap::pointer m_yzmap_svc{nullptr};
 
 
   };

--- a/gen/inc/WireCellGen/Scaler.h
+++ b/gen/inc/WireCellGen/Scaler.h
@@ -3,12 +3,9 @@
 
 #include "WireCellIface/IDrifter.h"
 #include "WireCellIface/IConfigurable.h"
-#include "WireCellIface/IRandom.h"
-#include "WireCellUtil/Units.h"
+#include "WireCellIface/IYZMap.h"
 #include "WireCellAux/Logger.h"
 #include "WireCellUtil/BoundingBox.h"
-
-#include <set>
 
 namespace WireCell {
 
@@ -31,23 +28,10 @@ namespace WireCell {
 
     private:
       std::vector<WireCell::BoundingBox> m_boxes;
-     //std::size_t m_count{0};
 
-      double bin_width;
-      double tpc_width;
-      double bin_height;
-      int n_ybin;
-      int n_zbin;
-      double yoffset;
-      double zoffset;
-      int plane;
+      int plane{0};
       std::string anode_name;
-      std::string yzmap_scale_filename;
-      //Json::Value map = Json::arrayValue;
-      //Json::arrayValue map;
-      Json::Value jmap;
-
-      std::vector<std::vector<double>> yzmap;
+      IYZMap::pointer m_yzmap_svc{nullptr};
 
 
     };  // Scaler

--- a/gen/inc/WireCellGen/YZMap.h
+++ b/gen/inc/WireCellGen/YZMap.h
@@ -1,0 +1,42 @@
+#ifndef WIRECELL_GEN_YZMAP
+#define WIRECELL_GEN_YZMAP
+
+#include "WireCellIface/IYZMap.h"
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellAux/Logger.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace WireCell::Gen {
+
+    class YZMap : public Aux::Logger, public IYZMap, public IConfigurable {
+    public:
+        YZMap();
+        virtual ~YZMap();
+
+        virtual double value(const std::string& anode_name,
+                             int plane,
+                             double y, double z) const;
+
+        virtual void configure(const WireCell::Configuration& cfg);
+        virtual WireCell::Configuration default_configuration() const;
+
+    private:
+        // Full 4-level map: anode_name -> plane -> [binz][biny]
+        std::unordered_map<std::string,
+            std::unordered_map<int,
+                std::vector<std::vector<double>>>> m_map;
+
+        double m_bin_width{0};
+        double m_bin_height{0};
+        double m_yoffset{0};
+        double m_zoffset{0};
+        int m_nbinsy{0};
+        int m_nbinsz{0};
+    };
+
+}
+
+#endif

--- a/gen/src/DepoSetFilterYZ.cxx
+++ b/gen/src/DepoSetFilterYZ.cxx
@@ -2,7 +2,6 @@
 #include "WireCellUtil/NamedFactory.h"
 #include "WireCellAux/SimpleDepoSet.h"
 #include "WireCellIface/IDepo.h"
-#include "WireCellUtil/Persist.h"
 #include "WireCellIface/IAnodePlane.h"
 
 WIRECELL_FACTORY(DepoSetFilterYZ, WireCell::Gen::DepoSetFilterYZ, WireCell::INamed, WireCell::IDepoSetFilter,
@@ -20,69 +19,36 @@ DepoSetFilterYZ::~DepoSetFilterYZ() {}
 WireCell::Configuration DepoSetFilterYZ::default_configuration() const
 {
   Configuration cfg;
-  //../../util/src/Response.cxx
-
-  cfg["yzmap_filename"] = "YZMap_filename";
-  cfg["bin_width"]      = "BinWidth";
-  cfg["tpc_width"]      = "TPCWidth";
-  cfg["bin_height"]     = "BinHeight";
-  cfg["yoffset"]        = "YOffset";
-  cfg["zoffset"]        = "ZOffset";
-  cfg["nbinsy"]         = "NbinsY";
-  cfg["nbinsz"]         = "NbinsZ";
-  cfg["resp"]           = "Response";
-  cfg["anode"]          = "AnodePlane";
-  cfg["plane"]          = "WirePlane";
+  cfg["yzmap"]  = "";    // required: type:name of an IYZMap service
+  cfg["resp"]   = resp;
+  cfg["anode"]  = "";    // required: type:name of an IAnodePlane
+  cfg["plane"]  = plane;
   return cfg;
 }
 
 void DepoSetFilterYZ::configure(const WireCell::Configuration& cfg)
 {
-
-  //  log->debug("Conifg File Name");
-  const std::string filename = cfg["yzmap_filename"].asString();
-  if (filename.empty()) {
-    THROW(ValueError() << errmsg{"DepoSetFilterYZ requires an YZ region"});
+  const std::string yzmap_tn = cfg["yzmap"].asString();
+  if (yzmap_tn.empty()) {
+    THROW(ValueError() << errmsg{"DepoSetFilterYZ: yzmap service is required"});
   }
+  m_yzmap_svc = Factory::find_tn<IYZMap>(yzmap_tn);
 
-  //    log->debug("Conifg Anode TN");    
   const std::string anode_tn = cfg["anode"].asString();
   if (anode_tn.empty()) {
-    THROW(ValueError() << errmsg{"DepoSetFilterYZ requires an anode plane"});
+    THROW(ValueError() << errmsg{"DepoSetFilterYZ: anode is required"});
   }
-  //    log->debug("Config Andoe");
   WireCell::IAnodePlane::pointer anode = Factory::find_tn<IAnodePlane>(anode_tn);
   if (anode == nullptr) {
-    THROW(ValueError() << errmsg{"Input anode is a nullptr"});
+    THROW(ValueError() << errmsg{"DepoSetFilterYZ: anode is a nullptr"});
   }
-  //    log->debug("Conifg Andode Face");
-  IAnodeFace::vector abode_faces = anode->faces();
-  for (auto face : abode_faces) {
+  for (auto face : anode->faces()) {
     m_boxes.push_back(face->sensitive());
   }
-  //    log->debug("Rest...");
-  bin_width =  get<double>(cfg, "bin_width");
-  tpc_width =  get<double>(cfg, "tpc_width");
-  bin_height = get<double>(cfg, "bin_height");
-  yoffset =    get<double>(cfg, "yoffset");
-  zoffset =    get<double>(cfg, "zoffset");
-  nbinsy  =    get<int>   (cfg, "nbinsy");
-  nbinsz  =    get<int>   (cfg, "nbinsz");
-  resp =       get<int>   (cfg, "resp");
-  plane =      get<int>   (cfg, "plane");
-  anode_name = get<std::string>(cfg, "anode");
-  jmap = WireCell::Persist::load(filename);
 
-  yzmap.resize(nbinsz);
-  for(int binz = 0; binz < nbinsz; binz++){
-    yzmap[binz].resize(nbinsy);
-    for(int biny = 0; biny < nbinsy; biny++){
-      yzmap[binz][biny] = jmap[anode_name][std::to_string(plane)][binz][biny].asInt();
-    }
-  }
-
-  jmap.clear();
-
+  resp       = get<int>        (cfg, "resp",  resp);
+  plane      = get<int>        (cfg, "plane", plane);
+  anode_name = get<std::string>(cfg, "anode", anode_name);
 }
 
 bool DepoSetFilterYZ::operator()(const input_pointer& in, output_pointer& out)
@@ -108,28 +74,12 @@ bool DepoSetFilterYZ::operator()(const input_pointer& in, output_pointer& out)
     if(pass_anod == false){
       continue;}
 
-    double depo_y = idepo->pos().y()*units::mm;
-    double depo_z = idepo->pos().z()*units::mm;
-    //double yoffset = 180*units::cm;
-    //double zoffset = 900*units::cm;
+    double depo_y = idepo->pos().y();
+    double depo_z = idepo->pos().z();
 
-
-    int depo_bin_y = std::floor((depo_y+yoffset)/bin_height);
-    int depo_bin_z = std::floor((depo_z+zoffset)/bin_width);
-
-    if(depo_bin_y < 0)
-      depo_bin_y = 0;
-
-    if(depo_bin_z < 0)
-      depo_bin_z = 0;
-
-    if(depo_bin_y > nbinsy)
-      depo_bin_y = nbinsy;
-
-    if(depo_bin_z > nbinsz)
-      depo_bin_z = nbinsz;
-
-    if (yzmap[depo_bin_z][depo_bin_y] == resp+1) {pass_resp = true;}
+    if ((int)m_yzmap_svc->value(anode_name, plane, depo_y, depo_z) == resp+1) {
+      pass_resp = true;
+    }
 
     if (pass_resp && pass_anod) {
       //log->debug(" Passed! Resp {} at Y : {} and Z : {} on Plane {} and Anode {} ", resp+1, depo_y, depo_z, plane, anode_name);

--- a/gen/src/Scaler.cxx
+++ b/gen/src/Scaler.cxx
@@ -1,18 +1,10 @@
 #include "WireCellGen/Scaler.h"
 #include "WireCellUtil/NamedFactory.h"
 #include "WireCellUtil/Units.h"
-#include "WireCellUtil/String.h"
 
 #include "WireCellIface/IAnodePlane.h"
 #include "WireCellIface/IAnodeFace.h"
-#include "WireCellIface/IWirePlane.h"
 #include "WireCellAux/SimpleDepo.h"
-
-#include "WireCellUtil/Persist.h"
-
-#include <boost/range.hpp>
-
-#include <sstream>
 
 WIRECELL_FACTORY(Scaler, WireCell::Gen::Scaler,
                  WireCell::INamed,
@@ -24,16 +16,6 @@ using namespace WireCell;
 
 Gen::Scaler::Scaler()
   : Aux::Logger("Scaler", "gen")
-  , bin_width(0.0*units::cm)
-  , tpc_width(0.0*units::mm)
-  , bin_height(0.0*units::cm)
-  , n_ybin(31)
-  , n_zbin(180)
-  , yoffset(180*units::cm)// ymin is -180 in ICARUS
-  , zoffset(900*units::cm)// zmin is -900 in ICARUS
-  , plane(0)
-  , anode_name("Empty")
-  , yzmap_scale_filename("Empty")
 {
 }
 
@@ -42,17 +24,9 @@ Gen::Scaler::~Scaler() {}
 WireCell::Configuration Gen::Scaler::default_configuration() const
 {
   Configuration cfg;
-
-  cfg["yzmap_scale_filename"] = yzmap_scale_filename;
-  cfg["bin_width"]      = bin_width;
-  cfg["tpc_width"]      = tpc_width;
-  cfg["bin_height"]     = bin_height;
-  cfg["n_ybin"]     = n_ybin;
-  cfg["n_zbin"]     = n_zbin;
-  cfg["yoffset"]     = yoffset;
-  cfg["zoffset"]     = zoffset;
-  cfg["anode"]          = anode_name;
-  cfg["plane"]          = plane;
+  cfg["yzmap"] = "";    // required: type:name of an IYZMap service
+  cfg["anode"] = "";    // required: type:name of an IAnodePlane
+  cfg["plane"] = plane;
   return cfg;
 }
 
@@ -60,47 +34,26 @@ void Gen::Scaler::configure(const WireCell::Configuration& cfg)
 {
   reset();
 
-  const std::string filename = cfg["yzmap_scale_filename"].asString();
-  if (filename.empty()) {
-    THROW(ValueError() << errmsg{"Scaler requires an YZ region"});
+  const std::string yzmap_tn = cfg["yzmap"].asString();
+  if (yzmap_tn.empty()) {
+    THROW(ValueError() << errmsg{"Scaler: yzmap service is required"});
   }
+  m_yzmap_svc = Factory::find_tn<IYZMap>(yzmap_tn);
 
-  //    log->debug("Conifg Anode TN");    
   const std::string anode_tn = cfg["anode"].asString();
   if (anode_tn.empty()) {
-    THROW(ValueError() << errmsg{"Scaler requires an anode plane"});
+    THROW(ValueError() << errmsg{"Scaler: anode is required"});
   }
-  //    log->debug("Config Andoe");
   WireCell::IAnodePlane::pointer anode = Factory::find_tn<IAnodePlane>(anode_tn);
   if (anode == nullptr) {
-    THROW(ValueError() << errmsg{"Input anode is a nullptr"});
+    THROW(ValueError() << errmsg{"Scaler: anode is a nullptr"});
   }
-  //    log->debug("Conifg Andode Face");
-  IAnodeFace::vector abode_faces = anode->faces();
-  for (auto face : abode_faces) {
+  for (auto face : anode->faces()) {
     m_boxes.push_back(face->sensitive());
   }
-  //    log->debug("Rest...");
-  bin_width =  get<double>(cfg, "bin_width", bin_width);
-  tpc_width =  get<double>(cfg, "tpc_width", tpc_width);
-  bin_height = get<double>(cfg, "bin_height", bin_height);
-  plane =      get<int>   (cfg, "plane", plane);
 
+  plane      = get<int>        (cfg, "plane", plane);
   anode_name = get<std::string>(cfg, "anode", anode_name);
-
-  jmap = WireCell::Persist::load(filename);
-
-  yzmap.resize(n_zbin);
-  for(int binz = 0; binz < n_zbin; binz++){
-    yzmap[binz].resize(n_ybin);
-    for(int biny = 0; biny < n_ybin; biny++){
-      yzmap[binz][biny] = jmap[anode_name][std::to_string(plane)][binz][biny].asDouble();
-    }
-  }
-
-  jmap.clear();
-
-
 }
 
 void Gen::Scaler::reset() { }
@@ -128,26 +81,7 @@ bool Gen::Scaler::operator()(const input_pointer& depo, output_queue& outq)
   double depo_y = depo->pos().y();
   double depo_z = depo->pos().z();
 
-  int depo_bin_y = std::floor((depo_y+yoffset)/bin_height);
-  int depo_bin_z = std::floor((depo_z+zoffset)/bin_width);
-
-  if(depo_bin_y < 0){
-    depo_bin_y = 0;
-  }
-
-  if(depo_bin_z < 0){
-    depo_bin_z = 0;
-  }
-
-  if(depo_bin_y > n_ybin){
-    depo_bin_y = n_ybin;
-  }
-
-  if(depo_bin_z > n_zbin){
-    depo_bin_z = n_zbin;
-  }
-
-  double scale = yzmap[depo_bin_z][depo_bin_y];
+  double scale = m_yzmap_svc->value(anode_name, plane, depo_y, depo_z);
 
   auto newdepo = make_shared<Aux::SimpleDepo>(depo->time(), depo->pos(), Qi*scale, depo->prior(), depo->extent_long(), depo->extent_tran(), depo->prior()->id(), depo->prior()->pdg(), depo->prior()->energy());
 

--- a/gen/src/YZMap.cxx
+++ b/gen/src/YZMap.cxx
@@ -1,0 +1,96 @@
+#include "WireCellGen/YZMap.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/Persist.h"
+#include "WireCellUtil/Exceptions.h"
+
+#include <algorithm>
+#include <cmath>
+
+WIRECELL_FACTORY(YZMap, WireCell::Gen::YZMap,
+                 WireCell::INamed,
+                 WireCell::IYZMap, WireCell::IConfigurable)
+
+using namespace WireCell;
+
+Gen::YZMap::YZMap()
+    : Aux::Logger("YZMap", "gen")
+{
+}
+
+Gen::YZMap::~YZMap() {}
+
+WireCell::Configuration Gen::YZMap::default_configuration() const
+{
+    Configuration cfg;
+    cfg["filename"]   = "";
+    cfg["bin_width"]  = m_bin_width;
+    cfg["bin_height"] = m_bin_height;
+    cfg["yoffset"]    = m_yoffset;
+    cfg["zoffset"]    = m_zoffset;
+    cfg["nbinsy"]     = m_nbinsy;
+    cfg["nbinsz"]     = m_nbinsz;
+    return cfg;
+}
+
+void Gen::YZMap::configure(const WireCell::Configuration& cfg)
+{
+    const std::string filename = cfg["filename"].asString();
+    if (filename.empty()) {
+        THROW(ValueError() << errmsg{"YZMap: filename is required"});
+    }
+
+    m_bin_width  = get<double>(cfg, "bin_width",  m_bin_width);
+    m_bin_height = get<double>(cfg, "bin_height", m_bin_height);
+    m_yoffset    = get<double>(cfg, "yoffset",    m_yoffset);
+    m_zoffset    = get<double>(cfg, "zoffset",    m_zoffset);
+    m_nbinsy     = get<int>   (cfg, "nbinsy",     m_nbinsy);
+    m_nbinsz     = get<int>   (cfg, "nbinsz",     m_nbinsz);
+
+    auto jmap = Persist::load(filename);
+
+    m_map.clear();
+    for (const auto& anode_name : jmap.getMemberNames()) {
+        auto& plane_map = m_map[anode_name];
+        const auto& jplanes = jmap[anode_name];
+        for (const auto& plane_str : jplanes.getMemberNames()) {
+            int plane = std::stoi(plane_str);
+            auto& grid = plane_map[plane];
+            const auto& jgrid = jplanes[plane_str];
+            const int nbinsz = jgrid.size();
+            grid.resize(nbinsz);
+            for (int binz = 0; binz < nbinsz; ++binz) {
+                const auto& jrow = jgrid[binz];
+                const int nbinsy = jrow.size();
+                grid[binz].resize(nbinsy);
+                for (int biny = 0; biny < nbinsy; ++biny) {
+                    grid[binz][biny] = jrow[biny].asDouble();
+                }
+            }
+        }
+    }
+
+    log->debug("loaded {} anodes from {}", m_map.size(), filename);
+}
+
+double Gen::YZMap::value(const std::string& anode_name,
+                         int plane,
+                         double y, double z) const
+{
+    auto ait = m_map.find(anode_name);
+    if (ait == m_map.end()) {
+        return 0.0;
+    }
+    auto pit = ait->second.find(plane);
+    if (pit == ait->second.end()) {
+        return 0.0;
+    }
+    const auto& grid = pit->second;
+
+    int biny = (int)std::floor((y + m_yoffset) / m_bin_height);
+    int binz = (int)std::floor((z + m_zoffset) / m_bin_width);
+
+    biny = std::clamp(biny, 0, m_nbinsy);
+    binz = std::clamp(binz, 0, m_nbinsz);
+
+    return grid[binz][biny];
+}

--- a/iface/inc/WireCellIface/IYZMap.h
+++ b/iface/inc/WireCellIface/IYZMap.h
@@ -1,0 +1,22 @@
+#ifndef WIRECELL_IFACE_IYZMAP
+#define WIRECELL_IFACE_IYZMAP
+
+#include "WireCellUtil/IComponent.h"
+
+#include <string>
+
+namespace WireCell {
+    class IYZMap : public IComponent<IYZMap> {
+    public:
+        virtual ~IYZMap();
+
+        // Return map value for the given anode, plane, and detector (y, z)
+        // coordinates in WireCell units.  Handles binning and boundary
+        // clamping internally.
+        virtual double value(const std::string& anode_name,
+                             int plane,
+                             double y, double z) const = 0;
+    };
+}
+
+#endif

--- a/iface/src/IfaceDesctructors.cxx
+++ b/iface/src/IfaceDesctructors.cxx
@@ -110,6 +110,7 @@
 #include "WireCellIface/IWireSource.h"
 #include "WireCellIface/IWireSummarizer.h"
 #include "WireCellIface/IWireSummary.h"
+#include "WireCellIface/IYZMap.h"
 
 using namespace WireCell;
 
@@ -215,4 +216,5 @@ IWireSchema::~IWireSchema() {}
 IWireSource::~IWireSource() {}
 IWireSummarizer::~IWireSummarizer() {}
 IWireSummary::~IWireSummary() {}
+IYZMap::~IYZMap() {}
 


### PR DESCRIPTION
…instances

Introduce IYZMap interface and YZMap implementation that loads the full 4-level JSON map (anode, plane, binz, biny) once.  DepoSetFilterYZ and Scaler now hold an IYZMap::pointer and delegate all binning/clamping to the service via value(anode_name, plane, y, z).  ICARUS Jsonnet configs define one shared YZMap per JSON file instead of per-instance parameters.