### PR TITLE
YZmap update: jsonnet loading optimization

### DIFF
--- a/apps/src/Main.cxx
+++ b/apps/src/Main.cxx
@@ -271,7 +271,7 @@ void Main::initialize()
         log->debug("p.load({}) returned: top-level type={} size={}",
                    filename, (int)one.type(), one.size());
         //log->debug(one.toStyledString());
-        m_cfgmgr.extend(one);
+        m_cfgmgr.extend(std::move(one));  // move avoids the ~tree-size deep-copy
         log->debug("config file {} merged into cfgmgr", filename);
     }
     log->debug("all config files loaded ({} total)", m_cfgfiles.size());

--- a/apps/src/Main.cxx
+++ b/apps/src/Main.cxx
@@ -256,17 +256,25 @@ void Main::initialize()
     // backends the same.
     Log::set_pattern("[%H:%M:%S.%03e] %L [%^%=8n%$] %v");
     log = Log::logger("main");
-    log->set_pattern("[%H:%M:%S.%03e] %L [  main  ] %v");
+    Log::set_level("debug", "main");
+    Log::set_pattern("[%H:%M:%S.%03e] %L [  main  ] %v", "main");
     log->debug("logging to \"main\"");
 
     // Load configuration files
     for (auto filename : m_cfgfiles) {
-        log->debug("loading config file {}", filename);
+        log->debug("loading config file {}: extvars={} extcode={} tlavars={} tlacode={} load_paths={}",
+                   filename, m_extvars.size(), m_extcode.size(),
+                   m_tlavars.size(), m_tlacode.size(), m_load_path.size());
         Persist::Parser p(m_load_path, m_extvars, m_extcode, m_tlavars, m_tlacode);
+        log->debug("parser ready, calling p.load({})", filename);
         Json::Value one = p.load(filename);  // throws
+        log->debug("p.load({}) returned: top-level type={} size={}",
+                   filename, (int)one.type(), one.size());
         //log->debug(one.toStyledString());
         m_cfgmgr.extend(one);
+        log->debug("config file {} merged into cfgmgr", filename);
     }
+    log->debug("all config files loaded ({} total)", m_cfgfiles.size());
 
     // Find if we have our own special configuration entry
     int ind = m_cfgmgr.index("wire-cell");
@@ -356,6 +364,7 @@ void Main::initialize()
         Configuration cfg = cfgobj->default_configuration();
         cfg = update(cfg, c["data"]);
         cfgobj->configure(cfg);  // throws
+        log->debug("configured component:  \"{}\":\"{}\"", type, name);
     }
 }
 

--- a/apps/src/Main.cxx
+++ b/apps/src/Main.cxx
@@ -373,6 +373,12 @@ void Main::initialize()
         }
         log->debug("configured component:  \"{}\":\"{}\"", type, name);
     }
+
+    // All components are now configured.  Drop the bulk "data" sub-trees
+    // from the cfgmgr (finalize() only needs type/name) so the multi-GB
+    // resident Json::Value tree is released before event processing begins.
+    m_cfgmgr.clear_data();
+    log->debug("released config data sub-trees from cfgmgr");
 }
 
 void Main::operator()()

--- a/apps/src/Main.cxx
+++ b/apps/src/Main.cxx
@@ -256,7 +256,7 @@ void Main::initialize()
     // backends the same.
     Log::set_pattern("[%H:%M:%S.%03e] %L [%^%=8n%$] %v");
     log = Log::logger("main");
-    Log::set_level("debug", "main");
+    // Log::set_level("debug", "main");
     Log::set_pattern("[%H:%M:%S.%03e] %L [  main  ] %v", "main");
     log->debug("logging to \"main\"");
 

--- a/apps/src/Main.cxx
+++ b/apps/src/Main.cxx
@@ -296,7 +296,7 @@ void Main::initialize()
 
     // Load any plugin shared libraries requested by user.
     PluginManager& pm = PluginManager::instance();
