### PR TITLE
Re-enable RMS-noise-based filtering in ProtoduneHD

### DIFF
--- a/sigproc/src/ProtoduneHD.cxx
+++ b/sigproc/src/ProtoduneHD.cxx
@@ -853,18 +853,18 @@ WireCell::Waveform::ChannelMaskMap PDHD::OneChannelNoise::apply(int ch, signal_t
         PDHD::RemoveFilterFlags(signal);
     }
 
-    // const float min_rms = m_noisedb->min_rms_cut(ch);
-    // const float max_rms = m_noisedb->max_rms_cut(ch);
-    // // alternative RMS tagging
-    // PDHD::SignalFilter(signal);
-    // bool is_noisy = PDHD::NoisyFilterAlg(signal, min_rms, max_rms);
-    // PDHD::RemoveFilterFlags(signal);
-    // if (is_noisy) {
-    //     WireCell::Waveform::BinRange temp_bin_range;
-    //     temp_bin_range.first = 0;
-    //     temp_bin_range.second = signal.size();
-    //     ret["noisy"][ch].push_back(temp_bin_range);
-    // }
+    const float min_rms = m_noisedb->min_rms_cut(ch);
+    const float max_rms = m_noisedb->max_rms_cut(ch);
+    // alternative RMS tagging
+    PDHD::SignalFilter(signal);
+    bool is_noisy = PDHD::NoisyFilterAlg(signal, min_rms, max_rms);
+    PDHD::RemoveFilterFlags(signal);
+    if (is_noisy) {
+        WireCell::Waveform::BinRange temp_bin_range;
+        temp_bin_range.first = 0;
+        temp_bin_range.second = signal.size();
+        ret["noisy"][ch].push_back(temp_bin_range);
+    }
 
     return ret;
 }


### PR DESCRIPTION
The RMS-noise-based filtering logic in ProtoduneHD is currently commented out.

When channels have large RMS noise, the DNN ROI can incorrectly identify noise fluctuations as signal.

This PR re-enables the existing RMS-noise-based filtering logic in ProtoduneHD.cxx to help reduce such false positive ROI responses in high-noise channels.

Key changes:
Restore the commented RMS-noise-based filtering logic in sigproc/src/ProtoduneHD.cxx