-    for (auto plugin : m_plugins) {
+    for (const auto& plugin : m_plugins) {
         string pname, lname;
         std::tie(pname, lname) = String::parse_pair(plugin);
         log->debug("adding plugin: \"{}\"", plugin);
@@ -309,7 +309,7 @@ void Main::initialize()
     // Apply any component configuration sequence.
 
     // Instantiation
-    for (auto c : m_cfgmgr.all()) {
+    for (const auto& c : m_cfgmgr.all()) {
         if (c.isNull()) {
             continue;  // allow and ignore any totally empty configurations
         }
@@ -322,13 +322,13 @@ void Main::initialize()
         log->debug("constructing component: \"{}\":\"{}\"", type, name);
         auto iface = Factory::lookup<Interface>(type, name);  // throws
     }
-    for (auto c : m_apps) {
+    for (const auto& c : m_apps) {
         log->debug("constructing app: \"{}\"", c);
         Factory::lookup_tn<IApplication>(c);
     }
 
     // Give any named components their name.
-    for (auto c : m_cfgmgr.all()) {
+    for (const auto& c : m_cfgmgr.all()) {
         if (c.isNull()) {
             continue;  // allow and ignore any totally empty configurations
         }
@@ -347,7 +347,7 @@ void Main::initialize()
 
     // Finally, ask any configurables for their default, merge with
     // user config and give back.
-    for (auto c : m_cfgmgr.all()) {
+    for (const auto& c : m_cfgmgr.all()) {
         if (c.isNull()) {
             continue;  // allow and ignore any totally empty configurations
         }
@@ -362,8 +362,15 @@ void Main::initialize()
         // Get component's hard-coded default config, update it with
         // anything the user may have provided and apply it.
         Configuration cfg = cfgobj->default_configuration();
-        cfg = update(cfg, c["data"]);
-        cfgobj->configure(cfg);  // throws
+        if (cfg.isNull()) {
+            // Component has no defaults — skip the merge and pass user config directly.
+            cfgobj->configure(c["data"]);  // throws
+        }
+        else {
+            Configuration user_data = c["data"];  // update() needs a non-const ref
+            update(cfg, user_data);
+            cfgobj->configure(cfg);  // throws
+        }
         log->debug("configured component:  \"{}\":\"{}\"", type, name);
     }
 }
@@ -372,7 +379,7 @@ void Main::operator()()
 {
     // Find all IApplications to execute
     vector<IApplication::pointer> app_objs;
-    for (auto component : m_apps) {
+    for (const auto& component : m_apps) {
         string type, name;
         std::tie(type, name) = String::parse_pair(component);
         auto a = Factory::find<IApplication>(type, name);  // throws
@@ -405,7 +412,7 @@ void Main::operator()()
 
 void Main::finalize()
 {
-    for (auto c : m_cfgmgr.all()) {
+    for (const auto& c : m_cfgmgr.all()) {
         if (c.isNull()) {
             continue;  // allow and ignore any totally empty configurations
         }

--- a/cfg/pgrapher/experiment/icarus/detsim-yz-per-tpc-v10_20_03.fcl
+++ b/cfg/pgrapher/experiment/icarus/detsim-yz-per-tpc-v10_20_03.fcl
@@ -1,0 +1,3576 @@
+# Produced from 'fhicl-dump' using:
+#   Input  : detsim_2d_icarus_refactored_yzsim.fcl
+#   Policy : cet::filepath_maker
+#   Path   : "FHICL_FILE_PATH"
+
+outputs: {
+   rootoutput: {
+      compressionLevel: 1
+      dataTier: "simulated"
+      fileName: "%ifb_%tc-%p.root"
+      module_type: "RootOutput"
+      outputCommands: [
+         "keep *",
+         "drop *_ionization_*_*",
+         "drop *_simdrift_*_*",
+         "drop *_pdfastsim_*_*",
+         "drop raw::OpDetWaveform*_opdaq_*_*",
+         "drop sim::SimEnergyDeposits_largeant_*_*",
+         "drop sim::SimEnergyDepositLites_sedlite_*_*",
+         "drop sim::SimEnergyDeposits_shifted_*_*",
+         "drop sim::SimEnergyDepositLites_shifted_*_*",
+         "drop sim::SimChannels_daq_*_*"
+      ]
+      saveMemoryObjectThreshold: 0
+   }
+}
+physics: {
+   producers: {
+      crtdaq: {
+         DetSimAlg: {
+            ApplyCoincidenceC: true
+            ApplyCoincidenceD: true
+            ApplyCoincidenceM: true
+            ApplyStripCoincidenceC: true
+            BiasTime: 50
+            DeadTime: 22000
+            GlobalT0Offset: 1.6e6
+            Kbirks: 1.26e1
+            LayerCoincidenceWindowC: 30
+            LayerCoincidenceWindowD: 30
+            LayerCoincidenceWindowM: 50
+            PropDelay: 5.23e-2
+            PropDelayError: 7e-3
+            Q0: 1.891e-3
+            QMax: 4080
+            QPed: 6.36e1
+            QRMS: 10
+            QSlope: 70
+            QThresholdC: 169
+            QThresholdD: 169
+            QThresholdM: 379
+            StripCoincidenceWindow: 50
+            TDelayNorm: 4.12574e3
+            TDelayOffset: -1.525
+            TDelayRMSExpNorm: 1.6544
+            TDelayRMSExpScale: 7.93543e1
+            TDelayRMSExpShift: 7.56183e1
+            TDelayRMSGausNorm: 2.09138
+            TDelayRMSGausShift: 7.23993
+            TDelayRMSGausSigma: 1.70027e2
+            TDelayShift: -3.0031e2
+            TDelaySigma: 9.0392e1
+            TResInterpolator: 1.268
+            UltraVerbose: false
+            UseBirks: true
+            UseEdep: true
+            Verbose: false
+         }
+         G4ModuleLabel: "shifted"
+         module_type: "icaruscode/CRT/CRTDetSim"
+      }
+      daq0: {
+         module_type: "WireCellToolkit"
+         wcls_main: {
+            apps: [
+               "Pgrapher:pgrapher0"
+            ]
+            configs: [
+               "wcls-per-tpc-sim-drift-simchannel-yzsim.jsonnet"
+            ]
+            logsinks: ["stdout"]
+            loglevels: ["debug"]
+            inputers: [
+               "wclsSimDepoSetSource:electron"
+            ]
+            outputers: [
+               "wclsDepoFluxWriter:postdrift0",
+               "wclsDepoFluxWriter:postdrift1",
+               "wclsDepoFluxWriter:postdrift2",
+               "wclsDepoFluxWriter:postdrift3",
+               "wclsDepoFluxWriter:postdrift4",
+               "wclsDepoFluxWriter:postdrift5",
+               "wclsDepoFluxWriter:postdrift6",
+               "wclsDepoFluxWriter:postdrift7",
+               "wclsDepoFluxWriter:postdrift8",
+               "wclsDepoFluxWriter:postdrift9",
+               "wclsDepoFluxWriter:postdrift10",
+               "wclsDepoFluxWriter:postdrift11",
+               "wclsDepoFluxWriter:postdrift12",
+               "wclsDepoFluxWriter:postdrift13",
+               "wclsDepoFluxWriter:postdrift14",
+               "wclsDepoFluxWriter:postdrift15",
+               "wclsDepoFluxWriter:postdrift16",
+               "wclsDepoFluxWriter:postdrift17",
+               "wclsDepoFluxWriter:postdrift18",
+               "wclsDepoFluxWriter:postdrift19",
+               "wclsDepoFluxWriter:postdrift20",
+               "wclsDepoFluxWriter:postdrift21",
+               "wclsDepoFluxWriter:postdrift22",
+               "wclsDepoFluxWriter:postdrift23",
+               "wclsDepoFluxWriter:postdrift24",
+               "wclsDepoFluxWriter:postdrift25",
+               "wclsDepoFluxWriter:postdrift26",
+               "wclsDepoFluxWriter:postdrift27",
+               "wclsDepoFluxWriter:postdrift28",
+               "wclsDepoFluxWriter:postdrift29",
+               "wclsDepoFluxWriter:postdrift30",
+               "wclsDepoFluxWriter:postdrift31",
+               "wclsDepoFluxWriter:postdrift32",
+               "wclsDepoFluxWriter:postdrift33",
+               "wclsDepoFluxWriter:postdrift34",
+               "wclsDepoFluxWriter:postdrift35",
+               "wclsDepoFluxWriter:postdrift36",
+               "wclsDepoFluxWriter:postdrift37",
+               "wclsDepoFluxWriter:postdrift38",
+               "wclsDepoFluxWriter:postdrift39",
+               "wclsDepoFluxWriter:postdrift40",
+               "wclsDepoFluxWriter:postdrift41",
+               "wclsDepoFluxWriter:postdrift42",
+               "wclsDepoFluxWriter:postdrift43",
+               "wclsDepoFluxWriter:postdrift44",
+               "wclsDepoFluxWriter:postdrift45",
+               "wclsDepoFluxWriter:postdrift46",
+               "wclsDepoFluxWriter:postdrift47",
+               "wclsDepoFluxWriter:postdrift48",
+               "wclsDepoFluxWriter:postdrift49",
+               "wclsDepoFluxWriter:postdrift50",
+               "wclsDepoFluxWriter:postdrift51",
+               "wclsDepoFluxWriter:postdrift52",
+               "wclsDepoFluxWriter:postdrift53",
+               "wclsDepoFluxWriter:postdrift54",
+               "wclsDepoFluxWriter:postdrift55",
+               "wclsDepoFluxWriter:postdrift56",
+               "wclsDepoFluxWriter:postdrift57",
+               "wclsDepoFluxWriter:postdrift58",
+               "wclsDepoFluxWriter:postdrift59",
+               "wclsDepoFluxWriter:postdrift60",
+               "wclsDepoFluxWriter:postdrift61",
+               "wclsDepoFluxWriter:postdrift62",
+               "wclsDepoFluxWriter:postdrift63",
+               "wclsDepoFluxWriter:postdrift64",
+               "wclsDepoFluxWriter:postdrift65",
+               "wclsDepoFluxWriter:postdrift66",
+               "wclsDepoFluxWriter:postdrift67",
+               "wclsDepoFluxWriter:postdrift68",
+               "wclsDepoFluxWriter:postdrift69",
+               "wclsDepoFluxWriter:postdrift70",
+               "wclsDepoFluxWriter:postdrift71",
+               "wclsDepoFluxWriter:postdrift72",
+               "wclsDepoFluxWriter:postdrift73",
+               "wclsDepoFluxWriter:postdrift74",
+               "wclsDepoFluxWriter:postdrift75",
+               "wclsDepoFluxWriter:postdrift76",
+               "wclsDepoFluxWriter:postdrift77",
+               "wclsDepoFluxWriter:postdrift78",
+               "wclsDepoFluxWriter:postdrift79",
+               "wclsDepoFluxWriter:postdrift80",
+               "wclsDepoFluxWriter:postdrift81",
+               "wclsDepoFluxWriter:postdrift82",
+               "wclsDepoFluxWriter:postdrift83",
+               "wclsDepoFluxWriter:postdrift84",
+               "wclsDepoFluxWriter:postdrift85",
+               "wclsDepoFluxWriter:postdrift86",
+               "wclsDepoFluxWriter:postdrift87",
+               "wclsDepoFluxWriter:postdrift88",
+               "wclsDepoFluxWriter:postdrift89",
+               "wclsFrameSaver:simdigits0"
+            ]
+            params: {
+               SimEnergyDepositLabel: "filtersed"
+               cathode_input_format: "array"
+               file_rcresp: "icarus_fnal_rc_tail.json"
+               tpc_idx: "0"
+               files_fields: "\"icarus_final_fit_dqdx0.json.bz2\",\n                           \"icarus_final_fit_dqdx1.json.bz2\",\n                           \"icarus_final_fit_dqdx2.json.bz2\",\n                           \"icarus_final_fit_dqdx3.json.bz2\",\n                           \"icarus_final_fit_dqdx4.json.bz2\",\n                           \"icarus_final_fit_dqdx5.json.bz2\",\n                           \"icarus_final_fit_dqdx6.json.bz2\",\n                           \"icarus_final_fit_dqdx7.json.bz2\",\n                           \"icarus_final_fit_dqdx8.json.bz2\",\n                           \"icarus_final_fit_dqdx9.json.bz2\",\n                           \"icarus_final_fit_dqdx10.json.bz2\",\n                           \"icarus_final_fit_dqdx11.json.bz2\",\n                           \"icarus_final_fit_dqdx12.json.bz2\",\n                           \"icarus_final_fit_dqdx13.json.bz2\",\n                           \"icarus_final_fit_dqdx14.json.bz2\""
+            }
+            plugins: [
+               "WireCellPgraph",
+               "WireCellGen",
+               "WireCellSio",
+               "WireCellRoot",
+               "WireCellLarsoft",
+               "WireCellHio"
+            ]
+            structs: {
+               DL: 4e-9
+               DT: 8.8e-9
+               coh_noise_scale: 1
+               gain0: 1.705212e1
+               gain1: 1.26181926e1
+               gain2: 1.30261362e1
+               int_noise_scale: 1
+               lifetime: 3000
+               lifetime_TPCEE: 3000
+               lifetime_TPCEW: 3000
+               lifetime_TPCWE: 3000
+               lifetime_TPCWW: 3000
+               overlay_drifter: false
+               shaping0: 1.3
+               shaping1: 1.45
+               shaping2: 1.3
+               time_offset_u: 0
+               time_offset_v: 0
+               time_offset_y: 0
+            }
+            tool_type: "WCLS"
+         }
+      }
+      daq1: {
+         module_type: "WireCellToolkit"
+         wcls_main: {
+            apps: [
+               "Pgrapher:pgrapher1"
+            ]
+            configs: [
+               "wcls-per-tpc-sim-drift-simchannel-yzsim.jsonnet"
+            ]
+            logsinks: ["stdout"]
+            loglevels: ["debug"]
+            inputers: [
+               "wclsSimDepoSetSource:electron"
+            ]
+            outputers: [
+               "wclsDepoFluxWriter:postdrift90",
+               "wclsDepoFluxWriter:postdrift91",
+               "wclsDepoFluxWriter:postdrift92",
+               "wclsDepoFluxWriter:postdrift93",
+               "wclsDepoFluxWriter:postdrift94",
+               "wclsDepoFluxWriter:postdrift95",
+               "wclsDepoFluxWriter:postdrift96",
+               "wclsDepoFluxWriter:postdrift97",
+               "wclsDepoFluxWriter:postdrift98",
+               "wclsDepoFluxWriter:postdrift99",
+               "wclsDepoFluxWriter:postdrift100",
+               "wclsDepoFluxWriter:postdrift101",
+               "wclsDepoFluxWriter:postdrift102",
+               "wclsDepoFluxWriter:postdrift103",
+               "wclsDepoFluxWriter:postdrift104",
+               "wclsDepoFluxWriter:postdrift105",
+               "wclsDepoFluxWriter:postdrift106",
+               "wclsDepoFluxWriter:postdrift107",
+               "wclsDepoFluxWriter:postdrift108",
+               "wclsDepoFluxWriter:postdrift109",
+               "wclsDepoFluxWriter:postdrift110",
+               "wclsDepoFluxWriter:postdrift111",
+               "wclsDepoFluxWriter:postdrift112",
+               "wclsDepoFluxWriter:postdrift113",
+               "wclsDepoFluxWriter:postdrift114",
+               "wclsDepoFluxWriter:postdrift115",
+               "wclsDepoFluxWriter:postdrift116",
+               "wclsDepoFluxWriter:postdrift117",
+               "wclsDepoFluxWriter:postdrift118",
+               "wclsDepoFluxWriter:postdrift119",
+               "wclsDepoFluxWriter:postdrift120",
+               "wclsDepoFluxWriter:postdrift121",
+               "wclsDepoFluxWriter:postdrift122",
+               "wclsDepoFluxWriter:postdrift123",
+               "wclsDepoFluxWriter:postdrift124",
+               "wclsDepoFluxWriter:postdrift125",
+               "wclsDepoFluxWriter:postdrift126",
+               "wclsDepoFluxWriter:postdrift127",
+               "wclsDepoFluxWriter:postdrift128",
+               "wclsDepoFluxWriter:postdrift129",
+               "wclsDepoFluxWriter:postdrift130",
+               "wclsDepoFluxWriter:postdrift131",
+               "wclsDepoFluxWriter:postdrift132",
+               "wclsDepoFluxWriter:postdrift133",
+               "wclsDepoFluxWriter:postdrift134",
+               "wclsDepoFluxWriter:postdrift135",
+               "wclsDepoFluxWriter:postdrift136",
+               "wclsDepoFluxWriter:postdrift137",
+               "wclsDepoFluxWriter:postdrift138",
+               "wclsDepoFluxWriter:postdrift139",
+               "wclsDepoFluxWriter:postdrift140",
+               "wclsDepoFluxWriter:postdrift141",
+               "wclsDepoFluxWriter:postdrift142",
+               "wclsDepoFluxWriter:postdrift143",
+               "wclsDepoFluxWriter:postdrift144",
+               "wclsDepoFluxWriter:postdrift145",
+               "wclsDepoFluxWriter:postdrift146",
+               "wclsDepoFluxWriter:postdrift147",
+               "wclsDepoFluxWriter:postdrift148",
+               "wclsDepoFluxWriter:postdrift149",
+               "wclsDepoFluxWriter:postdrift150",
+               "wclsDepoFluxWriter:postdrift151",
+               "wclsDepoFluxWriter:postdrift152",
+               "wclsDepoFluxWriter:postdrift153",
+               "wclsDepoFluxWriter:postdrift154",
+               "wclsDepoFluxWriter:postdrift155",
+               "wclsDepoFluxWriter:postdrift156",
+               "wclsDepoFluxWriter:postdrift157",
+               "wclsDepoFluxWriter:postdrift158",
+               "wclsDepoFluxWriter:postdrift159",
+               "wclsDepoFluxWriter:postdrift160",
+               "wclsDepoFluxWriter:postdrift161",
+               "wclsDepoFluxWriter:postdrift162",
+               "wclsDepoFluxWriter:postdrift163",
+               "wclsDepoFluxWriter:postdrift164",
+               "wclsDepoFluxWriter:postdrift165",
+               "wclsDepoFluxWriter:postdrift166",
+               "wclsDepoFluxWriter:postdrift167",
+               "wclsDepoFluxWriter:postdrift168",
+               "wclsDepoFluxWriter:postdrift169",
+               "wclsDepoFluxWriter:postdrift170",
+               "wclsDepoFluxWriter:postdrift171",
+               "wclsDepoFluxWriter:postdrift172",
+               "wclsDepoFluxWriter:postdrift173",
+               "wclsDepoFluxWriter:postdrift174",
+               "wclsDepoFluxWriter:postdrift175",
+               "wclsDepoFluxWriter:postdrift176",
+               "wclsDepoFluxWriter:postdrift177",
+               "wclsDepoFluxWriter:postdrift178",
+               "wclsDepoFluxWriter:postdrift179",
+               "wclsFrameSaver:simdigits1"
+            ]
+            params: {
+               SimEnergyDepositLabel: "filtersed"
+               cathode_input_format: "array"
+               file_rcresp: "icarus_fnal_rc_tail.json"
+               tpc_idx: "1"
+               files_fields: "\"icarus_final_fit_dqdx0.json.bz2\",\n                           \"icarus_final_fit_dqdx1.json.bz2\",\n                           \"icarus_final_fit_dqdx2.json.bz2\",\n                           \"icarus_final_fit_dqdx3.json.bz2\",\n                           \"icarus_final_fit_dqdx4.json.bz2\",\n                           \"icarus_final_fit_dqdx5.json.bz2\",\n                           \"icarus_final_fit_dqdx6.json.bz2\",\n                           \"icarus_final_fit_dqdx7.json.bz2\",\n                           \"icarus_final_fit_dqdx8.json.bz2\",\n                           \"icarus_final_fit_dqdx9.json.bz2\",\n                           \"icarus_final_fit_dqdx10.json.bz2\",\n                           \"icarus_final_fit_dqdx11.json.bz2\",\n                           \"icarus_final_fit_dqdx12.json.bz2\",\n                           \"icarus_final_fit_dqdx13.json.bz2\",\n                           \"icarus_final_fit_dqdx14.json.bz2\""
+            }
+            plugins: [
+               "WireCellPgraph",
+               "WireCellGen",
+               "WireCellSio",
+               "WireCellRoot",
+               "WireCellLarsoft",
+               "WireCellHio"
+            ]
+            structs: {
+               DL: 4e-9
+               DT: 8.8e-9
+               coh_noise_scale: 1
+               gain0: 1.705212e1
+               gain1: 1.26181926e1
+               gain2: 1.30261362e1
+               int_noise_scale: 1
+               lifetime: 3000
+               lifetime_TPCEE: 3000
+               lifetime_TPCEW: 3000
+               lifetime_TPCWE: 3000
+               lifetime_TPCWW: 3000
+               overlay_drifter: false
+               shaping0: 1.3
+               shaping1: 1.45
+               shaping2: 1.3
+               time_offset_u: 0
+               time_offset_v: 0
+               time_offset_y: 0
+            }
+            tool_type: "WCLS"
+         }
+      }
+      daq2: {
+         module_type: "WireCellToolkit"
+         wcls_main: {
+            apps: [
+               "Pgrapher:pgrapher2"
+            ]
+            configs: [
+               "wcls-per-tpc-sim-drift-simchannel-yzsim.jsonnet"
+            ]
+            logsinks: ["stdout"]
+            loglevels: ["debug"]
+            inputers: [
+               "wclsSimDepoSetSource:electron"
+            ]
+            outputers: [
+               "wclsDepoFluxWriter:postdrift180",
+               "wclsDepoFluxWriter:postdrift181",
+               "wclsDepoFluxWriter:postdrift182",
+               "wclsDepoFluxWriter:postdrift183",
+               "wclsDepoFluxWriter:postdrift184",
+               "wclsDepoFluxWriter:postdrift185",
+               "wclsDepoFluxWriter:postdrift186",
+               "wclsDepoFluxWriter:postdrift187",
+               "wclsDepoFluxWriter:postdrift188",
+               "wclsDepoFluxWriter:postdrift189",
+               "wclsDepoFluxWriter:postdrift190",
+               "wclsDepoFluxWriter:postdrift191",
+               "wclsDepoFluxWriter:postdrift192",
+               "wclsDepoFluxWriter:postdrift193",
+               "wclsDepoFluxWriter:postdrift194",
+               "wclsDepoFluxWriter:postdrift195",
+               "wclsDepoFluxWriter:postdrift196",
+               "wclsDepoFluxWriter:postdrift197",
+               "wclsDepoFluxWriter:postdrift198",
+               "wclsDepoFluxWriter:postdrift199",
+               "wclsDepoFluxWriter:postdrift200",
+               "wclsDepoFluxWriter:postdrift201",
+               "wclsDepoFluxWriter:postdrift202",
+               "wclsDepoFluxWriter:postdrift203",
+               "wclsDepoFluxWriter:postdrift204",
+               "wclsDepoFluxWriter:postdrift205",
+               "wclsDepoFluxWriter:postdrift206",
+               "wclsDepoFluxWriter:postdrift207",
+               "wclsDepoFluxWriter:postdrift208",
+               "wclsDepoFluxWriter:postdrift209",
+               "wclsDepoFluxWriter:postdrift210",
+               "wclsDepoFluxWriter:postdrift211",
+               "wclsDepoFluxWriter:postdrift212",
+               "wclsDepoFluxWriter:postdrift213",
+               "wclsDepoFluxWriter:postdrift214",
+               "wclsDepoFluxWriter:postdrift215",
+               "wclsDepoFluxWriter:postdrift216",
+               "wclsDepoFluxWriter:postdrift217",
+               "wclsDepoFluxWriter:postdrift218",
+               "wclsDepoFluxWriter:postdrift219",
+               "wclsDepoFluxWriter:postdrift220",
+               "wclsDepoFluxWriter:postdrift221",
+               "wclsDepoFluxWriter:postdrift222",
+               "wclsDepoFluxWriter:postdrift223",
+               "wclsDepoFluxWriter:postdrift224",
+               "wclsDepoFluxWriter:postdrift225",
+               "wclsDepoFluxWriter:postdrift226",
+               "wclsDepoFluxWriter:postdrift227",
+               "wclsDepoFluxWriter:postdrift228",
+               "wclsDepoFluxWriter:postdrift229",
+               "wclsDepoFluxWriter:postdrift230",
+               "wclsDepoFluxWriter:postdrift231",
+               "wclsDepoFluxWriter:postdrift232",
+               "wclsDepoFluxWriter:postdrift233",
+               "wclsDepoFluxWriter:postdrift234",
+               "wclsDepoFluxWriter:postdrift235",
+               "wclsDepoFluxWriter:postdrift236",
+               "wclsDepoFluxWriter:postdrift237",
+               "wclsDepoFluxWriter:postdrift238",
+               "wclsDepoFluxWriter:postdrift239",
+               "wclsDepoFluxWriter:postdrift240",
+               "wclsDepoFluxWriter:postdrift241",
+               "wclsDepoFluxWriter:postdrift242",
+               "wclsDepoFluxWriter:postdrift243",
+               "wclsDepoFluxWriter:postdrift244",
+               "wclsDepoFluxWriter:postdrift245",
+               "wclsDepoFluxWriter:postdrift246",
+               "wclsDepoFluxWriter:postdrift247",
+               "wclsDepoFluxWriter:postdrift248",
+               "wclsDepoFluxWriter:postdrift249",
+               "wclsDepoFluxWriter:postdrift250",
+               "wclsDepoFluxWriter:postdrift251",
+               "wclsDepoFluxWriter:postdrift252",
+               "wclsDepoFluxWriter:postdrift253",
+               "wclsDepoFluxWriter:postdrift254",
+               "wclsDepoFluxWriter:postdrift255",
+               "wclsDepoFluxWriter:postdrift256",
+               "wclsDepoFluxWriter:postdrift257",
+               "wclsDepoFluxWriter:postdrift258",
+               "wclsDepoFluxWriter:postdrift259",
+               "wclsDepoFluxWriter:postdrift260",
+               "wclsDepoFluxWriter:postdrift261",
+               "wclsDepoFluxWriter:postdrift262",
+               "wclsDepoFluxWriter:postdrift263",
+               "wclsDepoFluxWriter:postdrift264",
+               "wclsDepoFluxWriter:postdrift265",
+               "wclsDepoFluxWriter:postdrift266",
+               "wclsDepoFluxWriter:postdrift267",
+               "wclsDepoFluxWriter:postdrift268",
+               "wclsDepoFluxWriter:postdrift269",
+               "wclsFrameSaver:simdigits2"
+            ]
+            params: {
+               SimEnergyDepositLabel: "filtersed"
+               cathode_input_format: "array"
+               file_rcresp: "icarus_fnal_rc_tail.json"
+               tpc_idx: "2"
+               files_fields: "\"icarus_final_fit_dqdx0.json.bz2\",\n                           \"icarus_final_fit_dqdx1.json.bz2\",\n                           \"icarus_final_fit_dqdx2.json.bz2\",\n                           \"icarus_final_fit_dqdx3.json.bz2\",\n                           \"icarus_final_fit_dqdx4.json.bz2\",\n                           \"icarus_final_fit_dqdx5.json.bz2\",\n                           \"icarus_final_fit_dqdx6.json.bz2\",\n                           \"icarus_final_fit_dqdx7.json.bz2\",\n                           \"icarus_final_fit_dqdx8.json.bz2\",\n                           \"icarus_final_fit_dqdx9.json.bz2\",\n                           \"icarus_final_fit_dqdx10.json.bz2\",\n                           \"icarus_final_fit_dqdx11.json.bz2\",\n                           \"icarus_final_fit_dqdx12.json.bz2\",\n                           \"icarus_final_fit_dqdx13.json.bz2\",\n                           \"icarus_final_fit_dqdx14.json.bz2\""
+            }
+            plugins: [
+               "WireCellPgraph",
+               "WireCellGen",
+               "WireCellSio",
+               "WireCellRoot",
+               "WireCellLarsoft",
+               "WireCellHio"
+            ]
+            structs: {
+               DL: 4e-9
+               DT: 8.8e-9
+               coh_noise_scale: 1
+               gain0: 1.705212e1
+               gain1: 1.26181926e1
+               gain2: 1.30261362e1
+               int_noise_scale: 1
+               lifetime: 3000
+               lifetime_TPCEE: 3000
+               lifetime_TPCEW: 3000
+               lifetime_TPCWE: 3000
+               lifetime_TPCWW: 3000
+               overlay_drifter: false
+               shaping0: 1.3
+               shaping1: 1.45
+               shaping2: 1.3
+               time_offset_u: 0
+               time_offset_v: 0
+               time_offset_y: 0
+            }
+            tool_type: "WCLS"
+         }
+      }
+      daq3: {
+         module_type: "WireCellToolkit"
+         wcls_main: {
+            apps: [
+               "Pgrapher:pgrapher3"
+            ]
+            configs: [
+               "wcls-per-tpc-sim-drift-simchannel-yzsim.jsonnet"
+            ]
+            logsinks: ["stdout"]
+            loglevels: ["debug"]
+            inputers: [
+               "wclsSimDepoSetSource:electron"
+            ]
+            outputers: [
+               "wclsDepoFluxWriter:postdrift270",
+               "wclsDepoFluxWriter:postdrift271",
+               "wclsDepoFluxWriter:postdrift272",
+               "wclsDepoFluxWriter:postdrift273",
+               "wclsDepoFluxWriter:postdrift274",
+               "wclsDepoFluxWriter:postdrift275",
+               "wclsDepoFluxWriter:postdrift276",
+               "wclsDepoFluxWriter:postdrift277",
+               "wclsDepoFluxWriter:postdrift278",
+               "wclsDepoFluxWriter:postdrift279",
+               "wclsDepoFluxWriter:postdrift280",
+               "wclsDepoFluxWriter:postdrift281",
+               "wclsDepoFluxWriter:postdrift282",
+               "wclsDepoFluxWriter:postdrift283",
+               "wclsDepoFluxWriter:postdrift284",
+               "wclsDepoFluxWriter:postdrift285",
+               "wclsDepoFluxWriter:postdrift286",
+               "wclsDepoFluxWriter:postdrift287",
+               "wclsDepoFluxWriter:postdrift288",
+               "wclsDepoFluxWriter:postdrift289",
+               "wclsDepoFluxWriter:postdrift290",
+               "wclsDepoFluxWriter:postdrift291",
+               "wclsDepoFluxWriter:postdrift292",
+               "wclsDepoFluxWriter:postdrift293",
+               "wclsDepoFluxWriter:postdrift294",
+               "wclsDepoFluxWriter:postdrift295",
+               "wclsDepoFluxWriter:postdrift296",
+               "wclsDepoFluxWriter:postdrift297",
+               "wclsDepoFluxWriter:postdrift298",
+               "wclsDepoFluxWriter:postdrift299",
+               "wclsDepoFluxWriter:postdrift300",
+               "wclsDepoFluxWriter:postdrift301",
+               "wclsDepoFluxWriter:postdrift302",
+               "wclsDepoFluxWriter:postdrift303",
+               "wclsDepoFluxWriter:postdrift304",
+               "wclsDepoFluxWriter:postdrift305",
+               "wclsDepoFluxWriter:postdrift306",
+               "wclsDepoFluxWriter:postdrift307",
+               "wclsDepoFluxWriter:postdrift308",
+               "wclsDepoFluxWriter:postdrift309",
+               "wclsDepoFluxWriter:postdrift310",
+               "wclsDepoFluxWriter:postdrift311",
+               "wclsDepoFluxWriter:postdrift312",
+               "wclsDepoFluxWriter:postdrift313",
+               "wclsDepoFluxWriter:postdrift314",
+               "wclsDepoFluxWriter:postdrift315",
+               "wclsDepoFluxWriter:postdrift316",
+               "wclsDepoFluxWriter:postdrift317",
+               "wclsDepoFluxWriter:postdrift318",
+               "wclsDepoFluxWriter:postdrift319",
+               "wclsDepoFluxWriter:postdrift320",
+               "wclsDepoFluxWriter:postdrift321",
+               "wclsDepoFluxWriter:postdrift322",
+               "wclsDepoFluxWriter:postdrift323",
+               "wclsDepoFluxWriter:postdrift324",
+               "wclsDepoFluxWriter:postdrift325",
+               "wclsDepoFluxWriter:postdrift326",
+               "wclsDepoFluxWriter:postdrift327",
+               "wclsDepoFluxWriter:postdrift328",
+               "wclsDepoFluxWriter:postdrift329",
+               "wclsDepoFluxWriter:postdrift330",
+               "wclsDepoFluxWriter:postdrift331",
+               "wclsDepoFluxWriter:postdrift332",
+               "wclsDepoFluxWriter:postdrift333",
+               "wclsDepoFluxWriter:postdrift334",
+               "wclsDepoFluxWriter:postdrift335",
+               "wclsDepoFluxWriter:postdrift336",
+               "wclsDepoFluxWriter:postdrift337",
+               "wclsDepoFluxWriter:postdrift338",
+               "wclsDepoFluxWriter:postdrift339",
+               "wclsDepoFluxWriter:postdrift340",
+               "wclsDepoFluxWriter:postdrift341",
+               "wclsDepoFluxWriter:postdrift342",
+               "wclsDepoFluxWriter:postdrift343",
+               "wclsDepoFluxWriter:postdrift344",
+               "wclsDepoFluxWriter:postdrift345",
+               "wclsDepoFluxWriter:postdrift346",
+               "wclsDepoFluxWriter:postdrift347",
+               "wclsDepoFluxWriter:postdrift348",
+               "wclsDepoFluxWriter:postdrift349",
+               "wclsDepoFluxWriter:postdrift350",
+               "wclsDepoFluxWriter:postdrift351",
+               "wclsDepoFluxWriter:postdrift352",
+               "wclsDepoFluxWriter:postdrift353",
+               "wclsDepoFluxWriter:postdrift354",
+               "wclsDepoFluxWriter:postdrift355",
+               "wclsDepoFluxWriter:postdrift356",
+               "wclsDepoFluxWriter:postdrift357",
+               "wclsDepoFluxWriter:postdrift358",
+               "wclsDepoFluxWriter:postdrift359",
+               "wclsFrameSaver:simdigits3"
+            ]
+            params: {
+               SimEnergyDepositLabel: "filtersed"
+               cathode_input_format: "array"
+               file_rcresp: "icarus_fnal_rc_tail.json"
+               tpc_idx: "3"
+               files_fields: "\"icarus_final_fit_dqdx0.json.bz2\",\n                           \"icarus_final_fit_dqdx1.json.bz2\",\n                           \"icarus_final_fit_dqdx2.json.bz2\",\n                           \"icarus_final_fit_dqdx3.json.bz2\",\n                           \"icarus_final_fit_dqdx4.json.bz2\",\n                           \"icarus_final_fit_dqdx5.json.bz2\",\n                           \"icarus_final_fit_dqdx6.json.bz2\",\n                           \"icarus_final_fit_dqdx7.json.bz2\",\n                           \"icarus_final_fit_dqdx8.json.bz2\",\n                           \"icarus_final_fit_dqdx9.json.bz2\",\n                           \"icarus_final_fit_dqdx10.json.bz2\",\n                           \"icarus_final_fit_dqdx11.json.bz2\",\n                           \"icarus_final_fit_dqdx12.json.bz2\",\n                           \"icarus_final_fit_dqdx13.json.bz2\",\n                           \"icarus_final_fit_dqdx14.json.bz2\""
+            }
+            plugins: [
+               "WireCellPgraph",
+               "WireCellGen",
+               "WireCellSio",
+               "WireCellRoot",
+               "WireCellLarsoft",
+               "WireCellHio"
+            ]
+            structs: {
+               DL: 4e-9
+               DT: 8.8e-9
+               coh_noise_scale: 1
+               gain0: 1.705212e1
+               gain1: 1.26181926e1
+               gain2: 1.30261362e1
+               int_noise_scale: 1
+               lifetime: 3000
+               lifetime_TPCEE: 3000
+               lifetime_TPCEW: 3000
+               lifetime_TPCWE: 3000
+               lifetime_TPCWW: 3000
+               overlay_drifter: false
+               shaping0: 1.3
+               shaping1: 1.45
+               shaping2: 1.3
+               time_offset_u: 0
+               time_offset_v: 0
+               time_offset_y: 0
+            }
+            tool_type: "WCLS"
+         }
+      }
+      emuTriggerUnshifted: {
+         BeamGates: "triggersimgatesinit"
+         EmitEmpty: true
+         ExtraInfo: true
+         Pattern: {
+            inMainWindow: 3
+            sumOfOppositeWindows: 5
+         }
+         Thresholds: [
+            400
+         ]
+         TriggerGatesTag: "pmttriggerwindowsinit"
+         TriggerTimeResolution: "8 ns"
+         module_type: "TriggerSimulationOnGates"
+      }
+      filtersed: {
+         A: -4.31172e-1
+         B: -2.52724
+         C: 2.2043e-1
+         InitSimEnergyDepositLabel: "shifted"
+         InitSimEnergyDepositLiteLabel: "shifted"
+         P1_X: -400
+         P1_Y: -200
+         P1_Z: -2
+         P2_X: 400
+         P2_Y: 200
+         P2_Z: 2
+         module_type: "FilterSimEnergyDeposits"
+      }
+      merge: {
+         AuxDetHitsInstanceLabels: [
+            ""
+         ]
+         EnergyDepositInstanceLabels: [
+            "priorSCE"
+         ]
+         FillAuxDetHits: false
+         FillAuxDetSimChannels: false
+         FillMCParticles: false
+         FillSimChannels: true
+         FillSimEnergyDeposits: false
+         FillSimPhotons: false
+         InputSourcesLabels: [
+            "daq:simpleSC0",
+            "daq:simpleSC1",
+            "daq:simpleSC2",
+            "daq:simpleSC3",
+            "daq:simpleSC4",
+            "daq:simpleSC5",
+            "daq:simpleSC6",
+            "daq:simpleSC7",
+            "daq:simpleSC8",
+            "daq:simpleSC9",
+            "daq:simpleSC10",
+            "daq:simpleSC11",
+            "daq:simpleSC12",
+            "daq:simpleSC13",
+            "daq:simpleSC14",
+            "daq:simpleSC15",
+            "daq:simpleSC16",
+            "daq:simpleSC17",
+            "daq:simpleSC18",
+            "daq:simpleSC19",
+            "daq:simpleSC20",
+            "daq:simpleSC21",
+            "daq:simpleSC22",
+            "daq:simpleSC23",
+            "daq:simpleSC24",
+            "daq:simpleSC25",
+            "daq:simpleSC26",
+            "daq:simpleSC27",
+            "daq:simpleSC28",
+            "daq:simpleSC29",
+            "daq:simpleSC30",
+            "daq:simpleSC31",
+            "daq:simpleSC32",
+            "daq:simpleSC33",
+            "daq:simpleSC34",
+            "daq:simpleSC35",
+            "daq:simpleSC36",
+            "daq:simpleSC37",
+            "daq:simpleSC38",
+            "daq:simpleSC39",
+            "daq:simpleSC40",
+            "daq:simpleSC41",
+            "daq:simpleSC42",
+            "daq:simpleSC43",
+            "daq:simpleSC44",
+            "daq:simpleSC45",
+            "daq:simpleSC46",
+            "daq:simpleSC47",
+            "daq:simpleSC48",
+            "daq:simpleSC49",
+            "daq:simpleSC50",
+            "daq:simpleSC51",
+            "daq:simpleSC52",
+            "daq:simpleSC53",
+            "daq:simpleSC54",
+            "daq:simpleSC55",
+            "daq:simpleSC56",
+            "daq:simpleSC57",
+            "daq:simpleSC58",
+            "daq:simpleSC59",
+            "daq:simpleSC60",
+            "daq:simpleSC61",
+            "daq:simpleSC62",
+            "daq:simpleSC63",
+            "daq:simpleSC64",
+            "daq:simpleSC65",
+            "daq:simpleSC66",
+            "daq:simpleSC67",
+            "daq:simpleSC68",
+            "daq:simpleSC69",
+            "daq:simpleSC70",
+            "daq:simpleSC71",
+            "daq:simpleSC72",
+            "daq:simpleSC73",
+            "daq:simpleSC74",
+            "daq:simpleSC75",
+            "daq:simpleSC76",
+            "daq:simpleSC77",
+            "daq:simpleSC78",
+            "daq:simpleSC79",
+            "daq:simpleSC80",
+            "daq:simpleSC81",
+            "daq:simpleSC82",
+            "daq:simpleSC83",
+            "daq:simpleSC84",
+            "daq:simpleSC85",
+            "daq:simpleSC86",
+            "daq:simpleSC87",
+            "daq:simpleSC88",
+            "daq:simpleSC89",
+            "daq:simpleSC90",
+            "daq:simpleSC91",
+            "daq:simpleSC92",
+            "daq:simpleSC93",
+            "daq:simpleSC94",
+            "daq:simpleSC95",
+            "daq:simpleSC96",
+            "daq:simpleSC97",
+            "daq:simpleSC98",
+            "daq:simpleSC99",
+            "daq:simpleSC100",
+            "daq:simpleSC101",
+            "daq:simpleSC102",
+            "daq:simpleSC103",
+            "daq:simpleSC104",
+            "daq:simpleSC105",
+            "daq:simpleSC106",
+            "daq:simpleSC107",
+            "daq:simpleSC108",
+            "daq:simpleSC109",
+            "daq:simpleSC110",
+            "daq:simpleSC111",
+            "daq:simpleSC112",
+            "daq:simpleSC113",
+            "daq:simpleSC114",
+            "daq:simpleSC115",
+            "daq:simpleSC116",
+            "daq:simpleSC117",
+            "daq:simpleSC118",
+            "daq:simpleSC119",
+            "daq:simpleSC120",
+            "daq:simpleSC121",
+            "daq:simpleSC122",
+            "daq:simpleSC123",
+            "daq:simpleSC124",
+            "daq:simpleSC125",
+            "daq:simpleSC126",
+            "daq:simpleSC127",
+            "daq:simpleSC128",
+            "daq:simpleSC129",
+            "daq:simpleSC130",
+            "daq:simpleSC131",
+            "daq:simpleSC132",
+            "daq:simpleSC133",
+            "daq:simpleSC134",
+            "daq:simpleSC135",
+            "daq:simpleSC136",
+            "daq:simpleSC137",
+            "daq:simpleSC138",
+            "daq:simpleSC139",
+            "daq:simpleSC140",
+            "daq:simpleSC141",
+            "daq:simpleSC142",
+            "daq:simpleSC143",
+            "daq:simpleSC144",
+            "daq:simpleSC145",
+            "daq:simpleSC146",
+            "daq:simpleSC147",
+            "daq:simpleSC148",
+            "daq:simpleSC149",
+            "daq:simpleSC150",
+            "daq:simpleSC151",
+            "daq:simpleSC152",
+            "daq:simpleSC153",
+            "daq:simpleSC154",
+            "daq:simpleSC155",
+            "daq:simpleSC156",
+            "daq:simpleSC157",
+            "daq:simpleSC158",
+            "daq:simpleSC159",
+            "daq:simpleSC160",
+            "daq:simpleSC161",
+            "daq:simpleSC162",
+            "daq:simpleSC163",
+            "daq:simpleSC164",
+            "daq:simpleSC165",
+            "daq:simpleSC166",
+            "daq:simpleSC167",
+            "daq:simpleSC168",
+            "daq:simpleSC169",
+            "daq:simpleSC170",
+            "daq:simpleSC171",
+            "daq:simpleSC172",
+            "daq:simpleSC173",
+            "daq:simpleSC174",
+            "daq:simpleSC175",
+            "daq:simpleSC176",
+            "daq:simpleSC177",
+            "daq:simpleSC178",
+            "daq:simpleSC179",
+            "daq:simpleSC180",
+            "daq:simpleSC181",
+            "daq:simpleSC182",
+            "daq:simpleSC183",
+            "daq:simpleSC184",
+            "daq:simpleSC185",
+            "daq:simpleSC186",
+            "daq:simpleSC187",
+            "daq:simpleSC188",
+            "daq:simpleSC189",
+            "daq:simpleSC190",
+            "daq:simpleSC191",
+            "daq:simpleSC192",
+            "daq:simpleSC193",
+            "daq:simpleSC194",
+            "daq:simpleSC195",
+            "daq:simpleSC196",
+            "daq:simpleSC197",
+            "daq:simpleSC198",
+            "daq:simpleSC199",
+            "daq:simpleSC200",
+            "daq:simpleSC201",
+            "daq:simpleSC202",
+            "daq:simpleSC203",
+            "daq:simpleSC204",
+            "daq:simpleSC205",
+            "daq:simpleSC206",
+            "daq:simpleSC207",
+            "daq:simpleSC208",
+            "daq:simpleSC209",
+            "daq:simpleSC210",
+            "daq:simpleSC211",
+            "daq:simpleSC212",
+            "daq:simpleSC213",
+            "daq:simpleSC214",
+            "daq:simpleSC215",
+            "daq:simpleSC216",
+            "daq:simpleSC217",
+            "daq:simpleSC218",
+            "daq:simpleSC219",
+            "daq:simpleSC220",
+            "daq:simpleSC221",
+            "daq:simpleSC222",
+            "daq:simpleSC223",
+            "daq:simpleSC224",
+            "daq:simpleSC225",
+            "daq:simpleSC226",
+            "daq:simpleSC227",
+            "daq:simpleSC228",
+            "daq:simpleSC229",
+            "daq:simpleSC230",
+            "daq:simpleSC231",
+            "daq:simpleSC232",
+            "daq:simpleSC233",
+            "daq:simpleSC234",
+            "daq:simpleSC235",
+            "daq:simpleSC236",
+            "daq:simpleSC237",
+            "daq:simpleSC238",
+            "daq:simpleSC239",
+            "daq:simpleSC240",
+            "daq:simpleSC241",
+            "daq:simpleSC242",
+            "daq:simpleSC243",
+            "daq:simpleSC244",
+            "daq:simpleSC245",
+            "daq:simpleSC246",
+            "daq:simpleSC247",
+            "daq:simpleSC248",
+            "daq:simpleSC249",
+            "daq:simpleSC250",
+            "daq:simpleSC251",
+            "daq:simpleSC252",
+            "daq:simpleSC253",
+            "daq:simpleSC254",
+            "daq:simpleSC255",
+            "daq:simpleSC256",
+            "daq:simpleSC257",
+            "daq:simpleSC258",
+            "daq:simpleSC259",
+            "daq:simpleSC260",
+            "daq:simpleSC261",
+            "daq:simpleSC262",
+            "daq:simpleSC263",
+            "daq:simpleSC264",
+            "daq:simpleSC265",
+            "daq:simpleSC266",
+            "daq:simpleSC267",
+            "daq:simpleSC268",
+            "daq:simpleSC269",
+            "daq:simpleSC270",
+            "daq:simpleSC271",
+            "daq:simpleSC272",
+            "daq:simpleSC273",
+            "daq:simpleSC274",
+            "daq:simpleSC275",
+            "daq:simpleSC276",
+            "daq:simpleSC277",
+            "daq:simpleSC278",
+            "daq:simpleSC279",
+            "daq:simpleSC280",
+            "daq:simpleSC281",
+            "daq:simpleSC282",
+            "daq:simpleSC283",
+            "daq:simpleSC284",
+            "daq:simpleSC285",
+            "daq:simpleSC286",
+            "daq:simpleSC287",
+            "daq:simpleSC288",
+            "daq:simpleSC289",
+            "daq:simpleSC290",
+            "daq:simpleSC291",
+            "daq:simpleSC292",
+            "daq:simpleSC293",
+            "daq:simpleSC294",
+            "daq:simpleSC295",
+            "daq:simpleSC296",
+            "daq:simpleSC297",
+            "daq:simpleSC298",
+            "daq:simpleSC299",
+            "daq:simpleSC300",
+            "daq:simpleSC301",
+            "daq:simpleSC302",
+            "daq:simpleSC303",
+            "daq:simpleSC304",
+            "daq:simpleSC305",
+            "daq:simpleSC306",
+            "daq:simpleSC307",
+            "daq:simpleSC308",
+            "daq:simpleSC309",
+            "daq:simpleSC310",
+            "daq:simpleSC311",
+            "daq:simpleSC312",
+            "daq:simpleSC313",
+            "daq:simpleSC314",
+            "daq:simpleSC315",
+            "daq:simpleSC316",
+            "daq:simpleSC317",
+            "daq:simpleSC318",
+            "daq:simpleSC319",
+            "daq:simpleSC320",
+            "daq:simpleSC321",
+            "daq:simpleSC322",
+            "daq:simpleSC323",
+            "daq:simpleSC324",
+            "daq:simpleSC325",
+            "daq:simpleSC326",
+            "daq:simpleSC327",
+            "daq:simpleSC328",
+            "daq:simpleSC329",
+            "daq:simpleSC330",
+            "daq:simpleSC331",
+            "daq:simpleSC332",
+            "daq:simpleSC333",
+            "daq:simpleSC334",
+            "daq:simpleSC335",
+            "daq:simpleSC336",
+            "daq:simpleSC337",
+            "daq:simpleSC338",
+            "daq:simpleSC339",
+            "daq:simpleSC340",
+            "daq:simpleSC341",
+            "daq:simpleSC342",
+            "daq:simpleSC343",
+            "daq:simpleSC344",
+            "daq:simpleSC345",
+            "daq:simpleSC346",
+            "daq:simpleSC347",
+            "daq:simpleSC348",
+            "daq:simpleSC349",
+            "daq:simpleSC350",
+            "daq:simpleSC351",
+            "daq:simpleSC352",
+            "daq:simpleSC353",
+            "daq:simpleSC354",
+            "daq:simpleSC355",
+            "daq:simpleSC356",
+            "daq:simpleSC357",
+            "daq:simpleSC358",
+            "daq:simpleSC359"
+         ]
+         SkipTrackIDOffsets: true
+         StoreReflected: false
+         TrackIDOffsets: [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+         ]
+         module_type: "MergeSimSources"
+      }
+      opdaq: {
+         BeamGateTriggerNReps: 10
+         BeamGateTriggerRepPeriod: "2.0 us"
+         CreateBeamGateTriggers: true
+         DarkNoiseRate: "1.6 kHz"
+         DiscrimAlgo: "AboveThreshold"
+         FluctuateGain: true
+         InputModule: "pdfastsim"
+         PMTspecs: {
+            DynodeK: 7.5e-1
+            Gain: 7.5e6
+            VoltageDistribution: [
+               1.74e1,
+               3.4,
+               5,
+               3.33,
+               1.67,
+               1,
+               1.2,
+               1.5,
+               2.2,
+               3
+            ]
+         }
+         Pedestal: {
+            NoiseGenerator: {
+               RMS: 3
+               tool_type: "PMTfastGausNoiseGeneratorTool"
+            }
+            Pedestal: 1.49995e4
+            tool_type: "PMTconstantPedestalGeneratorTool"
+         }
+         PreTrigFraction: 2.5e-1
+         PulsePolarity: -1
+         QE: 7.3e-2
+         ReadoutEnablePeriod: "2.0 ms"
+         ReadoutWindowSize: 2000
+         SinglePhotonResponse: {
+            Gain: 7.5e6
+            TransitTime: "55.1 ns"
+            WaveformData: "Responses/SPR202202.txt"
+            tool_type: "SampledWaveformFunctionTool"
+         }
+         ThresholdADC: 15
+         TriggerOffsetPMT: "-1.0 ms"
+         module_type: "SimPMTIcarus"
+      }
+      pmtfixedthrinit: {
+         Baseline: 1.49995e4
+         NChannels: 360
+         OpticalWaveforms: "opdaq"
+         OutputCategory: "DiscriminatePMTwaveforms"
+         TriggerGateBuilder: {
+            ChannelThresholds: [
+               18,
+               300,
+               400,
+               600
+            ]
+            GateDuration: "160 ns"
+            tool_type: "FixedTriggerGateBuilderTool"
+         }
+         module_type: "DiscriminatePMTwaveforms"
+      }
+      pmtlvdsgatesinit: {
+         ChannelPairing: [
+            [
+               0,
+               2
+            ],
+            [
+               1,
+               4
+            ],
+            [
+               3,
+               6
+            ],
+            [
+               5,
+               8
+            ],
+            [
+               7,
+               9
+            ],
+            [
+               10,
+               12
+            ],
+            [
+               11,
+               14
+            ],
+            [
+               13
+            ],
+            [
+               15,
+               18
+            ],
+            [
+               16
+            ],
+            [
+               17,
+               19
+            ],
+            [
+               20,
+               22
+            ],
+            [
+               21,
+               24
+            ],
+            [
+               23,
+               26
+            ],
+            [
+               25,
+               28
+            ],
+            [
+               27,
+               29
+            ],
+            [
+               30,
+               32
+            ],
+            [
+               31,
+               34
+            ],
+            [
+               33,
+               36
+            ],
+            [
+               35,
+               38
+            ],
+            [
+               37,
+               39
+            ],
+            [
+               40,
+               42
+            ],
+            [
+               41,
+               44
+            ],
+            [
+               43
+            ],
+            [
+               45,
+               48
+            ],
+            [
+               46
+            ],
+            [
+               47,
+               49
+            ],
+            [
+               50,
+               52
+            ],
+            [
+               51,
+               54
+            ],
+            [
+               53,
+               56
+            ],
+            [
+               55,
+               58
+            ],
+            [
+               57,
+               59
+            ],
+            [
+               60,
+               62
+            ],
+            [
+               61,
+               64
+            ],
+            [
+               63,
+               66
+            ],
+            [
+               65,
+               68
+            ],
+            [
+               67,
+               69
+            ],
+            [
+               70,
+               72
+            ],
+            [
+               71,
+               74
+            ],
+            [
+               73
+            ],
+            [
+               75,
+               78
+            ],
+            [
+               76
+            ],
+            [
+               77,
+               79
+            ],
+            [
+               80,
+               82
+            ],
+            [
+               81,
+               84
+            ],
+            [
+               83,
+               86
+            ],
+            [
+               85,
+               88
+            ],
+            [
+               87,
+               89
+            ],
+            [
+               90,
+               92
+            ],
+            [
+               91,
+               94
+            ],
+            [
+               93,
+               96
+            ],
+            [
+               95,
+               98
+            ],
+            [
+               97,
+               99
+            ],
+            [
+               100,
+               102
+            ],
+            [
+               101,
+               104
+            ],
+            [
+               103
+            ],
+            [
+               105,
+               108
+            ],
+            [
+               106
+            ],
+            [
+               107,
+               109
+            ],
+            [
+               110,
+               112
+            ],
+            [
+               111,
+               114
+            ],
+            [
+               113,
+               116
+            ],
+            [
+               115,
+               118
+            ],
+            [
+               117,
+               119
+            ],
+            [
+               120,
+               122
+            ],
+            [
+               121,
+               124
+            ],
+            [
+               123,
+               126
+            ],
+            [
+               125,
+               128
+            ],
+            [
+               127,
+               129
+            ],
+            [
+               130,
+               132
+            ],
+            [
+               131,
+               134
+            ],
+            [
+               133
+            ],
+            [
+               135,
+               138
+            ],
+            [
+               136
+            ],
+            [
+               137,
+               139
+            ],
+            [
+               140,
+               142
+            ],
+            [
+               141,
+               144
+            ],
+            [
+               143,
+               146
+            ],
+            [
+               145,
+               148
+            ],
+            [
+               147,
+               149
+            ],
+            [
+               150,
+               152
+            ],
+            [
+               151,
+               154
+            ],
+            [
+               153,
+               156
+            ],
+            [
+               155,
+               158
+            ],
+            [
+               157,
+               159
+            ],
+            [
+               160,
+               162
+            ],
+            [
+               161,
+               164
+            ],
+            [
+               163
+            ],
+            [
+               165,
+               168
+            ],
+            [
+               166
+            ],
+            [
+               167,
+               169
+            ],
+            [
+               170,
+               172
+            ],
+            [
+               171,
+               174
+            ],
+            [
+               173,
+               176
+            ],
+            [
+               175,
+               178
+            ],
+            [
+               177,
+               179
+            ],
+            [
+               180,
+               182
+            ],
+            [
+               181,
+               184
+            ],
+            [
+               183,
+               186
+            ],
+            [
+               185,
+               188
+            ],
+            [
+               187,
+               189
+            ],
+            [
+               190,
+               192
+            ],
+            [
+               191,
+               194
+            ],
+            [
+               193
+            ],
+            [
+               195,
+               198
+            ],
+            [
+               196
+            ],
+            [
+               197,
+               199
+            ],
+            [
+               200,
+               202
+            ],
+            [
+               201,
+               204
+            ],
+            [
+               203,
+               206
+            ],
+            [
+               205,
+               208
+            ],
+            [
+               207,
+               209
+            ],
+            [
+               210,
+               212
+            ],
+            [
+               211,
+               214
+            ],
+            [
+               213,
+               216
+            ],
+            [
+               215,
+               218
+            ],
+            [
+               217,
+               219
+            ],
+            [
+               220,
+               222
+            ],
+            [
+               221,
+               224
+            ],
+            [
+               223
+            ],
+            [
+               225,
+               228
+            ],
+            [
+               226
+            ],
+            [
+               227,
+               229
+            ],
+            [
+               230,
+               232
+            ],
+            [
+               231,
+               234
+            ],
+            [
+               233,
+               236
+            ],
+            [
+               235,
+               238
+            ],
+            [
+               237,
+               239
+            ],
+            [
+               240,
+               242
+            ],
+            [
+               241,
+               244
+            ],
+            [
+               243,
+               246
+            ],
+            [
+               245,
+               248
+            ],
+            [
+               247,
+               249
+            ],
+            [
+               250,
+               252
+            ],
+            [
+               251,
+               254
+            ],
+            [
+               253
+            ],
+            [
+               255,
+               258
+            ],
+            [
+               256
+            ],
+            [
+               257,
+               259
+            ],
+            [
+               260,
+               262
+            ],
+            [
+               261,
+               264
+            ],
+            [
+               263,
+               266
+            ],
+            [
+               265,
+               268
+            ],
+            [
+               267,
+               269
+            ],
+            [
+               270,
+               272
+            ],
+            [
+               271,
+               274
+            ],
+            [
+               273,
+               276
+            ],
+            [
+               275,
+               278
+            ],
+            [
+               277,
+               279
+            ],
+            [
+               280,
+               282
+            ],
+            [
+               281,
+               284
+            ],
+            [
+               283
+            ],
+            [
+               285,
+               288
+            ],
+            [
+               286
+            ],
+            [
+               287,
+               289
+            ],
+            [
+               290,
+               292
+            ],
+            [
+               291,
+               294
+            ],
+            [
+               293,
+               296
+            ],
+            [
+               295,
+               298
+            ],
+            [
+               297,
+               299
+            ],
+            [
+               300,
+               302
+            ],
+            [
+               301,
+               304
+            ],
+            [
+               303,
+               306
+            ],
+            [
+               305,
+               308
+            ],
+            [
+               307,
+               309
+            ],
+            [
+               310,
+               312
+            ],
+            [
+               311,
+               314
+            ],
+            [
+               313
+            ],
+            [
+               315,
+               318
+            ],
+            [
+               316
+            ],
+            [
+               317,
+               319
+            ],
+            [
+               320,
+               322
+            ],
+            [
+               321,
+               324
+            ],
+            [
+               323,
+               326
+            ],
+            [
+               325,
+               328
+            ],
+            [
+               327,
+               329
+            ],
+            [
+               330,
+               332
+            ],
+            [
+               331,
+               334
+            ],
+            [
+               333,
+               336
+            ],
+            [
+               335,
+               338
+            ],
+            [
+               337,
+               339
+            ],
+            [
+               340,
+               342
+            ],
+            [
+               341,
+               344
+            ],
+            [
+               343
+            ],
+            [
+               345,
+               348
+            ],
+            [
+               346
+            ],
+            [
+               347,
+               349
+            ],
+            [
+               350,
+               352
+            ],
+            [
+               351,
+               354
+            ],
+            [
+               353,
+               356
+            ],
+            [
+               355,
+               358
+            ],
+            [
+               357,
+               359
+            ]
+         ]
+         CombinationMode: "OR"
+         IgnoreChannels: [
+            70,
+            106,
+            217,
+            54,
+            58,
+            67,
+            98,
+            112,
+            153,
+            254
+         ]
+         LogCategory: "LVDSgates"
+         Thresholds: [
+            400
+         ]
+         TriggerGatesTag: "pmtfixedthrinit"
+         module_type: "LVDSgates"
+      }
+      pmttriggerwindowsinit: {
+         MissingChannels: [
+            70,
+            106,
+            217,
+            54,
+            58,
+            67,
+            98,
+            112,
+            153,
+            254
+         ]
+         Stride: 15
+         Thresholds: [
+            400
+         ]
+         TriggerGatesTag: "pmtlvdsgatesinit"
+         WindowSize: 30
+         module_type: "SlidingWindowTrigger"
+      }
+      rns: {
+         module_type: "RandomNumberSaver"
+      }
+      shifted: {
+         AdditionalOffset: 0
+         InitAuxDetSimChannelLabel: "genericcrt"
+         InitBeamGateInfoLabel: "triggersimgatesinit"
+         InitSimEnergyDepositLabel: "ionization"
+         InitSimEnergyDepositLiteLabel: "sedlite"
+         InitSimPhotonsLabel: "pdfastsim"
+         InitWaveformLabel: "opdaq"
+         InputTriggerLabel: "emuTriggerUnshifted"
+         ShiftAuxDetIDEs: true
+         ShiftBeamGateInfo: true
+         ShiftSimEnergyDepositLites: true
+         ShiftSimEnergyDeposits: true
+         ShiftSimPhotons: true
+         ShiftWaveforms: true
+         module_type: "AdjustSimForTrigger"
+      }
+      shiftedpriorSCE: {
+         AdditionalOffset: 0
+         InitAuxDetSimChannelLabel: ""
+         InitBeamGateInfoLabel: ""
+         InitSimEnergyDepositLabel: "ionization:priorSCE"
+         InitSimPhotonsLabel: ""
+         InitWaveformLabel: ""
+         InputTriggerLabel: "emuTriggerUnshifted"
+         ShiftAuxDetIDEs: false
+         ShiftBeamGateInfo: false
+         ShiftSimEnergyDeposits: true
+         ShiftSimPhotons: false
+         ShiftWaveforms: false
+         module_type: "AdjustSimForTrigger"
+      }
+      triggersimgatesinit: {
+         BeamGateTag: "beamgate"
+         Changes: [
+            {
+               Select: {
+                  Types: [
+                     "BNB"
+                  ]
+               }
+               Start: {
+                  SetTo: "-0.2 us"
+               }
+               Width: {
+                  Add: "0.5 us"
+                  SetTo: "1.6 us"
+               }
+            },
+            {
+               Select: {
+                  Types: [
+                     "NuMI"
+                  ]
+               }
+               Start: {
+                  SetTo: "-0.2 us"
+               }
+               Width: {
+                  Add: "0.6 us"
+                  SetTo: "9.5 us"
+               }
+            }
+         ]
+         module_type: "FixBeamGateInfo"
+      }
+   }
+   simulate: [
+      "rns",
+      "opdaq",
+      "pmtfixedthrinit",
+      "pmtlvdsgatesinit",
+      "pmttriggerwindowsinit",
+      "triggersimgatesinit",
+      "emuTriggerUnshifted",
+      "shifted",
+      "shiftedpriorSCE",
+      "filtersed"
+      , "daq0"
+      , "daq1"
+      , "daq2"
+      , "daq3"
+   #   , "merge",
+    #   "crtdaq"
+   ]
+   stream: [
+      "rootoutput"
+   ]
+}
+process_name: "DetSim"
+services: {
+   ActionHolder: {}
+   AuxDetGeometry: {
+      GDML: "icarus_refactored_nounderscore_20230918.gdml"
+      Name: "icarus_v4"
+      SortingParameters: {
+         tool_type: "AuxDetGeoObjectSorterICARUS"
+      }
+      SurfaceY: 690
+   }
+   ChannelStatusService: {
+      ChannelStatusProvider: {
+         AlgName: "SIOVChannelStatusProvider"
+         DatabaseRetrievalAlg: {
+            AlgName: "DatabaseRetrievalAlg"
+            DBFolderName: "tpc_channelstatus_data"
+            DBTag: "v3r4"
+            DBUrl: "https://dbdata0vm.fnal.gov:9443/icarus_con_prod/app/"
+            UseSQLite: true
+         }
+         UseDB: true
+         UseFile: false
+      }
+      service_provider: "SIOVChannelStatusICARUSService"
+   }
+   DetPedestalService: {
+      DetPedestalRetrievalAlg: {
+         AlgName: "DetPedestalRetrievalAlg"
+         DatabaseRetrievalAlg: {
+            AlgName: "DatabaseRetrievalAlg"
+            DBFolderName: ""
+            DBTag: ""
+            DBUrl: ""
+         }
+         DefaultCollMean: 400
+         DefaultCollRms: 3e-1
+         DefaultIndMean: 2048
+         DefaultIndRms: 3e-1
+         DefaultMeanErr: 0
+         DefaultRmsErr: 0
+         UseDB: false
+         UseFile: false
+      }
+      service_provider: "SIOVDetPedestalService"
+   }
+   DetectorClocksService: {
+      ClockSpeedExternal: 3.125e1
+      ClockSpeedOptical: 500
+      ClockSpeedTPC: 2.5
+      ClockSpeedTrigger: 16
+      DefaultBeamTime: 1500
+      DefaultTrigTime: 1500
+      FramePeriod: 1.6384e3
+      G4RefTime: -1500
+      InheritClockConfig: true
+      TrigModuleName: "daqTrigger"
+      TriggerOffsetTPC: -340
+      service_provider: "DetectorClocksServiceStandard"
+   }
+   DetectorHolder: {}
+   DetectorPropertiesService: {
+      DriftVelFudgeFactor: 9.9733e-1
+      Efield: [
+         4.938e-1,
+         7.33e-1,
+         9.33e-1
+      ]
+      Electronlifetime: 3000
+      ElectronsToADC: 1.208041e-3
+      IncludeInterPlanePitchInXTickOffsets: false
+      InheritNumberTimeSamples: true
+      NumberTimeSamples: 4096
+      ReadOutWindowSize: 4096
+      SimpleBoundaryProcess: false
+      SternheimerA: 1.956e-1
+      SternheimerCbar: 5.2146
+      SternheimerK: 3
+      SternheimerX0: 2e-1
+      SternheimerX1: 3
+      Temperature: 8.75e1
+      TimeOffsetU: 0
+      TimeOffsetV: 0
+      TimeOffsetY: 0
+      TimeOffsetZ: 0
+      UseIcarusMicrobooneDriftModel: true
+      service_provider: "DetectorPropertiesServiceStandard"
+   }
+   DuplicateEventTracker: {}
+   FileCatalogMetadata: {
+      fileType: "mc"
+      group: "icarus"
+      runType: "physics"
+   }
+   Geometry: {
+      GDML: "icarus_refactored_nounderscore_20230918.gdml"
+      Name: "icarus_v4"
+      SortingParameters: {
+         tool_type: "GeoObjectSorterPMTasTPC"
+      }
+      SurfaceY: 690
+   }
+   GeometryConfigurationWriter: {}
+   LArG4Detector: {
+      category: "world"
+      gdmlFileName_: "icarus_refactored_nounderscore_20230918.gdml"
+   }
+   LArG4Parameters: {
+      CosmogenicK0Bias: 0
+      CosmogenicXSMNBiasFactor: 1
+      CosmogenicXSMNBiasOn: 0
+      DisableWireplanes: false
+      ElectronClusterSize: 20
+      EllipsModBoxA: 9.04e-1
+      EllipsModBoxB: 2.04e-1
+      EllipsModBoxR: 1.25
+      EnabledPhysics: [
+         "Em",
+         "SynchrotronAndGN",
+         "Ion",
+         "Hadron",
+         "Decay",
+         "HadronElastic",
+         "Stopping",
+         "FastOptical"
+      ]
+      FillSimEnergyDeposits: true
+      IonAndScintCalculator: "Correlated"
+      KeepEMShowerDaughters: false
+      LarqlAlpha: 3.72e-2
+      LarqlBeta: 1.24e-2
+      LarqlChi0A: 3.38427e-3
+      LarqlChi0B: -6.57037
+      LarqlChi0C: 1.88418
+      LarqlChi0D: 1.29379e-4
+      LongitudinalDiffusion: 4e-9
+      MinNumberOfElCluster: 0
+      ModBoxA: 9.3e-1
+      ModBoxB: 2.12e-1
+      ModifyProtonCut: false
+      NewProtonCut: 0
+      OpticalParamModels: [
+         "OverlaidWireplanes"
+      ]
+      OpticalParamOrientations: [
+         0
+      ]
+      OpticalParamParameters: [
+         [
+            [
+               60,
+               3,
+               1.5e-1
+            ],
+            [
+               -60,
+               3,
+               1.5e-1
+            ],
+            [
+               0,
+               3,
+               1.5e-1
+            ]
+         ]
+      ]
+      OpticalParamVolumes: [
+         "volTPCPlaneVert_PV"
+      ]
+      OpticalSimVerbosity: 0
+      ParticleKineticEnergyCut: 1e-5
+      QAlpha: 4.3e-1
+      QProton: 1
+      RecombA: 8e-1
+      Recombk: 4.86e-2
+      SkipWireSignalInTPCs: []
+      StoreTrajectories: true
+      TransverseDiffusion: 8.8e-9
+      UseCustomPhysics: true
+      UseEllipsModBoxRecomb: true
+      UseLitePhotons: false
+      UseModBoxRecomb: false
+      UseModLarqlRecomb: true
+      VisualizationEnergyCut: 1e-2
+      VisualizeNeutrals: false
+      Wph: 1.95e1
+   }
+   LArPropertiesService: {
+      AbsLengthEnergies: [
+         4,
+         5,
+         6,
+         7,
+         8,
+         9,
+         10,
+         11
+      ]
+      AbsLengthSpectrum: [
+         8000,
+         8000,
+         8000,
+         8000,
+         8000,
+         2000,
+         2000,
+         2000
+      ]
+      AlphaScintYield: 16800
+      AlphaScintYieldRatio: 5.6e-1
+      Argon39DecayRate: 0
+      AtomicMass: 3.9948e1
+      AtomicNumber: 18
+      ElectronScintYield: 20000
+      ElectronScintYieldRatio: 2.7e-1
+      EnableCerenkovLight: false
+      ExcitationEnergy: 188
+      FastScintEnergies: [
+         7.2,
+         7.9,
+         8.3,
+         8.6,
+         8.9,
+         9.1,
+         9.3,
+         9.6,
+         9.7,
+         9.8,
+         10,
+         1.02e1,
+         1.03e1,
+         1.06e1,
+         11,
+         1.16e1,
+         1.19e1
+      ]
+      FastScintSpectrum: [
+         0,
+         4e-2,
+         1.2e-1,
+         2.7e-1,
+         4.4e-1,
+         6.2e-1,
+         8e-1,
+         9.1e-1,
+         9.2e-1,
+         8.5e-1,
+         7e-1,
+         5e-1,
+         3.1e-1,
+         1.3e-1,
+         4e-2,
+         1e-2,
+         0
+      ]
+      KaonScintYield: 24000
+      KaonScintYieldRatio: 2.3e-1
+      LoadExtraMatProperties: false
+      MuonScintYield: 24000
+      MuonScintYieldRatio: 2.3e-1
+      PionScintYield: 24000
+      PionScintYieldRatio: 2.3e-1
+      ProtonScintYield: 19200
+      ProtonScintYieldRatio: 2.9e-1
+      RIndexEnergies: [
+         1.18626,
+         1.68626,
+         2.18626,
+         2.68626,
+         3.18626,
+         3.68626,
+         4.18626,
+         4.68626,
+         5.18626,
+         5.68626,
+         6.18626,
+         6.68626,
+         7.18626,
+         7.68626,
+         8.18626,
+         8.68626,
+         9.18626,
+         9.68626,
+         1.01863e1,
+         1.06863e1,
+         1.11863e1
+      ]
+      RIndexSpectrum: [
+         1.24664,
+         1.2205,
+         1.22694,
+         1.22932,
+         1.23124,
+         1.23322,
+         1.23545,
+         1.23806,
+         1.24116,
+         1.24489,
+         1.24942,
+         1.25499,
+         1.26197,
+         1.2709,
+         1.28263,
+         1.29865,
+         1.32169,
+         1.35747,
+         1.42039,
+         1.56011,
+         2.16626
+      ]
+      RadiationLength: 1.955e1
+      RayleighEnergies: [
+         1.18626,
+         1.68626,
+         2.18626,
+         2.68626,
+         3.18626,
+         3.68626,
+         4.18626,
+         4.68626,
+         5.18626,
+         5.68626,
+         6.18626,
+         6.68626,
+         7.18626,
+         7.68626,
+         8.18626,
+         8.68626,
+         9.18626,
+         9.68626,
+         1.01863e1,
+         1.06863e1,
+         1.11863e1
+      ]
+      RayleighSpectrum: [
+         1.2008e6,
+         390747,
+         128633,
+         5.49691e4,
+         2.71918e4,
+         1.48537e4,
+         8.7169e3,
+         5.39742e3,
+         3.48137e3,
+         2.31651e3,
+         1.57763e3,
+         1.09202e3,
+         7.63045e2,
+         5.34232e2,
+         3.71335e2,
+         2.52942e2,
+         1.6538e2,
+         9.99003e1,
+         5.12653e1,
+         1.7495e1,
+         9.64341e-1
+      ]
+      ReflectiveSurfaceDiffuseFractions: [
+         [
+            5e-1,
+            5e-1,
+            5e-1
+         ]
+      ]
+      ReflectiveSurfaceEnergies: [
+         1.77,
+         2.0675,
+         2.481,
+         2.819,
+         2.953,
+         3.1807,
+         3.54,
+         4.135,
+         4.962,
+         5.39,
+         7,
+         15
+      ]
+      ReflectiveSurfaceNames: [
+         "STEEL_STAINLESS_Fe7Cr2Ni",
+         "copper",
+         "G10",
+         "vm2000",
+         "ALUMINUM_Al",
+         "ALUMINUM_PMT",
+         "ALUMINUM_CRYO"
+      ]
+      ReflectiveSurfaceReflectances: [
+         [
+            6.6e-1,
+            6.4e-1,
+            6.2e-1,
+            6e-1,
+            5.9e-1,
+            5.7e-1,
+            5.3e-1,
+            4.7e-1,
+            3.9e-1,
+            3.6e-1,
+            2.7e-1,
+            2.5e-1
+         ],
+         [
+            9.02e-1,
+            8.41e-1,
+            4.64e-1,
+            3.79e-1,
+            3.45e-1,
+            2.99e-1,
+            2.87e-1,
+            2.64e-1,
+            3.37e-1,
+            3e-1,
+            0,
+            0
+         ],
+         [
+            3.93e-1,
+            4.05e-1,
+            4.04e-1,
+            3.52e-1,
+            3.23e-1,
+            2.43e-1,
+            1.27e-1,
+            6.5e-2,
+            6.8e-2,
+            6.8e-2,
+            0,
+            0
+         ],
+         [
+            9.3e-1,
+            9.3e-1,
+            9.3e-1,
+            9.3e-1,
+            9.3e-1,
+            9.3e-1,
+            1e-1,
+            1e-1,
+            7e-1,
+            3e-1,
+            0,
+            0
+         ],
+         [
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            4.7e-1,
+            3.9e-1,
+            3.6e-1,
+            2.7e-1,
+            2.5e-1
+         ],
+         [
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            4.7e-1,
+            3.9e-1,
+            3.6e-1,
+            2.7e-1,
+            2.5e-1
+         ],
+         [
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            9e-1,
+            4.7e-1,
+            3.9e-1,
+            3.6e-1,
+            2.7e-1,
+            2.5e-1
+         ]
+      ]
+      ScintBirksConstant: 6.9e-2
+      ScintByParticleType: true
+      ScintFastTimeConst: 6
+      ScintPreScale: 7.3e-2
+      ScintResolutionScale: 1
+      ScintSlowTimeConst: 1590
+      ScintYield: 24000
+      ScintYieldRatio: 2.3e-1
+      SlowScintEnergies: [
+         7.2,
+         7.9,
+         8.3,
+         8.6,
+         8.9,
+         9.1,
+         9.3,
+         9.6,
+         9.7,
+         9.8,
+         10,
+         1.02e1,
+         1.03e1,
+         1.06e1,
+         11,
+         1.16e1,
+         1.19e1
+      ]
+      SlowScintSpectrum: [
+         0,
+         4e-2,
+         1.2e-1,
+         2.7e-1,
+         4.4e-1,
+         6.2e-1,
+         8e-1,
+         9.1e-1,
+         9.2e-1,
+         8.5e-1,
+         7e-1,
+         5e-1,
+         3.1e-1,
+         1.3e-1,
+         4e-2,
+         1e-2,
+         0
+      ]
+      TpbAbsorptionEnergies: [
+         5e-2,
+         1.77,
+         2.0675,
+         7.42,
+         7.75,
+         8.16,
+         8.73,
+         9.78,
+         1.069e1,
+         5.039e1
+      ]
+      TpbAbsorptionSpectrum: [
+         100000,
+         100000,
+         100000,
+         1e-3,
+         1e-11,
+         1e-11,
+         1e-11,
+         1e-11,
+         1e-11,
+         1e-11
+      ]
+      TpbEmmisionEnergies: [
+         5e-2,
+         1,
+         1.5,
+         2.25,
+         2.481,
+         2.819,
+         2.952,
+         2.988,
+         3.024,
+         3.1,
+         3.14,
+         3.1807,
+         3.54,
+         5.5,
+         5.039e1
+      ]
+      TpbEmmisionSpectrum: [
+         0,
+         0,
+         0,
+         5.88e-2,
+         2.35e-1,
+         8.53e-1,
+         1,
+         1,
+         9.259e-1,
+         7.04e-1,
+         2.96e-2,
+         1.1e-2,
+         0,
+         0,
+         0
+      ]
+      TpbTimeConstant: 2.5
+      service_provider: "LArPropertiesServiceStandard"
+   }
+   LArVoxelCalculator: {
+      VoxelEnergyCut: 1e-6
+      VoxelOffsetT: -2500
+      VoxelOffsetX: 0
+      VoxelOffsetY: 0
+      VoxelOffsetZ: 0
+      VoxelSizeT: 5000
+      VoxelSizeX: 3e-2
+      VoxelSizeY: 3e-2
+      VoxelSizeZ: 3e-2
+   }
+   MCTruthEventAction: {
+      service_type: "MCTruthEventActionService"
+   }
+   MagneticField: {
+      FieldDescriptions: [
+         {
+            ConstantField: [
+               0,
+               0,
+               0
+            ]
+            MagnetizedVolume: "volWorld"
+            UseField: 0
+         }
+      ]
+      service_provider: "MagneticFieldServiceStandard"
+   }
+   MemoryTracker: {
+      dbOutput: {
+         filename: "MemoryReport.db"
+         overwrite: true
+      }
+   }
+   NuRandomService: {
+      endOfJobSummary: false
+      initSeedPolicy: {
+         policy: "random"
+      }
+      policy: "perEvent"
+   }
+   ParticleListAction: {
+      EnergyCut: 1e-2
+      KeepDroppedParticlesInVolumes: [
+         "volTPCActive"
+      ]
+      KeepSecondToLast: true
+      KeepTransportation: true
+      SparsifyMargin: 1.5e-2
+      SparsifyTrajectories: true
+      keepEMShowerDaughters: false
+      keepGenTrajectories: [
+         "generator"
+      ]
+      keepOnlyPrimaryFullTrajectories: false
+      service_type: "ParticleListActionService"
+      storeTrajectories: true
+   }
+   PhotonVisibilityService: {
+      Distances_exp: [
+         0,
+         25,
+         50,
+         75,
+         100,
+         125,
+         150,
+         175,
+         200,
+         225,
+         250,
+         275,
+         300,
+         325,
+         350,
+         375
+      ]
+      Distances_landau: [
+         0,
+         25,
+         50,
+         75,
+         100,
+         125,
+         150,
+         175,
+         200,
+         225,
+         250,
+         275,
+         300,
+         325,
+         350,
+         375,
+         400,
+         425,
+         450,
+         475,
+         500,
+         525,
+         550
+      ]
+      DoNotLoadLibrary: false
+      Expo_over_Landau_norm: [
+         [
+            1.49644e-2,
+            1.49644e-2,
+            3.37403e-2,
+            9.67895e-2,
+            1.52669e-1,
+            1.81732e-1,
+            2.3025e-1,
+            2.90033e-1,
+            3.38948e-1,
+            3.72986e-1,
+            4.04828e-1,
+            4.41243e-1,
+            4.41243e-1,
+            4.41243e-1,
+            4.41243e-1,
+            4.41243e-1
+         ],
+         [
+            2.52807e-2,
+            2.52807e-2,
+            6.38727e-2,
+            1.13343e-1,
+            1.65669e-1,
+            2.16794e-1,
+            2.74868e-1,
+            3.25299e-1,
+            3.8959e-1,
+            4.66117e-1,
+            5.15046e-1,
+            5.78897e-1,
+            6.21872e-1,
+            6.89713e-1,
+            7.42833e-1,
+            7.73619e-1
+         ]
+      ]
+      IncludePropTime: true
+      LibraryFile: "PhotonLibrary/PhotonLibrary-20201209.root"
+      Mapping: {
+         tool_type: "ICARUSPhotonMappingTransformations"
+      }
+      Mpv: [
+         [
+            2.73373,
+            2.73373,
+            3.599,
+            5.80141,
+            7.57883,
+            9.56959,
+            1.16047e1,
+            1.36676e1,
+            1.56126e1,
+            1.75389e1,
+            1.9492e1,
+            2.13254e1,
+            2.13254e1,
+            2.13254e1,
+            2.13254e1,
+            2.13254e1,
+            2.13254e1,
+            2.13254e1,
+            2.13254e1,
+            2.13254e1,
+            2.13254e1,
+            2.13254e1,
+            2.13254e1
+         ],
+         [
+            2.19076,
+            2.19076,
+            4.0163,
+            5.86531,
+            8.09466,
+            1.04547e1,
+            1.29261e1,
+            1.52731e1,
+            1.77939e1,
+            2.06664e1,
+            2.299e1,
+            2.57017e1,
+            2.79139e1,
+            3.09469e1,
+            3.36378e1,
+            3.61413e1,
+            3.98435e1,
+            4.21625e1,
+            4.46396e1,
+            4.65133e1,
+            4.86331e1,
+            5.06754e1,
+            5.33949e1
+         ]
+      ]
+      NX: 74
+      NY: 77
+      NZ: 394
+      Norm_over_entries: [
+         [
+            4.64837,
+            4.64837,
+            2.86581,
+            1.4143,
+            9.74871e-1,
+            7.1311e-1,
+            5.5772e-1,
+            4.61078e-1,
+            4.11807e-1,
+            3.64951e-1,
+            3.25477e-1,
+            2.97132e-1,
+            2.97132e-1,
+            2.97132e-1,
+            2.97132e-1,
+            2.97132e-1,
+            2.97132e-1,
+            2.97132e-1,
+            2.97132e-1,
+            2.97132e-1,
+            2.97132e-1,
+            2.97132e-1,
+            2.97132e-1
+         ],
+         [
+            3.43562,
+            3.43562,
+            1.61042,
+            9.81127e-1,
+            6.4465e-1,
+            4.76552e-1,
+            3.69063e-1,
+            3.10461e-1,
+            2.64819e-1,
+            2.31387e-1,
+            2.15373e-1,
+            1.99128e-1,
+            1.89638e-1,
+            1.70387e-1,
+            1.59308e-1,
+            1.51498e-1,
+            1.40134e-1,
+            1.35217e-1,
+            1.31114e-1,
+            1.29511e-1,
+            1.26329e-1,
+            1.2452e-1,
+            1.24595e-1
+         ]
+      ]
+      Slope: [
+         [
+            -1.81318e-1,
+            -1.81318e-1,
+            -1.48935e-1,
+            -1.26243e-1,
+            -1.0837e-1,
+            -8.60558e-2,
+            -7.59728e-2,
+            -7.06126e-2,
+            -6.72814e-2,
+            -6.22897e-2,
+            -5.77351e-2,
+            -5.46709e-2,
+            -5.46709e-2,
+            -5.46709e-2,
+            -5.46709e-2,
+            -5.46709e-2
+         ],
+         [
+            -1.69274e-1,
+            -1.69274e-1,
+            -1.19906e-1,
+            -9.83691e-2,
+            -7.81793e-2,
+            -6.59805e-2,
+            -5.87059e-2,
+            -5.45288e-2,
+            -5.14041e-2,
+            -4.89773e-2,
+            -4.7259e-2,
+            -4.54668e-2,
+            -4.39597e-2,
+            -4.15122e-2,
+            -3.96851e-2,
+            -3.78005e-2
+         ]
+      ]
+      UseCryoBoundary: false
+      Width: [
+         [
+            1.98303e-1,
+            1.98303e-1,
+            3.47397e-1,
+            5.62874e-1,
+            7.50881e-1,
+            9.98318e-1,
+            1.2622,
+            1.55553,
+            1.79799,
+            2.05579,
+            2.3295,
+            2.57611,
+            2.57611,
+            2.57611,
+            2.57611,
+            2.57611,
+            2.57611,
+            2.57611,
+            2.57611,
+            2.57611,
+            2.57611,
+            2.57611,
+            2.57611
+         ],
+         [
+            3.05766e-1,
+            3.05766e-1,
+            5.08544e-1,
+            7.47765e-1,
+            1.12059,
+            1.57047,
+            2.07501,
+            2.54661,
+            3.09789,
+            3.79078,
+            4.19731,
+            4.74438,
+            5.09894,
+            5.83702,
+            6.36225,
+            6.80253,
+            8.278,
+            8.717,
+            9.2568,
+            9.7239,
+            1.05865e1,
+            1.13262e1,
+            1.18423e1
+         ]
+      ]
+      XMax: -25
+      XMin: -395
+      YMax: 170
+      YMin: -215
+      ZMax: 985
+      ZMin: -985
+      angle_bin_timing_vuv: 45
+      inflexion_point_distance: 400
+      max_d: 2500
+      min_d: 25
+      step_size: 1
+      vuv_vgroup_max: 18
+      vuv_vgroup_mean: 1.35e1
+   }
+   PhysicsList: {
+      BoundaryInvokeSD: false
+      CerenkovMaxBetaChange: 10
+      CerenkovMaxNumPhotons: 100
+      CerenkovStackPhotons: false
+      DumpList: true
+      NeutronKinELimit: 0
+      NeutronTimeLimit: 0
+      PhysicsListName: "QGSP_BERT_HP"
+      ScintillationByParticleType: false
+      ScintillationStackPhotons: false
+      ScintillationTrackInfo: false
+      ScintillationTrackSecondariesFirst: false
+      Verbosity: 1
+      WLSProfile: "delta"
+      enableAbsorption: false
+      enableBoundary: false
+      enableCerenkov: false
+      enableMieHG: false
+      enableNeutronLimit: false
+      enableOptical: false
+      enableRayleigh: false
+      enableScintillation: false
+      enableStepLimit: true
+      enableWLS: false
+   }
+   PhysicsListHolder: {}
+   RandomNumberGenerator: {}
+   SignalShapingICARUSService: {
+      DeconNorm: 1
+      InitialFFTSize: 4096
+      NoiseFactVec: [
+         [
+            1.151,
+            1.151,
+            1.151,
+            1.151
+         ],
+         [
+            1.152,
+            1.152,
+            1.152,
+            1.152
+         ],
+         [
+            1.096,
+            1.096,
+            1.096,
+            1.096
+         ]
+      ]
+      PlaneForNormalization: 2
+      PrintResponses: "false"
+      ResponseTools: {
+         ResponsePlane0: {
+            Correction3D: 1
+            ElectronicsResponse: {
+               ADCPerPCAtLowestASICGain: 5500
+               ASICShapingTime: 1.3
+               FCperADCMicroS: 3.21e-2
+               Plane: 0
+               TimeOffset: 0
+               tool_type: "ElectronicsResponseBesselApprox"
+            }
+            FieldResponse: {
+               FieldResponseAmplitude: 1
+               FieldResponseFileName: "t600_response"
+               FieldResponseFileVersion: "v0.0"
+               FieldResponseHistName: "t600_response"
+               Plane: 0
+               ResponseType: 0
+               SignalType: 0
+               TimeCorrectionFactor: 1000
+               tool_type: "FieldResponse"
+            }
+            Filter: {
+               FilterFunction: "(x>0.0) ? ((1. - gaus(0)) * gaus(3)) : 0.0"
+               FilterParametersVec: [
+                  1,
+                  0,
+                  4,
+                  1,
+                  0,
+                  100
+               ]
+               FilterWidthCorrectionFactor: 1
+               Plane: 0
+               tool_type: "Filter"
+            }
+            Plane: 0
+            TimeScaleFactor: 1
+            UseEmpiricalOffsets: true
+            tool_type: "Response"
+         }
+         ResponsePlane1: {
+            Correction3D: 1
+            ElectronicsResponse: {
+               ADCPerPCAtLowestASICGain: 5500
+               ASICShapingTime: 1.3
+               FCperADCMicroS: 3.21e-2
+               Plane: 1
+               TimeOffset: 0
+               tool_type: "ElectronicsResponseBesselApprox"
+            }
+            FieldResponse: {
+               FieldResponseAmplitude: 1
+               FieldResponseFileName: "t600_response"
+               FieldResponseFileVersion: "v0.0"
+               FieldResponseHistName: "t600_response"
+               Plane: 1
+               ResponseType: 1
+               SignalType: 0
+               TimeCorrectionFactor: 1000
+               tool_type: "FieldResponse"
+            }
+            Filter: {
+               FilterFunction: "(x>0.0) ? ((1. - gaus(0)) * gaus(3)) : 0.0"
+               FilterParametersVec: [
+                  1,
+                  0,
+                  4,
+                  1,
+                  0,
+                  100
+               ]
+               FilterWidthCorrectionFactor: 1
+               Plane: 1
+               tool_type: "Filter"
+            }
+            Plane: 1
+            TimeScaleFactor: 1
+            UseEmpiricalOffsets: true
+            tool_type: "Response"
+         }
+         ResponsePlane2: {
+            Correction3D: 1
+            ElectronicsResponse: {
+               ADCPerPCAtLowestASICGain: 5500
+               ASICShapingTime: 1.3
+               FCperADCMicroS: 3.21e-2
+               Plane: 2
+               TimeOffset: 0
+               tool_type: "ElectronicsResponseBesselApprox"
+            }
+            FieldResponse: {
+               FieldResponseAmplitude: 1
+               FieldResponseFileName: "t600_response"
+               FieldResponseFileVersion: "v0.0"
+               FieldResponseHistName: "t600_response"
+               Plane: 2
+               ResponseType: 2
+               SignalType: 1
+               TimeCorrectionFactor: 1000
+               tool_type: "FieldResponse"
+            }
+            Filter: {
+               FilterFunction: "(x>0.0) ? gaus(0) : 0.0"
+               FilterParametersVec: [
+                  1,
+                  0,
+                  100
+               ]
+               FilterWidthCorrectionFactor: 1
+               Plane: 2
+               tool_type: "Filter"
+            }
+            Plane: 2
+            TimeScaleFactor: 1
+            UseEmpiricalOffsets: true
+            tool_type: "Response"
+         }
+      }
+      StoreHistograms: true
+   }
+   SpaceChargeService: {
+      EnableCalEfieldSCE: false
+      EnableCalSpatialSCE: false
+      EnableCorrSCE: false
+      EnableSimEfieldSCE: false
+      EnableSimSpatialSCE: false
+      InputFilename: "SCEoffsets/SCEoffsets_ICARUS_E500_voxelTH3.root"
+      RepresentationType: "Voxelized_TH3"
+      service_provider: "SpaceChargeServiceICARUS"
+   }
+   TFileService: {
+      fileName: "Supplemental-%ifb_%tc-%p.root"
+   }
+   TimeTracker: {
+      dbOutput: {
+         filename: "TimingReport.db"
+         overwrite: true
+      }
+      printSummary: true
+   }
+   WireReadout: {
+      Mapper: {
+         WirelessChannels: {
+            CollectionEvenPostChannels: 96
+            CollectionEvenPreChannels: 64
+            CollectionOddPostChannels: 64
+            CollectionOddPreChannels: 96
+            FirstInductionPostChannels: 96
+            FirstInductionPreChannels: 0
+            SecondInductionEvenPostChannels: 64
+            SecondInductionEvenPreChannels: 96
+            SecondInductionOddPostChannels: 96
+            SecondInductionOddPreChannels: 64
+         }
+      }
+      SortingParameters: {
+         tool_type: "WireReadoutSorterStandard"
+      }
+      service_provider: "WireReadoutICARUS"
+   }
+   message: {
+      destinations: {
+         LogErrorFile: {
+            append: false
+            categories: {
+               default: {}
+}
+            filename: "errors.log"
+            threshold: "WARNING"
+            type: "file"
+}
+         LogSeeds: {
+            append: false
+            categories: {
+               NuRandomService: {
+                  limit: -1
+               }
+               default: {
+                  limit: 0
+               }
+            }
+            filename: "randomseeds.log"
+            threshold: "INFO"
+            type: "file"
+         }
+         LogStandardOut: {
+            categories: {
+               NuRandomService: {
+                  limit: 0
+               }
+               default: {}
+}
+            threshold: "INFO"
+            type: "cout"
+}
+}
+}
+   scheduler: {
+      defaultExceptions: false
+   }
+}

--- a/cfg/pgrapher/experiment/icarus/sim.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/sim.jsonnet
@@ -20,8 +20,14 @@ function(params, tools) {
                         for n in std.range(0, nanodes-1)],
 
 
+    // Build one DepoTransform per (anode, plane, response) — 45 entries per
+    // anode (3 planes x 15 response bins).  Derive the count from
+    // tools.anodes so that callers that narrow tools.anodes to a per-TPC
+    // subset (e.g. the per-module wcls-per-tpc...jsonnet) only build the
+    // relevant slice instead of indexing past the end.  With the full 8
+    // anodes this evaluates to std.range(0, 359), matching the legacy form.
     local transformsyz = [sim.make_depotransform_withplane("depotransform-%d-"%n+tools.anodes[std.floor(n/45)].name+"-plane%d"%std.mod(std.floor(n/15),3),tools.anodes[std.floor(n/45)], [std.mod(std.floor(n/15),3)],tools.pirs[std.mod(n,15)])
-	                  for n in std.range(0, 359)],
+	                  for n in std.range(0, nanodes*45 - 1)],
 //    local transformsyz = [sim.make_depotransform_withplane("depotransform-%d-"%n+tools.anodes[std.floor(n/45)].name+"-plane%d"%std.mod(std.floor(n/15),3),tools.anodes[std.floor(n/45)], [std.mod(std.floor(n/15),3)],tools.pirs[0])
 
 
@@ -60,8 +66,8 @@ function(params, tools) {
                 toffset: 0,
                 nticks: params.sim.reframer.nticks,
             },
-	    }, nin=1, nout=1) for n in std.range(0, 359)],
-    
+	    }, nin=1, nout=1) for n in std.range(0, nanodes*45 - 1)],
+
 
     // fixme: see https://github.com/WireCell/wire-cell-gen/issues/29
     local make_noise_model = function(anode, csdb=null) {
@@ -95,6 +101,29 @@ function(params, tools) {
     local noises = [add_noise(model) for model in noise_models],
     
     local outtags = ["orig%d"%n for n in std.range(0, nanodes-1)],
+            
+    local xregions = wc.unique_list(std.flattenArrays([v.faces for v in params.det.volumes])),
+    local overlay_drifter_data = params.lar {
+                rng: wc.tn(tools.random),
+                xregions: xregions,
+                time_offset: params.sim.depo_toffset,
+
+                drift_speed: params.lar.drift_speed,
+                fluctuate: params.sim.fluctuate,
+
+                DL: params.lar.DL,
+                DT: params.lar.DT,
+                lifetime: params.lar.lifetime,
+		ar39activity: 0, // no simulated activity
+
+		// DB config
+		DBFileName: "tpc_elifetime_data",
+		DBTag: "v2r1",
+		ELifetimeCorrection: true,
+		Verbose: false,
+		TPC: 0,
+        },
+     
 
     ret : {
 
@@ -110,7 +139,7 @@ function(params, tools) {
         splusn: f.fanpipe('DepoSetFanout', self.splusn_pipelines, 'FrameFanin', "simsplusngraph", outtags),
 
         analog_pipelinesyz: [g.pipeline([depos2tracesyz[n]],
-                                        name="simanalogpipe-%d-"%n + tools.anodes[std.floor(n/45)].name) for n in std.range(0, 359)],
+                                        name="simanalogpipe-%d-"%n + tools.anodes[std.floor(n/45)].name) for n in std.range(0, nanodes*45 - 1)],
         signal_pipelinesyz: [g.pipeline([depos2tracesyz[n], reframersyz[n],  digitizers[n]],
                                       name="simsigpipe-" + tools.anodes[n].name) for n in std.range(0, nanodes-1)],
         splusn_pipelinesyz:  [g.pipeline([depos2tracesyz[n], reframersyz[n], noises[n], digitizers[n]],
@@ -119,6 +148,24 @@ function(params, tools) {
         analogyz: f.fanpipe('DepoSetFanout', self.analog_pipelinesyz, 'FrameFanin', "simanaloggraph", outtags),
         signalyz: f.fanpipe('DepoSetFanout', self.signal_pipelinesyz, 'FrameFanin', "simsignalgraph", outtags),
         splusnyz: f.fanpipe('DepoSetFanout', self.splusn_pipelinesyz, 'FrameFanin', "simsplusngraph", outtags),
+
+        drifter_data: params.lar {
+            rng: wc.tn(tools.random),
+            xregions: xregions,
+            time_offset: params.sim.depo_toffset,
+            drift_speed: params.lar.drift_speed,
+            fluctuate: params.sim.fluctuate,
+            DL: params.lar.DL,
+            DT: params.lar.DT,
+        },
+
+        // Drifter for Overlay MC
+        overlay_drifter_data: overlay_drifter_data,
+
+        overlay_drifter: g.pnode({
+            data: overlay_drifter_data,
+            type: "wclsICARUSDrifter",
+        }, nin=1, nout=1, uses=[tools.random]),
 
     } + sim,                    // tack on base for user sugar.
 }.ret

--- a/cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-yzsim-refactored.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-yzsim-refactored.jsonnet
@@ -1,0 +1,537 @@
+// Same configuration as in wcls-sim-drift-simchannel.jsonnet
+// except that this produces four instances of std::vector<RawDigits>
+// one per physics module (WW, WE, EE, EW) in ICARUS
+
+local g = import 'pgraph.jsonnet';
+local f = import 'pgrapher/common/funcs.jsonnet';
+local wc = import 'wirecell.jsonnet';
+
+local io = import 'pgrapher/common/fileio.jsonnet';
+local tools_maker = import 'pgrapher/experiment/icarus/icarus_tools.jsonnet';
+local base = import 'pgrapher/experiment/icarus/simparams.jsonnet';
+
+// load the electronics response parameters
+local er_params = [
+  {
+    gain: std.extVar('gain0')*wc.mV/wc.fC,
+    shaping: std.extVar('shaping0')*wc.us,
+  },
+
+  {
+    gain: std.extVar('gain1')*wc.mV/wc.fC,
+    shaping: std.extVar('shaping1')*wc.us,
+  },
+
+  {
+    gain: std.extVar('gain2')*wc.mV/wc.fC,
+    shaping: std.extVar('shaping2')*wc.us,
+  },
+];
+
+local params = base {
+  lar: super.lar {
+    // Longitudinal diffusion constant
+    DL: std.extVar('DL') * wc.cm2 / wc.ns,
+    // Transverse diffusion constant
+    DT: std.extVar('DT') * wc.cm2 / wc.ns,
+    // Electron lifetime
+    lifetime: std.extVar('lifetime') * wc.us,
+    // Electron drift speed, assumes a certain applied E-field
+    // drift_speed: std.extVar('driftSpeed') * wc.mm / wc.us,
+  },
+
+ files: super.files {
+   //  fields: [ std.extVar('files_fields'), ]
+
+       	fields: [          
+			"icarus_fnal_fit_ks_P0nom_P1bin0.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin1.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin2.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin3.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin4.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin5.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin6.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin7.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin8.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin9.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin10.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin11.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin12.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin13.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin14.json.bz2",	
+			"icarus_fnal_fit_ks_P0nom_P1bin15.json.bz2"]
+  },
+
+  rc_resp: if std.extVar('file_rcresp') != "" then
+  {
+    // "icarus_fnal_rc_tail.json"
+    filename: std.extVar('file_rcresp'),
+    postgain: 1.0,
+    start: 0.0,
+    tick: 0.4*wc.us,
+    nticks: 4255,
+    type: "JsonElecResponse",
+    rc_layers: 1
+  }
+  else super.rc_resp,
+
+  elec: std.mapWithIndex(function (n, eparam)
+    super.elec[n] + {
+      gain: eparam.gain,
+      shaping: eparam.shaping,
+    }, er_params),
+};
+
+local tools = tools_maker(params);
+
+local sim_maker = import 'pgrapher/experiment/icarus/sim.jsonnet';
+local sim = sim_maker(params, tools);
+
+local nanodes = std.length(tools.anodes);
+local anode_iota = std.range(0, nanodes - 1);
+
+
+local output = 'wct-sim-ideal-sig.npz';
+
+
+//local depos = g.join_sources(g.pnode({type:"DepoMerger", name:"BlipTrackJoiner"}, nin=2, nout=1),
+//                             [sim.ar39(), sim.tracks(tracklist)]);
+// local depos = sim.tracks(tracklist, step=1.0 * wc.mm);
+
+local wcls_maker = import 'pgrapher/ui/wcls/nodes.jsonnet';
+local wcls = wcls_maker(params, tools);
+//local wcls_input = {
+//  // depos: wcls.input.depos(name="", art_tag="ionization"),
+//  depos: wcls.input.depos(name='electron', art_tag='ionization'),  // default art_tag="blopper"
+//};
+
+//Haiwang DepoSetSource Implementation:
+local wcls_input = {
+	depos: wcls.input.depos(name="", art_tag="IonAndScint"),
+	deposet: g.pnode({
+        	type: 'wclsSimDepoSetSource',
+        	name: "electron",
+        	data: {
+            	model: "",
+            	scale: -1, //scale is -1 to correct a sign error in the SimDepoSource converter.
+            	art_tag: std.extVar('SimEnergyDepositLabel'), //name of upstream art producer of depos "label:instance:processName"
+            	assn_art_tag: "",
+              id_is_track: false,    // Use this for "id-is-index" in the output
+        	},
+    	}, nin=0, nout=1),
+};
+
+// Collect all the wc/ls output converters for use below.  Note the
+// "name" MUST match what is used in theh "outputers" parameter in the
+// FHiCL that loads this file.
+local mega_anode = {
+  type: 'MegaAnodePlane',
+  name: 'meganodes',
+  data: {
+    anodes_tn: [wc.tn(anode) for anode in tools.anodes],
+  },
+};
+
+// A ``duo'' anode consists of two ``splits''
+local duoanodes = [
+{
+  type: 'MegaAnodePlane',
+  name: 'duoanode%d' %n,
+  data: {
+    // anodes_tn: ["AnodePlane:anode110", "AnodePlane:anode120"],
+    anodes_tn: [wc.tn(a) for a in tools.anodes[2*n:2*(n+1)]],
+    // anodes_tn: [wc.tn(tools.anodes[2*n]), wc.tn(tools.anodes[2*n+1])],
+  }, 
+}
+for n in std.range(0,3)];
+local volname = ["EE", "EW", "WE", "WW"];
+local wcls_output = {
+  // ADC output from simulation
+  // sim_digits: wcls.output.digits(name="simdigits", tags=["orig"]),
+  sim_digits: [ 
+  g.pnode({
+    type: 'wclsFrameSaver',
+    name: 'simdigits%d' %n,
+    data: {
+      // anode: wc.tn(tools.anode),
+      anode: wc.tn(duoanodes[n]),
+      digitize: true,  // true means save as RawDigit, else recob::Wire
+      //frame_tags: ['daq%d' %n],
+      frame_tags: ['TPC%s' %volname[n]],
+      // Three options for nticks:
+      // - If nonzero, force number of ticks in output waveforms.
+      // - If zero, use whatever input data has. (default)
+      // - If -1, use value as per LS's detector properties service.
+      // nticks: params.daq.nticks,
+      // nticks: -1,
+      // chanmaskmaps: ['bad'],
+    },
+  }, nin=1, nout=1, uses=[duoanodes[n]])
+  for n in std.range(0,3)],
+
+  // The noise filtered "ADC" values.  These are truncated for
+  // art::Event but left as floats for the WCT SP.  Note, the tag
+  // "raw" is somewhat historical as the output is not equivalent to
+  // "raw data".
+  nf_digits: wcls.output.digits(name='nfdigits', tags=['raw']),
+
+  // The output of signal processing.  Note, there are two signal
+  // sets each created with its own filter.  The "gauss" one is best
+  // for charge reconstruction, the "wiener" is best for S/N
+  // separation.  Both are used in downstream WC code.
+  sp_signals: wcls.output.signals(name='spsignals', tags=['gauss', 'wiener']),
+
+  // save "threshold" from normal decon for each channel noise
+  // used in imaging
+  sp_thresholds: wcls.output.thresholds(name='spthresholds', tags=['threshold']),
+};
+
+//local deposio = io.numpy.depos(output);
+
+local overlay_drifter = std.extVar("overlay_drifter");
+local localeLiftime = [std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us];
+local drifter_data = if overlay_drifter then sim.overlay_drifter_data else sim.drifter_data;
+
+local drifters = [{
+        local xregions = wc.unique_list(std.flattenArrays([v.faces for v in params.det.volumes])),
+
+        type: if overlay_drifter then "wclsICARUSDrifter" else "Drifter",
+	name: "drifter%d" %n, //%std.floor(n/45),
+        data: params.lar + drifter_data {
+            lifetime: localeLiftime[std.floor(n/45)],
+            TPC: std.floor(n/90),
+	    charge_scale: 1 //std.mod(n,15)+1 //needs to be 1 
+        },
+    } 
+    for n in std.range(0,359)];  
+
+local setdrifters = [g.pnode({
+                     type: 'DepoSetDrifter',
+		     name: 'setdrifters%d' %n, 
+                     data: {
+		              drifter: wc.tn(drifters[n])
+			      #drifter: "Drifter"
+           		   }
+	             }, nin=1, nout=1,
+	             uses=[drifters[n]])
+                     #uses=[drifter])  
+		     for n in std.range(0,359)];
+
+local yzmap_filter = {
+    type: "YZMap", name: "yzmap_filter",
+    data: {
+        filename: 'yzmap_icarus_v3_run1.json',
+        bin_width:  10*wc.cm,
+        bin_height: 10*wc.cm,
+        yoffset: 180*wc.cm,
+        zoffset: 900*wc.cm,
+        nbinsy: 31,
+        nbinsz: 180,
+    }
+};
+
+local yzmap_gain = {
+    type: "YZMap", name: "yzmap_gain",
+    data: {
+        filename: 'yzmap_gain_icarus_v3_run1.json',
+        bin_width:  10*wc.cm,
+        bin_height: 10*wc.cm,
+        yoffset: 180*wc.cm,
+        zoffset: 900*wc.cm,
+        nbinsy: 31,
+        nbinsz: 180,
+    }
+};
+
+local scalers = [{
+        type: "Scaler",
+	name: "scaler%d" %n,
+        data: {
+                 yzmap: wc.tn(yzmap_gain),
+                 anode: wc.tn(tools.anodes[std.floor(n/45)]),
+		 plane: std.mod(std.floor(n/15),3)
+        },
+	}
+         for n in std.range(0,359)];
+
+local setscaler = [g.pnode({
+			type: 'DepoSetScaler',
+	        	name: 'setscaler%d' %n,
+            		data: {
+                	      scaler: wc.tn(scalers[n])
+           		       }
+        	  }, nin=1, nout=1,
+        	  uses=[scalers[n], yzmap_gain])
+		  for n in std.range(0,359)];
+
+
+local bagger = sim.make_bagger();
+
+
+// signal plus noise pipelines
+//local sn_pipes = sim.signal_pipelines;
+// local sn_pipes = sim.splusn_pipelines;
+local analog_pipes = sim.analog_pipelinesyz;
+
+local perfect = import 'pgrapher/experiment/icarus/chndb-base.jsonnet';
+local chndb = [{
+  type: 'OmniChannelNoiseDB',
+  name: 'ocndbperfect%d' % n,
+  data: perfect(params, tools.anodes[n], tools.field, n){dft:wc.tn(tools.dft)},
+  uses: [tools.anodes[n], tools.field, tools.dft],
+} for n in anode_iota];
+
+
+// local nf_maker = import 'pgrapher/experiment/icarus/nf.jsonnet';
+// local nf_pipes = [nf_maker(params, tools.anodes[n], chndb_pipes[n]) for n in std.range(0, std.length(tools.anodes)-1)];
+// local nf_pipes = [nf_maker(params, tools.anodes[n], chndb[n], n, name='nf%d' % n) for n in anode_iota];
+
+local sp_maker = import 'pgrapher/experiment/icarus/sp.jsonnet';
+local sp = sp_maker(params, tools);
+local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
+
+local rng = tools.random;
+local wcls_simchannel_sink_old = 
+  g.pnode({
+    type: 'wclsDepoSetSimChannelSink',
+    name: 'postdriftold',
+    data: {
+      artlabel: 'simpleSCOld',  // where to save in art::Event
+      anodes_tn: [wc.tn(anode) for anode in tools.anodes],
+      rng: wc.tn(rng),
+      tick: params.daq.tick,
+      start_time: -0.34 * wc.ms, // TriggerOffsetTPC from detectorclocks_icarus.fcl
+      readout_time: params.daq.readout_time,
+      nsigma: 3.0,
+      drift_speed: params.lar.drift_speed,
+      u_to_rp: 100 * wc.mm,
+      v_to_rp: 100 * wc.mm,
+      y_to_rp: 100 * wc.mm,
+
+      // GP: The shaping time of the electronics response (1.3us) shifts the peak
+      //     of the field response time. Eyeballing simulation times, it does this
+      //     by a bit less than the 1.3us (1us).
+      //
+      //     N.B. for future: there is likely an additional offset on the two induction
+      //     planes due to where the deconvolution precisely defines where the "peak"
+      //     of the pulse is. One may want to refine these parameters to account for that.
+      //     This perturbation shouldn't be more than a tick or two.
+      u_time_offset: std.extVar('time_offset_u') * wc.us,
+      v_time_offset: std.extVar('time_offset_v') * wc.us,
+      y_time_offset: std.extVar('time_offset_y') * wc.us,
+
+      g4_ref_time: -1500 * wc.us, // G4RefTime from detectorclocks_icarus.fcl
+      use_energy: true,
+    },
+  },nin=1, nout=1, uses=tools.anodes);
+
+local wcls_simchannel_sink =
+  [ g.pnode({
+    type: 'wclsDepoFluxWriter',
+    name: 'postdrift%d' %n,
+    data: {
+      anodes: [wc.tn(anode) for anode in tools.anodes],
+      field_response: wc.tn(tools.field),
+
+      // time binning
+      tick: params.daq.tick,
+      window_start: -340 * wc.us, // TriggerOffsetTPC from detectorclocks_icarus.fcl
+      window_duration: params.daq.readout_time,
+
+      nsigma: 3.0,
+
+      reference_time: -1500 * wc.us - self.window_start, // G4RefTime from detectorclocks_icarus.fcl less window start as per Brett Viren
+
+      smear_long: 0.0,
+      smear_tran: 0.0,
+
+      time_offsets: [std.extVar('time_offset_u') * wc.us, std.extVar('time_offset_v') * wc.us, std.extVar('time_offset_y') * wc.us],
+
+      process_planes: [std.mod(std.floor(n/15),3)],
+
+      // input from art::Event
+      sed_label: std.extVar('SimEnergyDepositLabel'),
+
+      // output to art::Event
+      simchan_label: 'simpleSC%d' %n,
+    },
+  },   nin=1, nout=1, uses=tools.anodes+[tools.field])
+       	      for n in std.range(0,359)];
+
+local nicks = ["incoTPCEE","incoTPCEW","incoTPCWE","incoTPCWW", "coheTPCEE","coheTPCEW","coheTPCWE","coheTPCWW"];
+local scale_int = std.extVar('int_noise_scale');
+local scale_coh = std.extVar('coh_noise_scale');
+local models = [
+    {
+        type: "GroupNoiseModel",
+        name: nicks[n],
+        data: {
+            // This can also be given as a JSON/Jsonnet file
+            spectra: params.files.noisegroups[n],
+            groups: params.files.wiregroups,
+            scale: if n<4 then scale_int else scale_coh,
+            nsamples: params.daq.nticks,
+            tick: params.daq.tick,
+        }
+    } for n in std.range(0,7)];
+
+local add_noise = function(model, n,t) g.pnode({
+    type: t,
+    name: "addnoise%d-" %n + model.name,
+    data: {
+        rng: wc.tn(tools.random),
+        dft: wc.tn(tools.dft),
+        model: wc.tn(model),
+        nsamples: params.daq.nticks,
+    }}, nin=1, nout=1, uses=[tools.random, tools.dft, model]);
+local noises = [add_noise(models[n], n,"IncoherentAddNoise") for n in std.range(0,3)];
+local coh_noises = [add_noise(models[n],n,"CoherentAddNoise") for n in std.range(4,7)];
+
+// local digitizer = sim.digitizer(mega_anode, name="digitizer", tag="orig");
+local digitizers = [
+    sim.digitizer(mega_anode, name="digitizer%d-" %n + mega_anode.name, tag="TPC%s"%volname[n])
+    for n in std.range(0,3)];
+
+local reframer = [
+    g.pnode({
+            type: 'Reframer',
+            name: 'reframer-%d-'%n+mega_anode.name,
+            data: {
+                anode: wc.tn(mega_anode),
+                tags: "TPC%s"%volname[n],           // ?? what do?
+                fill: 0.0,
+                tbin: params.sim.reframer.tbin, 
+                toffset: 0,
+                nticks: params.sim.reframer.nticks,
+            },
+       }, nin=1, nout=1) for n in std.range(0, 3)];
+
+local retaggers = [
+g.pnode({
+  type: 'Retagger',
+  name: 'retagger%d' %n,
+  data: {
+    // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
+    tag_rules: [{
+      // Retagger also handles "frame" and "trace" like fanin/fanout
+      // merge separately all traces like origN to orig.
+      frame: {
+        '.*': 'orig',
+      },
+      merge: {
+        'orig\\d': 'daq%d' %n,
+      },
+    }],
+  },
+}, nin=1, nout=1)
+for n in std.range(0, 3)];
+
+local frame_summers = [
+    g.pnode({
+        type: 'FrameSummerYZ',
+        name: 'framesummer%d' %n,
+        data: {
+	    multiplicity: 90
+        },
+    }, nin=90, nout=1) for n in std.range(0, 3)];
+
+local deposetfilteryz = [ g.pnode({
+            type: 'DepoSetFilterYZ',
+   	    name: 'deposetfilteryz_resp%d-'%std.mod(r,15)+'plane%d-'%std.mod(std.floor(r/15),3)+tools.anodes[std.floor(r/45)].name,
+            data: {
+	    	  yzmap: wc.tn(yzmap_filter),
+		  resp: std.mod(r,15),
+                  anode: wc.tn(tools.anodes[std.floor(r/45)]),
+		  plane: std.mod(std.floor(r/15),3)
+            	  }
+        }, nin=1, nout=1,
+        uses=tools.anodes + [yzmap_filter])
+	for r in std.range(0,359)];
+
+local util = import 'pgrapher/experiment/icarus/funcs.jsonnet';
+local outtags = ['orig%d' % n for n in std.range(0, 3)];
+
+local actpipes = [g.pipeline([reframer[n], noises[n], coh_noises[n], digitizers[n], /*retaggers[n],*/ wcls_output.sim_digits[n]], name="noise-digitizer%d" %n) for n in std.range(0,3)];
+local driftpipes = [g.pipeline([deposetfilteryz[n], setdrifters[n], setscaler[n], wcls_simchannel_sink[n]], name="depo-set-drifter%d" %n) for n in std.range(0,359)];
+local pipe_drift = util.fandrifter('DepoSetFanout', driftpipes, analog_pipes, frame_summers, actpipes, 'FrameFanin', 'fandrifter', outtags);
+local pipe_reducer = util.fansummeryz('DepoSetFanout', analog_pipes, frame_summers, actpipes, 'FrameFanin', 'fansummer', outtags);
+
+// local retagger = g.pnode({
+//   type: 'Retagger',
+//   data: {
+//     // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
+//     tag_rules: [{
+//       // Retagger also handles "frame" and "trace" like fanin/fanout
+//       // merge separately all traces like origN to orig.
+//       frame: {
+//         '.*': 'orig',
+//       },
+//       merge: {
+//         'orig\\d': 'daq',
+//       },
+//     }],
+//   },
+// }, nin=1, nout=1);
+
+//local frameio = io.numpy.frames(output);
+// sim.frame_sink is g.pnode({type:"DumpFrames"}, ...) — its inode has no
+// 'name' field, so the wrapper's lazy `name: prune_array([..., inode.name, ""])[0]`
+// throws "Field does not exist: name" the first time anything forces it.
+local sink = g.pnode({ type: 'DumpFrames', name: 'sinkdump' }, nin=1, nout=0);
+
+
+
+// local graph = g.pipeline([wcls_input.depos, drifter,  wcls_simchannel_sink.simchannels, bagger, pipe_reducer, retagger, wcls_output.sim_digits, sink]);
+//local graph = g.pipeline([wcls_input.depos, drifter,  wcls_simchannel_sink, bagger, pipe_reducer, sink]);
+//local graph = g.pipeline([wcls_input.deposet, setdrifter, wcls_simchannel_sink_old, wcls_simchannel_sink, pipe_reducer, sink]);
+
+local graph = g.pipeline([wcls_input.deposet,pipe_drift, sink]);
+
+local app = {
+  type: 'Pgrapher',
+  data: {
+    edges: g.edges(graph),
+  },
+};
+
+
+// Finally, the configuration sequence which is emitted.
+
+// Replacement for g.uses(graph).  The library version (pgraph.popuses +
+// wc.unique_list) re-expands shared sub-DAGs every time they're encountered
+// and then dedups via O(N^2) deep-equality; with the 360-element fan-out
+// here that grows to many minutes.  This DFS post-order visits each unique
+// inode exactly once (memoized by "type:name") and emits children before
+// parents, matching popuses' ordering -- which downstream WCT relies on
+// (e.g. WireSchemaFile must configure before AnodePlanes that reference it).
+// Pnodes (g.pipeline/g.pnode/g.intern wrappers) are scaffolding whose names
+// can collide (fandrifter creates fanout/fanin/intern all named 'fandrifter'),
+// so we always traverse them and never dedup them.  The pgraph is acyclic
+// by design, so unconditional traversal terminates.
+local key_of(x) = if std.objectHas(x, 'name') && x.name != ''
+                  then x.type + ':' + x.name
+                  else x.type;
+local strip_uses(x) = { [k]: x[k] for k in std.objectFields(x) if k != 'uses' };
+
+local visit(node, state) =
+  if node.type == 'Pnode' then
+    if std.objectHas(node, 'uses')
+    then std.foldl(function(s, c) visit(c, s), node.uses, state)
+    else state
+  else
+    local k = key_of(node);
+    if std.objectHas(state.seen, k) then state
+    else
+      local after_children =
+        if std.objectHas(node, 'uses')
+        then std.foldl(function(s, c) visit(c, s), node.uses, state)
+        else state;
+      {
+        seen: after_children.seen { [k]: true },
+        result: after_children.result + [strip_uses(node)],
+      };
+
+local resolve_uses_unique(roots) =
+  std.foldl(function(s, n) visit(n, s), roots, { seen: {}, result: [] }).result;
+
+resolve_uses_unique(graph.uses) + [app]

--- a/cfg/pgrapher/experiment/icarus/wcls-per-tpc-sim-drift-simchannel-yzsim.jsonnet
+++ b/cfg/pgrapher/experiment/icarus/wcls-per-tpc-sim-drift-simchannel-yzsim.jsonnet
@@ -1,0 +1,418 @@
+// Per-TPC variant of wcls-multitpc-sim-drift-simchannel-yzsim-refactored.jsonnet.
+//
+// Reads `tpc_idx` (0..3) from an external variable.  Builds only the slice of
+// the graph that belongs to that one TPC by narrowing `tools.anodes` to the
+// per-TPC two-element subset and letting sim_maker scope its derived per-
+// anode pipelines (transformsyz, analog_pipelinesyz, etc.) accordingly.
+//
+// Designed to be driven by 4 separate `WireCellToolkit` art modules, one per
+// TPC, so each module's `WCLS_tool::process()` flushes its TPC's frame to the
+// art Event before the next module starts and the float SimpleTraces can be
+// reclaimed.
+//
+// Per-instance component names that need to be unique across the 4 modules
+// (Pgrapher, fanout, summer, actpipe, FrameSaver, etc.) carry `%d %tpc_idx`.
+// The shared heavy components (PIR, FieldResponse, AnodePlane, DFT) stay
+// singletons across modules - WCT's NamedFactory de-duplicates them by name
+// and their `configure()` is now idempotent (PIR's `m_bywire`/`m_ir` are
+// cleared at the top of `build_responses()`).
+//
+// Instance names that show up in the art Event are kept identical to the
+// single-module setup (`simdigits<tpc_idx>` and `simpleSC<n>` with global n in
+// [tpc_idx*90, tpc_idx*90+90)).
+
+local g = import 'pgraph.jsonnet';
+local f = import 'pgrapher/common/funcs.jsonnet';
+local wc = import 'wirecell.jsonnet';
+
+local io = import 'pgrapher/common/fileio.jsonnet';
+local tools_maker = import 'pgrapher/experiment/icarus/icarus_tools.jsonnet';
+local base = import 'pgrapher/experiment/icarus/simparams.jsonnet';
+
+local er_params = [
+  { gain: std.extVar('gain0')*wc.mV/wc.fC, shaping: std.extVar('shaping0')*wc.us },
+  { gain: std.extVar('gain1')*wc.mV/wc.fC, shaping: std.extVar('shaping1')*wc.us },
+  { gain: std.extVar('gain2')*wc.mV/wc.fC, shaping: std.extVar('shaping2')*wc.us },
+];
+
+local params = base {
+  lar: super.lar {
+    DL: std.extVar('DL') * wc.cm2 / wc.ns,
+    DT: std.extVar('DT') * wc.cm2 / wc.ns,
+    lifetime: std.extVar('lifetime') * wc.us,
+  },
+  files: super.files {
+    fields: [
+      "icarus_fnal_fit_ks_P0nom_P1bin0.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin1.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin2.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin3.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin4.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin5.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin6.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin7.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin8.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin9.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin10.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin11.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin12.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin13.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin14.json.bz2",
+      "icarus_fnal_fit_ks_P0nom_P1bin15.json.bz2",
+    ],
+  },
+  rc_resp: if std.extVar('file_rcresp') != "" then {
+    filename: std.extVar('file_rcresp'),
+    postgain: 1.0,
+    start: 0.0,
+    tick: 0.4*wc.us,
+    nticks: 4255,
+    type: "JsonElecResponse",
+    rc_layers: 1,
+  } else super.rc_resp,
+  elec: std.mapWithIndex(function (n, eparam)
+    super.elec[n] + { gain: eparam.gain, shaping: eparam.shaping }, er_params),
+};
+
+// ---------------------------------------------------------------------------
+// Per-TPC selection.
+// tools_all is the full 8-anode tools object; `tools` is the same object with
+// anodes narrowed to this TPC's pair.  sim_maker then builds depotransforms
+// and analog pipelines only for those anodes (×45 per anode = 90 entries).
+// ---------------------------------------------------------------------------
+local tpc_idx = std.parseInt(std.extVar('tpc_idx'));
+local apa_lo = tpc_idx * 2;     // 2 anodes per TPC
+local local_iota = std.range(0, 89);  // 90 per-anode-plane-response branches
+local volname = ["EE", "EW", "WE", "WW"];
+
+local tools_all = tools_maker(params);
+local tools = tools_all { anodes: tools_all.anodes[apa_lo : apa_lo + 2] };
+
+local sim_maker = import 'pgrapher/experiment/icarus/sim.jsonnet';
+local sim = sim_maker(params, tools);   // analog_pipelinesyz has 90 entries
+
+// ---------------------------------------------------------------------------
+// Input: depo source from art Event (identical across all 4 per-TPC modules)
+// ---------------------------------------------------------------------------
+local wcls_maker = import 'pgrapher/ui/wcls/nodes.jsonnet';
+local wcls = wcls_maker(params, tools);
+local wcls_input = {
+  deposet: g.pnode({
+    type: 'wclsSimDepoSetSource',
+    name: "electron",
+    data: {
+      model: "",
+      scale: -1,
+      art_tag: std.extVar('SimEnergyDepositLabel'),
+      assn_art_tag: "",
+      id_is_track: false,
+    },
+  }, nin=0, nout=1),
+};
+
+// ---------------------------------------------------------------------------
+// MegaAnode / DuoAnode for this TPC.  `mega_anode` here is a *per-TPC*
+// MegaAnodePlane (not the shared 8-anode one) - it covers exactly the two
+// anodes this TPC processes.
+// ---------------------------------------------------------------------------
+local mega_anode = {
+  type: 'MegaAnodePlane',
+  name: 'meganodes%d' % tpc_idx,
+  data: { anodes_tn: [wc.tn(a) for a in tools.anodes] },
+};
+
+// duoanode is here for compatibility with wclsFrameSaver, which also takes
+// this TPC's pair of anodes.
+local duoanode = mega_anode;
+
+// ---------------------------------------------------------------------------
+// Output: this TPC's RawDigit saver (instance name stays simdigits<tpc_idx>)
+// ---------------------------------------------------------------------------
+local sim_digits = g.pnode({
+  type: 'wclsFrameSaver',
+  name: 'simdigits%d' % tpc_idx,
+  data: {
+    anode: wc.tn(duoanode),
+    digitize: true,
+    frame_tags: ['TPC%s' % volname[tpc_idx]],
+  },
+}, nin=1, nout=1, uses=[duoanode]);
+
+// ---------------------------------------------------------------------------
+// Helpers: global index for the n-th branch of this TPC.
+// ---------------------------------------------------------------------------
+local n_lo = tpc_idx * 90;
+local glob(i) = n_lo + i;
+
+// ---------------------------------------------------------------------------
+// 90 drifters / scalers / simchannel sinks for this TPC.
+// Instance names keep the global numbering (n_lo..n_hi-1) so SimChannel
+// product instances match the single-module reference run.
+// ---------------------------------------------------------------------------
+local overlay_drifter = std.extVar("overlay_drifter");
+local localeLiftime = [std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us,std.extVar('lifetime') * wc.us];
+local drifter_data = if overlay_drifter then sim.overlay_drifter_data else sim.drifter_data;
+
+local drifters = [{
+  type: if overlay_drifter then "wclsICARUSDrifter" else "Drifter",
+  name: "drifter%d" % glob(i),
+  data: params.lar + drifter_data {
+    lifetime: localeLiftime[std.floor(glob(i)/45)],
+    TPC: tpc_idx,
+    charge_scale: 1,
+  },
+} for i in local_iota];
+
+local setdrifters = [g.pnode({
+  type: 'DepoSetDrifter',
+  name: 'setdrifters%d' % glob(i),
+  data: { drifter: wc.tn(drifters[i]) },
+}, nin=1, nout=1, uses=[drifters[i]]) for i in local_iota];
+
+local yzmap_filter = {
+  type: "YZMap", name: "yzmap_filter",
+  data: {
+    filename: 'yzmap_icarus_v3_run1.json',
+    bin_width: 10*wc.cm, bin_height: 10*wc.cm,
+    yoffset: 180*wc.cm, zoffset: 900*wc.cm,
+    nbinsy: 31, nbinsz: 180,
+  },
+};
+
+local yzmap_gain = {
+  type: "YZMap", name: "yzmap_gain",
+  data: {
+    filename: 'yzmap_gain_icarus_v3_run1.json',
+    bin_width: 10*wc.cm, bin_height: 10*wc.cm,
+    yoffset: 180*wc.cm, zoffset: 900*wc.cm,
+    nbinsy: 31, nbinsz: 180,
+  },
+};
+
+local scalers = [{
+  type: "Scaler",
+  name: "scaler%d" % glob(i),
+  data: {
+    yzmap: wc.tn(yzmap_gain),
+    anode: wc.tn(tools.anodes[std.floor(i/45)]),
+    plane: std.mod(std.floor(i/15), 3),
+  },
+} for i in local_iota];
+
+local setscaler = [g.pnode({
+  type: 'DepoSetScaler',
+  name: 'setscaler%d' % glob(i),
+  data: { scaler: wc.tn(scalers[i]) },
+}, nin=1, nout=1, uses=[scalers[i], yzmap_gain]) for i in local_iota];
+
+local wcls_simchannel_sink = [g.pnode({
+  type: 'wclsDepoFluxWriter',
+  name: 'postdrift%d' % glob(i),
+  data: {
+    anodes: [wc.tn(a) for a in tools.anodes],
+    field_response: wc.tn(tools.field),
+    tick: params.daq.tick,
+    window_start: -340 * wc.us,
+    window_duration: params.daq.readout_time,
+    nsigma: 3.0,
+    reference_time: -1500 * wc.us - self.window_start,
+    smear_long: 0.0,
+    smear_tran: 0.0,
+    time_offsets: [
+      std.extVar('time_offset_u') * wc.us,
+      std.extVar('time_offset_v') * wc.us,
+      std.extVar('time_offset_y') * wc.us,
+    ],
+    process_planes: [std.mod(std.floor(i/15), 3)],
+    sed_label: std.extVar('SimEnergyDepositLabel'),
+    simchan_label: 'simpleSC%d' % glob(i),
+  },
+}, nin=1, nout=1, uses=tools.anodes + [tools.field]) for i in local_iota];
+
+local deposetfilteryz = [g.pnode({
+  type: 'DepoSetFilterYZ',
+  name: 'deposetfilteryz_resp%d-plane%d-%s' % [
+    std.mod(i, 15),
+    std.mod(std.floor(i/15), 3),
+    tools.anodes[std.floor(i/45)].name,
+  ],
+  data: {
+    yzmap: wc.tn(yzmap_filter),
+    resp: std.mod(i, 15),
+    anode: wc.tn(tools.anodes[std.floor(i/45)]),
+    plane: std.mod(std.floor(i/15), 3),
+  },
+}, nin=1, nout=1, uses=tools.anodes + [yzmap_filter]) for i in local_iota];
+
+// ---------------------------------------------------------------------------
+// 90 analog pipelines for this TPC, sourced from the narrowed sim object.
+// ---------------------------------------------------------------------------
+local sigpipes = sim.analog_pipelinesyz;
+assert std.length(sigpipes) == 90 :
+       "expected 90 analog pipelines for one TPC, got %d" % std.length(sigpipes);
+
+// ---------------------------------------------------------------------------
+// 1 FrameSummerYZ for this TPC (sums 90 → 1)
+// ---------------------------------------------------------------------------
+local frame_summer = g.pnode({
+  type: 'FrameSummerYZ',
+  name: 'framesummer%d' % tpc_idx,
+  data: { multiplicity: 90 },
+}, nin=90, nout=1);
+
+// ---------------------------------------------------------------------------
+// Noise + digitizer for this TPC (one of each)
+// ---------------------------------------------------------------------------
+local nicks = ["incoTPCEE","incoTPCEW","incoTPCWE","incoTPCWW",
+               "coheTPCEE","coheTPCEW","coheTPCWE","coheTPCWW"];
+local scale_int = std.extVar('int_noise_scale');
+local scale_coh = std.extVar('coh_noise_scale');
+
+local inco_model = {
+  type: "GroupNoiseModel",
+  name: nicks[tpc_idx],
+  data: {
+    spectra: params.files.noisegroups[tpc_idx],
+    groups: params.files.wiregroups,
+    scale: scale_int,
+    nsamples: params.daq.nticks,
+    tick: params.daq.tick,
+  },
+};
+
+local cohe_model = {
+  type: "GroupNoiseModel",
+  name: nicks[tpc_idx + 4],
+  data: {
+    spectra: params.files.noisegroups[tpc_idx + 4],
+    groups: params.files.wiregroups,
+    scale: scale_coh,
+    nsamples: params.daq.nticks,
+    tick: params.daq.tick,
+  },
+};
+
+local add_noise_node = function(model, t) g.pnode({
+  type: t,
+  name: "addnoise%d-" % tpc_idx + model.name,
+  data: {
+    rng: wc.tn(tools.random),
+    dft: wc.tn(tools.dft),
+    model: wc.tn(model),
+    nsamples: params.daq.nticks,
+  },
+}, nin=1, nout=1, uses=[tools.random, tools.dft, model]);
+
+local inco_noise = add_noise_node(inco_model, "IncoherentAddNoise");
+local cohe_noise = add_noise_node(cohe_model, "CoherentAddNoise");
+
+local digitizer = sim.digitizer(mega_anode,
+                                name="digitizer%d-" % tpc_idx + mega_anode.name,
+                                tag="TPC%s" % volname[tpc_idx]);
+
+local reframer = g.pnode({
+  type: 'Reframer',
+  name: 'reframer-%d-' % tpc_idx + mega_anode.name,
+  data: {
+    anode: wc.tn(mega_anode),
+    tags: "TPC%s" % volname[tpc_idx],
+    fill: 0.0,
+    tbin: params.sim.reframer.tbin,
+    toffset: 0,
+    nticks: params.sim.reframer.nticks,
+  },
+}, nin=1, nout=1);
+
+local actpipe = g.pipeline(
+  [reframer, inco_noise, cohe_noise, digitizer, sim_digits],
+  name="noise-digitizer%d" % tpc_idx);
+
+// ---------------------------------------------------------------------------
+// Drift-side pipelines: one per anode/plane (filter → drifter → scaler → simchan-sink)
+// ---------------------------------------------------------------------------
+local driftpipes = [g.pipeline(
+  [deposetfilteryz[i], setdrifters[i], setscaler[i], wcls_simchannel_sink[i]],
+  name="depo-set-drifter%d" % glob(i)) for i in local_iota];
+
+// ---------------------------------------------------------------------------
+// Top-level per-TPC topology:
+//   wcls_input.deposet
+//      → fanout (1 → 90)
+//      → driftpipes[i]  (90×; each ends in simchan-sink which writes to art)
+//      → sigpipes[i]    (90× DepoTransform → analog frame)
+//      → frame_summer   (90 → 1)
+//      → actpipe        (reframer → noise → cohe-noise → digitizer → wclsFrameSaver)
+//      → final DumpFrames sink
+// ---------------------------------------------------------------------------
+local fanout = g.pnode({
+  type: 'DepoSetFanout',
+  name: 'fandrifter%d' % tpc_idx,
+  data: { multiplicity: 90, tag_rules: [] },
+}, nin=1, nout=90);
+
+local actpipe_sink = g.pnode(
+  { type: 'DumpFrames', name: 'actpipe%d-dump' % tpc_idx },
+  nin=1, nout=0);
+
+local drift = g.intern(
+  innodes=driftpipes,
+  outnodes=[actpipe],
+  centernodes=sigpipes + [frame_summer],
+  edges=
+    [g.edge(driftpipes[i], sigpipes[i]) for i in local_iota] +
+    [g.edge(sigpipes[i], frame_summer, 0, i) for i in local_iota] +
+    [g.edge(frame_summer, actpipe)],
+  name='drift-tpc%d' % tpc_idx);
+
+local fandrifter = g.intern(
+  innodes=[fanout],
+  outnodes=[actpipe_sink],
+  centernodes=[drift],
+  edges=
+    [g.edge(fanout, driftpipes[i], i, 0) for i in local_iota] +
+    [g.edge(drift, actpipe_sink, 0, 0)],
+  name='fandrifter%d-top' % tpc_idx);
+
+local graph = g.pipeline([wcls_input.deposet, fandrifter]);
+
+// ---------------------------------------------------------------------------
+// Per-TPC Pgrapher name.  WCT's NamedFactory is a singleton across art
+// modules; naming per-TPC keeps each module's graph isolated.  The fcl's
+// `apps:` for daq<k> must reference "Pgrapher:pgrapher<k>" to match.
+// ---------------------------------------------------------------------------
+local app = {
+  type: 'Pgrapher',
+  name: 'pgrapher%d' % tpc_idx,
+  data: { edges: g.edges(graph) },
+};
+
+// ---------------------------------------------------------------------------
+// Memoized DFS post-order for graph.uses (same as the upstream jsonnet).
+// ---------------------------------------------------------------------------
+local key_of(x) = if std.objectHas(x, 'name') && x.name != ''
+                  then x.type + ':' + x.name
+                  else x.type;
+local strip_uses(x) = { [k]: x[k] for k in std.objectFields(x) if k != 'uses' };
+
+local visit(node, state) =
+  if node.type == 'Pnode' then
+    if std.objectHas(node, 'uses')
+    then std.foldl(function(s, c) visit(c, s), node.uses, state)
+    else state
+  else
+    local k = key_of(node);
+    if std.objectHas(state.seen, k) then state
+    else
+      local after_children =
+        if std.objectHas(node, 'uses')
+        then std.foldl(function(s, c) visit(c, s), node.uses, state)
+        else state;
+      {
+        seen: after_children.seen { [k]: true },
+        result: after_children.result + [strip_uses(node)],
+      };
+
+local resolve_uses_unique(roots) =
+  std.foldl(function(s, n) visit(n, s), roots, { seen: {}, result: [] }).result;
+
+resolve_uses_unique(graph.uses) + [app]

--- a/gen/src/DepoSetFilterYZ.cxx
+++ b/gen/src/DepoSetFilterYZ.cxx
@@ -42,6 +42,11 @@ void DepoSetFilterYZ::configure(const WireCell::Configuration& cfg)
   if (anode == nullptr) {
     THROW(ValueError() << errmsg{"DepoSetFilterYZ: anode is a nullptr"});
   }
+  // Idempotent under repeated configure() (defensive: each instance is
+  // currently configured only once in normal usage, but a shared instance
+  // across multiple Main::initialize() calls would otherwise accumulate
+  // duplicate boxes).
+  m_boxes.clear();
   for (auto face : anode->faces()) {
     m_boxes.push_back(face->sensitive());
   }

--- a/gen/src/PlaneImpactResponse.cxx
+++ b/gen/src/PlaneImpactResponse.cxx
@@ -141,6 +141,14 @@ spectrum_resize(const Waveform::compseq_t& spec, size_t newsize, double norm)
 
 void Gen::PlaneImpactResponse::build_responses()
 {
+    // Make this method idempotent under repeated configure(): m_ir and
+    // m_bywire are appended to in the loops below, so if the same PIR
+    // instance is reconfigured (e.g. one shared by multiple WireCellToolkit
+    // art modules) the per-wire and per-impact-response indexing arrays would
+    // grow without bound and PIR::closest() would return mismatched data.
+    m_ir.clear();
+    m_bywire.clear();
+
     auto dft = Factory::find_tn<IDFT>(m_dftname);
 
     auto ifr = Factory::find_tn<IFieldResponse>(m_frname);

--- a/gen/src/Scaler.cxx
+++ b/gen/src/Scaler.cxx
@@ -48,6 +48,8 @@ void Gen::Scaler::configure(const WireCell::Configuration& cfg)
   if (anode == nullptr) {
     THROW(ValueError() << errmsg{"Scaler: anode is a nullptr"});
   }
+  // Idempotent under repeated configure() (defensive).
+  m_boxes.clear();
   for (auto face : anode->faces()) {
     m_boxes.push_back(face->sensitive());
   }

--- a/gpvm/configure-ssi-clang.sh
+++ b/gpvm/configure-ssi-clang.sh
@@ -24,4 +24,4 @@ env CC=clang CXX=clang++ FC=gfortran \
 --with-grpc-lib="$GRPC_LIB" \
 --with-triton-include="$TRITON_INC" \
 --with-triton-lib="$TRITON_LIB" \
---prefix=/exp/dune/app/users/$USER/opt
+--prefix=/exp/$CURRENT_EXPERIMENT/app/users/$USER/opt

--- a/gpvm/configure-ssi-gcc.sh
+++ b/gpvm/configure-ssi-gcc.sh
@@ -25,4 +25,4 @@ env CC=gcc CXX=g++ FC=gfortran \
 --with-triton-include="$TRITON_INC" \
 --with-triton-lib="$TRITON_LIB" \
 --with-libtorch="$LIBTORCH_FQ_DIR/" --with-libtorch-libs torch,torch_cpu,c10 \
---prefix=/exp/dune/app/users/$USER/opt
+--prefix=/exp/$CURRENT_EXPERIMENT/app/users/$USER/opt

--- a/util/inc/WireCellUtil/ConfigManager.h
+++ b/util/inc/WireCellUtil/ConfigManager.h
@@ -25,6 +25,10 @@ namespace WireCell {
         ~ConfigManager();
 
         /// Extend current list of configuration objects with more.
+        /// Pass by value (kept for ABI compatibility with pre-built binaries
+        /// such as cvmfs libWireCellApps.so); the body consumes `more` via
+        /// per-entry std::move into m_top, so new callers should pass an
+        /// rvalue (e.g. std::move(cfg)) to skip the caller-side deep-copy.
         void extend(Configuration more);
 
         // Add a fully-built configurable configuration for an instance, return its index

--- a/util/inc/WireCellUtil/ConfigManager.h
+++ b/util/inc/WireCellUtil/ConfigManager.h
@@ -52,6 +52,13 @@ namespace WireCell {
         /// Remove configuration at given index and return it.
         Configuration pop(int ind);
 
+        /// Drop the bulk "data" sub-tree from every top-level entry, retaining
+        /// only "type" and "name".  Useful after every IConfigurable has been
+        /// constructed and configured: the resident Json::Value tree (which
+        /// can be multiple GB for ICARUS-scale configs) is no longer needed
+        /// for downstream operation since finalize() only consults type/name.
+        void clear_data();
+
         /// Return a list of all known configurables
         typedef std::pair<std::string, std::string> ClassInstance;
         std::vector<ClassInstance> configurables() const;

--- a/util/inc/WireCellUtil/ConfigManager.h
+++ b/util/inc/WireCellUtil/ConfigManager.h
@@ -34,7 +34,7 @@ namespace WireCell {
         int add(Configuration& data, const std::string& type, const std::string& name = "");
 
         /// Return top-level, aggregate configuration
-        Configuration all() const { return m_top; }
+        const Configuration& all() const { return m_top; }
 
         Configuration at(int index) const;
 

--- a/util/inc/WireCellUtil/Configuration.h
+++ b/util/inc/WireCellUtil/Configuration.h
@@ -139,7 +139,7 @@ namespace WireCell {
 
 
     /// Follow a dot.separated.path and return the branch there.
-    Configuration branch(Configuration cfg, const std::string& dotpath);
+    Configuration branch(const Configuration& cfg, const std::string& dotpath);
 
     /// Merge dictionary b into a, return a
     Configuration update(Configuration& a, Configuration& b);
@@ -150,9 +150,9 @@ namespace WireCell {
 
     /// Return dictionary in given list if it value at dotpath matches
     template <typename T>
-    Configuration find(Configuration& lst, const std::string& dotpath, const T& val)
+    Configuration find(const Configuration& lst, const std::string& dotpath, const T& val)
     {
-        for (auto ent : lst) {
+        for (const auto& ent : lst) {
             auto maybe = branch(ent, dotpath);
             if (maybe.isNull()) {
                 continue;
@@ -166,7 +166,7 @@ namespace WireCell {
 
     /// Get value in configuration at the dotted path from or return default.
     template <typename T>
-    T get(Configuration cfg, const std::string& dotpath, const T& def = T())
+    T get(const Configuration& cfg, const std::string& dotpath, const T& def = T())
     {
         return convert(branch(cfg, dotpath), def);
     }

--- a/util/src/ConfigManager.cxx
+++ b/util/src/ConfigManager.cxx
@@ -26,18 +26,24 @@ void ConfigManager::extend(Configuration more)
         by_tn[get<string>(c, "type") + "\t" + get<string>(c, "name")] = i;
     }
 
-    for (const auto& one : more) {
-        const std::string key = get<string>(one, "type") + "\t" + get<string>(one, "name");
+    // We own `more` (by-value parameter): move each entry into m_top instead
+    // of deep-copying.  Read type/name into locals first because we may move
+    // `one` afterwards.  Callers that std::move()-in their argument also skip
+    // the caller-side deep-copy at the call boundary.
+    for (auto& one : more) {
+        const std::string type = get<string>(one, "type");
+        const std::string name = get<string>(one, "name");
+        const std::string key = type + "\t" + name;
         auto it = by_tn.find(key);
         if (it == by_tn.end()) {
             const int ind = m_top.size();
-            m_top[ind] = one;
+            m_top[ind] = std::move(one);
             by_tn[key] = ind;
         }
         else {
             spdlog::warn("ConfigManager::extend() overwriting type=\"{}\" name=\"{}\"",
-                         get<string>(one, "type"), get<string>(one, "name"));
-            m_top[it->second] = one;
+                         type, name);
+            m_top[it->second] = std::move(one);
         }
     }
 }
@@ -106,16 +112,8 @@ Configuration ConfigManager::pop(int ind)
         return Configuration();
     }
     Configuration ret;
-    Configuration reduced(Json::arrayValue);
-    int siz = size();
-    for (int i = 0; i < siz; ++i) {
-        if (i == ind) {
-            ret = m_top[i];
-        }
-        else {
-            reduced.append(m_top[i]);
-        }
-    }
-    m_top = reduced;
+    // In-place removal via jsoncpp; avoids cloning every non-popped entry into
+    // a fresh `reduced` array and then re-assigning that array back to m_top.
+    m_top.removeIndex(static_cast<Json::ArrayIndex>(ind), &ret);
     return ret;
 }

--- a/util/src/ConfigManager.cxx
+++ b/util/src/ConfigManager.cxx
@@ -2,6 +2,8 @@
 #include "WireCellUtil/NamedFactory.h"
 #include "WireCellUtil/Logging.h"
 
+#include <unordered_map>
+
 using namespace std;
 using namespace WireCell;
 
@@ -14,10 +16,29 @@ ConfigManager::~ConfigManager() {}
 
 void ConfigManager::extend(Configuration more)
 {
-    // m_top = append(m_top, more);
+    // O(N+M) instead of O(N*M): build an index map of existing entries once,
+    // then probe per new entry.  Bulk loads of large configs (thousands of
+    // entries) used to scale quadratically through add()->index() linear scan.
+    std::unordered_map<std::string, int> by_tn;
+    by_tn.reserve(m_top.size() + more.size());
+    for (int i = 0; i < static_cast<int>(m_top.size()); ++i) {
+        const auto& c = m_top[i];
+        by_tn[get<string>(c, "type") + "\t" + get<string>(c, "name")] = i;
+    }
 
     for (auto one : more) {
-        add(one);
+        const std::string key = get<string>(one, "type") + "\t" + get<string>(one, "name");
+        auto it = by_tn.find(key);
+        if (it == by_tn.end()) {
+            const int ind = m_top.size();
+            m_top[ind] = one;
+            by_tn[key] = ind;
+        }
+        else {
+            spdlog::warn("ConfigManager::extend() overwriting type=\"{}\" name=\"{}\"",
+                         get<string>(one, "type"), get<string>(one, "name"));
+            m_top[it->second] = one;
+        }
     }
 }
 

--- a/util/src/ConfigManager.cxx
+++ b/util/src/ConfigManager.cxx
@@ -117,3 +117,15 @@ Configuration ConfigManager::pop(int ind)
     m_top.removeIndex(static_cast<Json::ArrayIndex>(ind), &ret);
     return ret;
 }
+
+void ConfigManager::clear_data()
+{
+    // For each top-level entry, drop its "data" sub-tree.  finalize() only
+    // looks at "type" and "name" so the bulk payload can be released after
+    // configure() has run.
+    for (auto& c : m_top) {
+        if (c.isObject()) {
+            c.removeMember("data");
+        }
+    }
+}

--- a/util/src/ConfigManager.cxx
+++ b/util/src/ConfigManager.cxx
@@ -26,7 +26,7 @@ void ConfigManager::extend(Configuration more)
         by_tn[get<string>(c, "type") + "\t" + get<string>(c, "name")] = i;
     }
 
-    for (auto one : more) {
+    for (const auto& one : more) {
         const std::string key = get<string>(one, "type") + "\t" + get<string>(one, "name");
         auto it = by_tn.find(key);
         if (it == by_tn.end()) {
@@ -45,7 +45,7 @@ void ConfigManager::extend(Configuration more)
 int ConfigManager::index(const std::string& type, const std::string& name) const
 {
     int ind = -1;
-    for (auto c : m_top) {
+    for (const auto& c : m_top) {
         ++ind;
         if (get<string>(c, "type") != type) {
             continue;

--- a/util/src/Configuration.cxx
+++ b/util/src/Configuration.cxx
@@ -5,14 +5,32 @@
 using namespace WireCell;
 using namespace std;
 
-WireCell::Configuration WireCell::branch(WireCell::Configuration cfg, const std::string& dotpath)
+WireCell::Configuration WireCell::branch(const WireCell::Configuration& cfg, const std::string& dotpath)
 {
     std::vector<std::string> path;
     boost::algorithm::split(path, dotpath, boost::algorithm::is_any_of("."));
-    for (auto name : path) {
-        cfg = cfg[name];
+    const WireCell::Configuration* cur = &cfg;
+    for (const auto& name : path) {
+        cur = &((*cur)[name]);
     }
-    return cfg;
+    return *cur;
+}
+
+// ABI-compatibility shim for binaries (e.g. libWireCellLarsoft.so on cvmfs)
+// compiled against the older by-value branch() signature. Defined inside a
+// namespace block so the qualified definition is a declaration too; not
+// re-exposed in the header, so new code keeps using the const-ref overload.
+namespace WireCell {
+    Configuration branch(Configuration cfg, const std::string& dotpath)
+    {
+        std::vector<std::string> path;
+        boost::algorithm::split(path, dotpath, boost::algorithm::is_any_of("."));
+        const Configuration* cur = &cfg;
+        for (const auto& name : path) {
+            cur = &((*cur)[name]);
+        }
+        return *cur;
+    }
 }
 
 // http://stackoverflow.com/a/23860017

--- a/util/src/Persist.cxx
+++ b/util/src/Persist.cxx
@@ -17,6 +17,8 @@
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <cstring>
+#include <memory>
 
 // see #239 for why this is here.
 extern "C" {
@@ -245,12 +247,20 @@ Json::Value WireCell::Persist::loads(const std::string& text,
     return parser.loads(text);
 }
 
-// bundles few lines into function to avoid some copy-paste
+// Parse JSON text directly via CharReader, avoiding the stringstream/stringbuf
+// pipeline that used to materialize 2-3 extra copies of the input text for
+// large configurations.
 Json::Value WireCell::Persist::json2object(const std::string& text)
 {
     Json::Value res;
-    stringstream ss(text);
-    ss >> res;
+    Json::CharReaderBuilder builder;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    std::string errs;
+    const char* begin = text.data();
+    const char* end = begin + text.size();
+    if (!reader->parse(begin, end, &res, &errs)) {
+        THROW(IOError() << errmsg{"json parse failed: " + errs});
+    }
     return res;
 }
 
@@ -406,11 +416,23 @@ Json::Value WireCell::Persist::Parser::load(const std::string& filename)
         char* jtext = jsonnet_evaluate_file(m_jvm, to_chars(fname), &rc);
         if (rc) {
             error(jtext);
-            THROW(ValueError() << errmsg{jtext});
+            std::string emsg(jtext);
+            jsonnet_realloc(m_jvm, jtext, 0);
+            THROW(ValueError() << errmsg{emsg});
         }
-        std::string output(jtext);
+        // Parse directly from the libjsonnet buffer; avoids materializing a
+        // ~1 GB std::string copy of the jsonnet output before parsing.
+        Json::Value res;
+        Json::CharReaderBuilder builder;
+        std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+        std::string errs;
+        const std::size_t len = std::strlen(jtext);
+        const bool ok = reader->parse(jtext, jtext + len, &res, &errs);
         jsonnet_realloc(m_jvm, jtext, 0);
-        return json2object(output);
+        if (!ok) {
+            THROW(IOError() << errmsg{"jsonnet output JSON parse failed: " + errs});
+        }
+        return res;
     }
 
     // also support JSON, possibly compressed

--- a/util/src/Persist.cxx
+++ b/util/src/Persist.cxx
@@ -29,6 +29,7 @@ extern "C" {
     void jsonnet_ext_code(struct JsonnetVm* vmRef, char* key, char* value);
     void jsonnet_tla_var(struct JsonnetVm* vmRef, char* key, char* value);
     void jsonnet_tla_code(struct JsonnetVm* vmRef, char* key, char* value);
+    void jsonnet_max_stack(struct JsonnetVm* vmRef, unsigned v);
     char* jsonnet_evaluate_file(struct JsonnetVm* vmRef, char* filename, int* e);
     char* jsonnet_evaluate_snippet(struct JsonnetVm* vmRef, char* filename, char* code, int* e);
 }
@@ -326,6 +327,10 @@ WireCell::Persist::Parser::Parser(const std::vector<std::string>& load_paths, co
                                   const externalvars_t& tlacode)
     : m_jvm{jsonnet_make()}
 {
+    // Default jsonnet max stack is 500 frames, which std.foldl chews through
+    // when fed lists with hundreds of elements (e.g. 360-fold fan-out configs
+    // hitting g.uses/popuses/std.foldl).
+    jsonnet_max_stack(m_jvm, 100000);
 
     // Loading: 1) cwd, 2) passed in paths 3) environment
     m_load_paths.push_back(boost::filesystem::current_path());


### PR DESCRIPTION
To fix this issue #469 
Dev repo: https://github.com/HaiwangYu/wcdev-icarus
CI report: [report-pr471.pdf](https://github.com/user-attachments/files/28014016/report-pr471.pdf)


# YZmap update: jsonnet loading optimization

Reduces peak heap and wall-clock during WCT job startup and event
processing for ICARUS detsim, and makes the `IConfigurable::configure()`
contract idempotent so multiple `WireCellToolkit` art modules can share
WCT-side components in one art job (enables a per-TPC fcl that drops peak
RSS by another ~2.6 GB).  Backwards compatible: with the standard 8-anode
config and a single `WireCellToolkit` module, behavior is unchanged.

## Headline result on ICARUS detsim (1-event smoke test)

| metric (1 event)            | master  | this PR (single-module fcl) | this PR + per-TPC fcl |
|-----------------------------|---------|-----------------------------|-----------------------|
| **VmHWM** (peak RSS)        | 12.8 GB | 9.0 GB                      | **6.4 GB**            |
| **VmPeak** (peak virtual)   | 17.9 GB | 15.5 GB                     | 10.0 GB               |
| Real wall time              | 34m14s  | 22m48s                      | 24m35s                |
| Output / event content      | passes  | passes                      | passes                |

Cumulative VmHWM reduction: **−3.8 GB single-module**, **−6.4 GB per-TPC**
(−50% from master).  CPU time unchanged.

## What's in the PR

### A. WCT configuration loading (`util/`, `apps/`, `cfg/`)

A series of independent fixes to the WCT-side config bootstrap that
together cut several GB of transient + resident heap during
`Main::initialize()` and the first few events.

| tag    | files                                                 | what                                                                                                                                                                                                                                                                                                              |
|--------|-------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| **A0** | `util/src/Persist.cxx`                                | `json2object()` and the `.jsonnet` branch of `Parser::load()` now parse straight from the `char*` returned by `jsonnet_evaluate_file` via `Json::CharReaderBuilder::newCharReader()::parse()` instead of routing through a `std::stringstream` + `ostringstream::str()` pipeline.  Eliminates ~3 redundant copies of the ~1 GB JSON text that the parser used to keep alive simultaneously.  Also throws `IOError` with the parse error message on failure instead of silently returning an empty `Json::Value`. |
| **A1-A4** | `util/inc/WireCellUtil/Configuration.h`, `util/src/Configuration.cxx`, `util/inc/WireCellUtil/ConfigManager.h`, `util/src/ConfigManager.cxx`, `apps/src/Main.cxx` | • `branch()` now takes `const Configuration&` (plus a by-value overload kept for ABI compat with binaries built against the older signature on cvmfs).  Walks the dot-path via const-ref instead of repeated self-assignment.<br>• `find()` and `get()` templates take `const Configuration&`.<br>• `ConfigManager::all()` returns `const Configuration&` instead of by-value.<br>• Six `for (auto c : m_cfgmgr.all())` / `for (auto c : m_apps)` loops in `Main.cxx` (lines 299, 312, 325, 331, 350, 375, 408 in the original) → `for (const auto& …)`.<br>• `ConfigManager::extend()` and `index()` use `const auto&` iteration.<br>• When a component's `default_configuration()` is null, skip the no-op `update()` and pass `c["data"]` straight to `configure()` (saves a deep-copy per component). |
| **C1** | `util/src/ConfigManager.cxx`, `apps/src/Main.cxx`     | `ConfigManager::extend()` now `std::move`'s each entry into `m_top` instead of deep-copying.  Signature stays `void extend(Configuration more)` to preserve ABI; new callers should pass `std::move(cfg)` (and `Main.cxx:274` does).  Eliminates the per-entry deep copy inside the loop.                          |
| **C2** | `util/src/ConfigManager.cxx`                          | `ConfigManager::pop()` rewritten to use `Json::Value::removeIndex(i, &ret)` instead of cloning every other entry into a fresh `Json::arrayValue` and reassigning it back over `m_top`.  Drops another ~2 GB transient during the `wire-cell` entry extraction.                                                    |
| **C5** | `util/inc/WireCellUtil/ConfigManager.h`, `util/src/ConfigManager.cxx`, `apps/src/Main.cxx` | New `ConfigManager::clear_data()` that drops the bulk `"data"` sub-tree from every top-level entry.  `Main::initialize()` calls it after the configure loop completes; `finalize()` only consults `"type"` and `"name"` so the multi-GB resident `Json::Value` tree is released before event processing begins.  Lowers the post-config plateau ~1.8 GB and the late peak ~2 GB. |

The cumulative effect (single `WireCellToolkit` module on the
production ICARUS detsim fcl): VmHWM **12.8 GB → 9.0 GB** (−3.8 GB), and
the configure phase finishes in ≈ 4 s of wall time instead of ≈ 80 s.

### B. `IConfigurable::configure()` idempotency fixes (`gen/`)

WCT's `NamedFactory` is process-wide, so any setup that runs
`Main::initialize()` more than once on the same process (most relevantly:
multiple `WireCellToolkit` art modules in one art job) calls
`configure()` repeatedly on shared component instances.  The contract
requires `configure()` to be idempotent; three components weren't:

- **`PlaneImpactResponse::build_responses()`** appended to `m_ir` and
  `m_bywire` without clearing first.  After the second
  reconfigure, `nwires()` and the per-wire indexing drift out of sync
  with `m_half_extent`; `PIR::closest()` starts throwing for in-range
  pitches and `ImpactTransform` crashes downstream.  Fixed with
  `m_ir.clear(); m_bywire.clear();` at the top of `build_responses()`.
- **`DepoSetFilterYZ::configure()`** and **`Scaler::configure()`** —
  same `m_boxes.push_back(face->sensitive())` loop with no preceding
  `clear()`.  Defensive fix, since their instances aren't currently
  shared between WCT art modules but the contract issue is the same.

Audit confirmed the rest of `gen/src/` is already idempotent
(`AnodePlane`, `MegaAnodePlane`, `DepoTransform`, `Reframer`, `YZMap`,
`FieldResponse`, `ColdElecResponse`, `WarmElecResponse`,
`JsonElecResponse`, `WireSchemaFile` all clear or overwrite their
state before populating).

### C. `sim.jsonnet` generalization

Three hardcoded `std.range(0, 359)` in
`cfg/pgrapher/experiment/icarus/sim.jsonnet` (in `transformsyz`,
`reframersyz`, and `analog_pipelinesyz`) → `std.range(0, nanodes*45 - 1)`.
Each iterates over `tools.anodes[std.floor(n/45)]` so a caller that
narrows `tools.anodes` (e.g. to a single-TPC pair via
`tools = tools_all { anodes: tools_all.anodes[apa_lo : apa_lo + 2] }`)
now builds only the relevant 90 entries instead of indexing past the
end of the array.  With the default 8-anode `tools.anodes` the
expression evaluates to `(0, 359)` and behavior is unchanged.  This is
the change that enables the per-TPC fcl downstream.

### D. ICARUS detsim jsonnet variant
`cfg/pgrapher/experiment/icarus/wcls-multitpc-sim-drift-simchannel-yzsim-refactored.jsonnet`
ships as the up-to-date refactored variant (uses the YZMap service, the
`drifter_data` definitions, and the FrameFanin→DumpFrames topology
adjustments that the production icarus detsim flow needs).

## Why "memory" matters here

The original WCT-on-art configure path:

```
Json::Value one = p.load(filename);          // ~2 GB parsed tree
m_cfgmgr.extend(one);                        // deep-copies into m_top         ← C1
m_cfgmgr.pop(index_of_wirecell_entry);       // rebuilds m_top by appending    ← C2
for (auto c : m_cfgmgr.all()) { … }          // returned m_top by value (!)    ← A2
…  (6 such loops)                            // …                              ← A2
Configuration cfg = cfgobj->default_configuration();
cfg = update(cfg, c["data"]);                 // dup of c["data"]              ← A3
cfgobj->configure(cfg);                      // …
…
// post-configure: m_top stays resident (~2 GB) for the entire job
```

After this PR: ~2 GB transient gone from `extend`, ~2 GB transient gone
from `pop`, ~3 GB transient gone from the parser's stringstream
pipeline, the 6 by-value loops in `Main.cxx` are by-ref, and the
resident `m_top` payload is dropped after `configure()` completes.  The
combined effect is a multi-GB drop in both the startup peak and the
post-config plateau.

## Backwards compatibility

- All `util/` API changes are additive or maintain the old by-value
  signatures as ABI shims (declared in-place inside `namespace
  WireCell` blocks in the `.cxx`, not in the headers, so new code
  prefers the const-ref overload).  Binaries built against the older
  WCT headers on cvmfs (`libWireCellLarsoft`, `libWireCellAIML`,
  `libWireCellQLMatch`, and the cvmfs `libWireCell*` themselves) link
  cleanly.  Verified with `nm -D` against the cvmfs build set.
- `Pgrapher::configure()`'s edge-accumulation behavior is unchanged.
  The per-TPC fcl side-steps it by using unique `Pgrapher:pgrapher<k>`
  names.
- `sim.jsonnet`'s `std.range(0, nanodes*45 - 1)` evaluates to the
  legacy `(0, 359)` when called with the default 8-anode tools.
- The new `wcls-multitpc-…-refactored.jsonnet` is a separate variant;
  existing fcl that pointed at the older jsonnet keeps working.

## Tests

- 1-event smoke (`detsim_2d_icarus_refactored_yzsim.fcl` → produces
  `detsim.root`):
  - master: passes, VmHWM 12.8 GB.
  - this PR (same fcl, no other change): passes, VmHWM 9.0 GB,
    `RawDigit`/`SimChannel` collection byte-identical to master.
- 1-event smoke with the per-TPC fcl (4 `WireCellToolkit` art modules):
  passes, VmHWM 6.4 GB.  `RawDigit` instance names preserved
  (`simdigits0..3`).  `SimChannel` instance names preserved
  (`simpleSC0..359`) but now distributed across the four `daq0..daq3`
  module labels.
- Audit of `gen/src/` for `push_back`-without-`clear` patterns: only
  PIR / DepoSetFilterYZ / Scaler were affected, all addressed in this
  PR.  Others (`AnodePlane`, `MegaAnodePlane`, `DepoTransform`,
  `Reframer`, `YZMap`, FieldResponse and the various
  `*ElecResponse`/`WireSchemaFile`) already clear or overwrite the
  relevant state.

## Files

```
apps/src/Main.cxx                                           |  34 +-  12
cfg/pgrapher/experiment/icarus/sim.jsonnet                  |  51 +-   4
cfg/pgrapher/experiment/icarus/
    wcls-multitpc-sim-drift-simchannel-yzsim-refactored.jsonnet | 537 +- 0
gen/src/DepoSetFilterYZ.cxx                                 |   5 +-   0
gen/src/PlaneImpactResponse.cxx                             |   8 +-   0
gen/src/Scaler.cxx                                          |   2 +-   0
util/inc/WireCellUtil/ConfigManager.h                       |  12 +-   1
util/inc/WireCellUtil/Configuration.h                       |   4 +-   4
util/src/ConfigManager.cxx                                  |  45 +- 14
util/src/Configuration.cxx                                  |  22 +-  4
util/src/Persist.cxx                                        |  33 +-  6
```

## Commits

```
ac6dd767  per-TPC cfg                # sim.jsonnet 360→nanodes*45 generalization
47fd57ef  fresh cfg                  # PIR/DepoSetFilterYZ/Scaler idempotency
a83aa72b  C5 clear config data       # drop m_top "data" sub-trees post-configure
23fbc42c  C1, C2                     # extend() move-into-m_top, pop() removeIndex
cca127e0  A0                         # Persist json2object via CharReader, drop stringstream
92f572c1  configuration speed up     # A1-A4: by-ref loops + branch()/find()/get()/all()
9f1a0129  keep the debug for now
505f50bb  Bulk loads of large configs
35fa11c3  increase max stack
336afab4  optimized "uses"
```
