### PR TITLE
Add SCECorrection IPCTransform with pluggable ISCEField (SBND)

### DIFF
--- a/clus/inc/WireCellClus/SCECorrection.h
+++ b/clus/inc/WireCellClus/SCECorrection.h
@@ -1,0 +1,175 @@
+// SCECorrection.h
+//
+// A Clus::IPCTransform that performs combined T0 + SCE (Space Charge Effect)
+// correction for SBND, delegating the SCE displacement field to an externally
+// provided ISCEField.  This keeps clus/ ROOT-free; the field implementation
+// (typically WireCell::Root::SCEFieldTH3) lives in the root/ subpackage and
+// is looked up by jsonnet TypeName.
+//
+// Applies:
+//   (1) T0:  x_t0  = x_raw - dirx * cluster_t0 * drift_speed
+//   (2) SCE: x_sce = x_t0  + field->displacement_x(apa, x_t0, y, z)
+//
+// East/West (apa==0/1) routing is handled inside the ISCEField implementation.
+// If no field is provided (nullptr), the SCE step is a no-op (T0 still applied).
+//
+// Author: Avinay Bhat (UChicago), for SBND
+// Modeled on T0Correction by Haiwang Yu.
+
+#ifndef WIRECELLCLUS_SCECORRECTION_H
+#define WIRECELLCLUS_SCECORRECTION_H
+
+#include "WireCellClus/IPCTransform.h"
+#include "WireCellIface/IDetectorVolumes.h"
+#include "WireCellIface/ISCEField.h"
+#include "WireCellUtil/Logging.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace WireCell::Clus {
+
+    class SCECorrection : public WireCell::Clus::IPCTransform {
+    public:
+        SCECorrection(IDetectorVolumes::pointer dv,
+                      WireCell::ISCEField::pointer field = nullptr);
+        virtual ~SCECorrection() = default;
+
+        virtual Point forward(const Point& pos_raw,  double cluster_t0, int face, int apa) const override;
+        virtual Point backward(const Point& pos_cor, double cluster_t0, int face, int apa) const override;
+        virtual bool  filter(const Point& pos_cor,   double cluster_t0, int face, int apa) const override;
+
+        virtual Dataset forward(const Dataset& pc_raw,
+                                const std::vector<std::string>& arr_raw_names,
+                                const std::vector<std::string>& arr_cor_names,
+                                double cluster_t0, int face, int apa) const override;
+        virtual Dataset backward(const Dataset& pc_cor,
+                                 const std::vector<std::string>& arr_cor_names,
+                                 const std::vector<std::string>& arr_raw_names,
+                                 double cluster_t0, int face, int apa) const override;
+        virtual Dataset filter(const Dataset& pc_cor,
+                               const std::vector<std::string>& arr_cor_names,
+                               double cluster_t0, int face, int apa) const override;
+
+        virtual PointCloud::Tree::Scope output_scope() const override {
+            return {"3d", {"x_sce", "y", "z"}};
+        }
+        virtual std::vector<std::string> stored_array_names() const override {
+            return {"x_sce"};
+        }
+
+    private:
+        IDetectorVolumes::pointer m_dv;
+        WireCell::ISCEField::pointer m_field;
+        std::map<int, std::map<int, double>> m_drift_speeds;
+
+        // Combined T0 + SCE for one X coordinate.  All quantities in WCT mm.
+        inline double corrected_x(double x_raw_mm, double y_mm, double z_mm,
+                                  double cluster_t0, int face, int apa) const {
+            const double dirx = m_dv->face_dirx(WirePlaneId(kAllLayers, face, apa));
+            const double x_t0_mm = x_raw_mm - dirx * cluster_t0 * m_drift_speeds.at(apa).at(face);
+            const double dx_mm = m_field ? m_field->displacement_x(apa, x_t0_mm, y_mm, z_mm) : 0.0;
+            return x_t0_mm + dx_mm;
+        }
+    };
+
+    inline SCECorrection::SCECorrection(IDetectorVolumes::pointer dv,
+                                        WireCell::ISCEField::pointer field)
+        : m_dv(dv), m_field(field)
+    {
+        for (const auto& [wfid, _] : m_dv->wpident_faces()) {
+            WirePlaneId wpid(wfid);
+            const auto md = m_dv->metadata(wpid);
+            m_drift_speeds[wpid.apa()][wpid.face()] = md["drift_speed"].asDouble();
+        }
+        if (m_field) spdlog::info("SCECorrection: ISCEField wired in");
+        else         spdlog::info("SCECorrection: no ISCEField -- SCE disabled (T0 still applied)");
+    }
+
+    inline Point SCECorrection::forward(const Point& pos_raw, double t0, int face, int apa) const {
+        Point pc(pos_raw);
+        pc[0] = corrected_x(pos_raw[0], pos_raw[1], pos_raw[2], t0, face, apa);
+        return pc;
+    }
+
+    inline Point SCECorrection::backward(const Point& pos_cor, double t0, int face, int apa) const {
+        Point pr(pos_cor);
+        if (m_field) {
+            // Approximate: evaluate field at x_sce instead of x_t0 (small displacement OK).
+            pr[0] -= m_field->displacement_x(apa, pos_cor[0], pos_cor[1], pos_cor[2]);
+        }
+        const double dirx = m_dv->face_dirx(WirePlaneId(kAllLayers, face, apa));
+        pr[0] += dirx * t0 * m_drift_speeds.at(apa).at(face);
+        return pr;
+    }
+
+    inline bool SCECorrection::filter(const Point& pos_cor, double, int face, int apa) const {
+        auto wpid = m_dv->contained_by(pos_cor);
+        return wpid.valid() && wpid.apa() == apa && wpid.face() == face;
+    }
+
+    inline PointCloud::Dataset SCECorrection::forward(const PointCloud::Dataset& pc_raw,
+                                          const std::vector<std::string>& arr_raw_names,
+                                          const std::vector<std::string>& arr_cor_names,
+                                          double t0, int face, int apa) const
+    {
+        const auto& ax = pc_raw.get(arr_raw_names[0])->elements<double>();
+        const auto& ay = pc_raw.get(arr_raw_names[1])->elements<double>();
+        const auto& az = pc_raw.get(arr_raw_names[2])->elements<double>();
+        std::vector<double> ax_c(ax.size());
+        for (size_t i = 0; i < ax.size(); ++i) {
+            ax_c[i] = corrected_x(ax[i], ay[i], az[i], t0, face, apa);
+        }
+        Dataset ds;
+        ds.add(arr_cor_names[0], Array(ax_c));
+        ds.add(arr_cor_names[1], Array(ay));
+        ds.add(arr_cor_names[2], Array(az));
+        return ds;
+    }
+
+    inline PointCloud::Dataset SCECorrection::backward(const PointCloud::Dataset& pc_cor,
+                                           const std::vector<std::string>& arr_cor_names,
+                                           const std::vector<std::string>& arr_raw_names,
+                                           double t0, int face, int apa) const
+    {
+        const auto& ax = pc_cor.get(arr_cor_names[0])->elements<double>();
+        const auto& ay = pc_cor.get(arr_cor_names[1])->elements<double>();
+        const auto& az = pc_cor.get(arr_cor_names[2])->elements<double>();
+        const double dirx = m_dv->face_dirx(WirePlaneId(kAllLayers, face, apa));
+        const double v = m_drift_speeds.at(apa).at(face);
+        std::vector<double> ax_r(ax.size());
+        for (size_t i = 0; i < ax.size(); ++i) {
+            double x = ax[i];
+            if (m_field) x -= m_field->displacement_x(apa, ax[i], ay[i], az[i]);
+            x += dirx * t0 * v;
+            ax_r[i] = x;
+        }
+        Dataset ds;
+        ds.add(arr_raw_names[0], Array(ax_r));
+        ds.add(arr_raw_names[1], Array(ay));
+        ds.add(arr_raw_names[2], Array(az));
+        return ds;
+    }
+
+    inline PointCloud::Dataset SCECorrection::filter(const PointCloud::Dataset& pc_cor,
+                                         const std::vector<std::string>& arr_cor_names,
+                                         double, int face, int apa) const
+    {
+        std::vector<int> flt(pc_cor.size_major());
+        const auto& ax = pc_cor.get(arr_cor_names[0])->elements<double>();
+        const auto& ay = pc_cor.get(arr_cor_names[1])->elements<double>();
+        const auto& az = pc_cor.get(arr_cor_names[2])->elements<double>();
+        for (size_t i = 0; i < ax.size(); ++i) {
+            flt[i] = 0;
+            auto wpid = m_dv->contained_by(Point(ax[i], ay[i], az[i]));
+            if (wpid.valid() && wpid.apa() == apa && wpid.face() == face) flt[i] = 1;
+        }
+        Dataset ds;
+        ds.add("filter", Array(flt));
+        return ds;
+    }
+
+}  // namespace WireCell::Clus
+
+#endif  // WIRECELLCLUS_SCECORRECTION_H

--- a/clus/inc/WireCellClus/SCECorrection.h
+++ b/clus/inc/WireCellClus/SCECorrection.h
@@ -6,12 +6,15 @@
 // (typically WireCell::Root::SCEFieldTH3) lives in the root/ subpackage and
 // is looked up by jsonnet TypeName.
 //
-// Applies:
+// Applies (all in WCT mm):
 //   (1) T0:  x_t0  = x_raw - dirx * cluster_t0 * drift_speed
-//   (2) SCE: x_sce = x_t0  + field->displacement_x(apa, x_t0, y, z)
+//   (2) SCE: x_sce = x_t0 + field->displacement_x(apa, x_t0, y, z)
+//            y_sce = y    + field->displacement_y(apa, x_t0, y, z)
+//            z_sce = z    + field->displacement_z(apa, x_t0, y, z)
 //
 // East/West (apa==0/1) routing is handled inside the ISCEField implementation.
-// If no field is provided (nullptr), the SCE step is a no-op (T0 still applied).
+// If no field is provided (nullptr), the SCE step is a no-op (T0 still applied
+// to x; y, z pass through).
 //
 // Author: Avinay Bhat (UChicago), for SBND
 // Modeled on T0Correction by Haiwang Yu.
@@ -53,10 +56,10 @@ namespace WireCell::Clus {
                                double cluster_t0, int face, int apa) const override;
 
         virtual PointCloud::Tree::Scope output_scope() const override {
-            return {"3d", {"x_sce", "y", "z"}};
+            return {"3d", {"x_sce", "y_sce", "z_sce"}};
         }
         virtual std::vector<std::string> stored_array_names() const override {
-            return {"x_sce"};
+            return {"x_sce", "y_sce", "z_sce"};
         }
 
     private:
@@ -64,13 +67,19 @@ namespace WireCell::Clus {
         WireCell::ISCEField::pointer m_field;
         std::map<int, std::map<int, double>> m_drift_speeds;
 
-        // Combined T0 + SCE for one X coordinate.  All quantities in WCT mm.
-        inline double corrected_x(double x_raw_mm, double y_mm, double z_mm,
-                                  double cluster_t0, int face, int apa) const {
+        // Combined T0 + full 3D SCE for one point.  All quantities in WCT mm.
+        inline void corrected_xyz(double x_raw_mm, double y_mm, double z_mm,
+                                  double cluster_t0, int face, int apa,
+                                  double& xs, double& ys, double& zs) const {
             const double dirx = m_dv->face_dirx(WirePlaneId(kAllLayers, face, apa));
             const double x_t0_mm = x_raw_mm - dirx * cluster_t0 * m_drift_speeds.at(apa).at(face);
-            const double dx_mm = m_field ? m_field->displacement_x(apa, x_t0_mm, y_mm, z_mm) : 0.0;
-            return x_t0_mm + dx_mm;
+            if (m_field) {
+                xs = x_t0_mm + m_field->displacement_x(apa, x_t0_mm, y_mm, z_mm);
+                ys = y_mm    + m_field->displacement_y(apa, x_t0_mm, y_mm, z_mm);
+                zs = z_mm    + m_field->displacement_z(apa, x_t0_mm, y_mm, z_mm);
+            } else {
+                xs = x_t0_mm; ys = y_mm; zs = z_mm;
+            }
         }
     };
 
@@ -83,21 +92,23 @@ namespace WireCell::Clus {
             const auto md = m_dv->metadata(wpid);
             m_drift_speeds[wpid.apa()][wpid.face()] = md["drift_speed"].asDouble();
         }
-        if (m_field) spdlog::info("SCECorrection: ISCEField wired in");
+        if (m_field) spdlog::info("SCECorrection: ISCEField wired in (x,y,z)");
         else         spdlog::info("SCECorrection: no ISCEField -- SCE disabled (T0 still applied)");
     }
 
     inline Point SCECorrection::forward(const Point& pos_raw, double t0, int face, int apa) const {
         Point pc(pos_raw);
-        pc[0] = corrected_x(pos_raw[0], pos_raw[1], pos_raw[2], t0, face, apa);
+        corrected_xyz(pos_raw[0], pos_raw[1], pos_raw[2], t0, face, apa, pc[0], pc[1], pc[2]);
         return pc;
     }
 
     inline Point SCECorrection::backward(const Point& pos_cor, double t0, int face, int apa) const {
         Point pr(pos_cor);
         if (m_field) {
-            // Approximate: evaluate field at x_sce instead of x_t0 (small displacement OK).
+            // Approximate: evaluate field at the corrected position.
             pr[0] -= m_field->displacement_x(apa, pos_cor[0], pos_cor[1], pos_cor[2]);
+            pr[1] -= m_field->displacement_y(apa, pos_cor[0], pos_cor[1], pos_cor[2]);
+            pr[2] -= m_field->displacement_z(apa, pos_cor[0], pos_cor[1], pos_cor[2]);
         }
         const double dirx = m_dv->face_dirx(WirePlaneId(kAllLayers, face, apa));
         pr[0] += dirx * t0 * m_drift_speeds.at(apa).at(face);
@@ -117,14 +128,15 @@ namespace WireCell::Clus {
         const auto& ax = pc_raw.get(arr_raw_names[0])->elements<double>();
         const auto& ay = pc_raw.get(arr_raw_names[1])->elements<double>();
         const auto& az = pc_raw.get(arr_raw_names[2])->elements<double>();
-        std::vector<double> ax_c(ax.size());
+        std::vector<double> ax_c(ax.size()), ay_c(ax.size()), az_c(ax.size());
         for (size_t i = 0; i < ax.size(); ++i) {
-            ax_c[i] = corrected_x(ax[i], ay[i], az[i], t0, face, apa);
+            corrected_xyz(ax[i], ay[i], az[i], t0, face, apa,
+                          ax_c[i], ay_c[i], az_c[i]);
         }
         Dataset ds;
-        ds.add(arr_cor_names[0], Array(ax_c));
-        ds.add(arr_cor_names[1], Array(ay));
-        ds.add(arr_cor_names[2], Array(az));
+        ds.add(arr_cor_names[0], Array(ax_c));   // x_sce
+        ds.add(arr_cor_names[1], Array(ay_c));   // y_sce
+        ds.add(arr_cor_names[2], Array(az_c));   // z_sce
         return ds;
     }
 
@@ -138,17 +150,21 @@ namespace WireCell::Clus {
         const auto& az = pc_cor.get(arr_cor_names[2])->elements<double>();
         const double dirx = m_dv->face_dirx(WirePlaneId(kAllLayers, face, apa));
         const double v = m_drift_speeds.at(apa).at(face);
-        std::vector<double> ax_r(ax.size());
+        std::vector<double> ax_r(ax.size()), ay_r(ax.size()), az_r(ax.size());
         for (size_t i = 0; i < ax.size(); ++i) {
-            double x = ax[i];
-            if (m_field) x -= m_field->displacement_x(apa, ax[i], ay[i], az[i]);
+            double x = ax[i], y = ay[i], z = az[i];
+            if (m_field) {
+                x -= m_field->displacement_x(apa, ax[i], ay[i], az[i]);
+                y -= m_field->displacement_y(apa, ax[i], ay[i], az[i]);
+                z -= m_field->displacement_z(apa, ax[i], ay[i], az[i]);
+            }
             x += dirx * t0 * v;
-            ax_r[i] = x;
+            ax_r[i] = x; ay_r[i] = y; az_r[i] = z;
         }
         Dataset ds;
         ds.add(arr_raw_names[0], Array(ax_r));
-        ds.add(arr_raw_names[1], Array(ay));
-        ds.add(arr_raw_names[2], Array(az));
+        ds.add(arr_raw_names[1], Array(ay_r));
+        ds.add(arr_raw_names[2], Array(az_r));
         return ds;
     }
 

--- a/clus/src/PCTransforms.cxx
+++ b/clus/src/PCTransforms.cxx
@@ -6,6 +6,8 @@
 //
 
 #include "WireCellClus/IPCTransform.h"
+#include "WireCellClus/SCECorrection.h"
+#include "WireCellIface/ISCEField.h"
 #include "WireCellIface/IDetectorVolumes.h"
 
 #include "WireCellIface/IConfigurable.h"
@@ -178,6 +180,23 @@ public:
         std::string dvtn = get<std::string>(cfg, "detector_volumes", "DetectorVolumes");
         auto dv = Factory::find_tn<WireCell::IDetectorVolumes>(dvtn);
         m_pcts["T0Correction"] = std::make_shared<T0Correction>(dv);
+        // SBND SCE (Space Charge Effect) -- per-TPC TH3 displacement field
+        // provided externally as an ISCEField (typically WireCell::Root::SCEFieldTH3),
+        // looked up by TypeName from DetectorVolumes per-APA metadata key "sce_field".
+        // Falls back to a no-op (T0 only) when no field is configured.
+        WireCell::ISCEField::pointer sce_field;
+        for (const auto& [wfid, _] : dv->wpident_faces()) {
+            WirePlaneId wpid(wfid);
+            const auto md = dv->metadata(wpid);
+            if (md.isMember("sce_field")) {
+                std::string fld_tn = md["sce_field"].asString();
+                if (!fld_tn.empty()) {
+                    sce_field = Factory::find_tn<WireCell::ISCEField>(fld_tn);
+                }
+                break;
+            }
+        }
+        m_pcts["SCECorrection"] = std::make_shared<SCECorrection>(dv, sce_field);
         // ...
     }
 

--- a/iface/inc/WireCellIface/ISCEField.h
+++ b/iface/inc/WireCellIface/ISCEField.h
@@ -8,16 +8,17 @@ namespace WireCell {
     /** Per-TPC backward (reco -> true) Space-Charge-Effect displacement field.
      *
      *  Implementations expose, for a given APA/TPC index and 3D position,
-     *  the SIGNED backward X displacement to be added directly to a t0-corrected
-     *  X coordinate to recover the true X.  Out-of-domain queries are clamped
-     *  internally by the implementation.  Implementations that carry no map
-     *  should return 0 (no-op safe).
+     *  the SIGNED backward displacement to be added directly to a t0-corrected
+     *  coordinate to recover the true coordinate.  Out-of-domain queries are
+     *  clamped internally by the implementation.  Implementations that carry no
+     *  map should return 0 (no-op safe).
      *
      *  Units: WCT internal (mm) in, (mm) out.  Implementations handle any
      *  conversion required by their underlying map.
      *
-     *  Future revisions may add displacement_y / displacement_z if the
-     *  underlying map provides those components.
+     *  displacement_x is mandatory.  displacement_y / displacement_z are
+     *  optional: implementations whose underlying map lacks transverse
+     *  components inherit the default no-op (return 0).
      */
     class ISCEField : public IComponent<ISCEField> {
        public:
@@ -26,6 +27,12 @@ namespace WireCell {
         /// Backward X-displacement at (x,y,z) for APA index `apa`.
         /// SBND convention: apa=0 East, apa=1 West.  Units: mm.
         virtual double displacement_x(int apa, double x, double y, double z) const = 0;
+
+        /// Backward Y-displacement at (x,y,z).  Units: mm.  Optional (default no-op).
+        virtual double displacement_y(int /*apa*/, double /*x*/, double /*y*/, double /*z*/) const { return 0.0; }
+
+        /// Backward Z-displacement at (x,y,z).  Units: mm.  Optional (default no-op).
+        virtual double displacement_z(int /*apa*/, double /*x*/, double /*y*/, double /*z*/) const { return 0.0; }
     };
 
 }  // namespace WireCell

--- a/iface/inc/WireCellIface/ISCEField.h
+++ b/iface/inc/WireCellIface/ISCEField.h
@@ -1,0 +1,33 @@
+#ifndef WIRECELLIFACE_ISCEFIELD
+#define WIRECELLIFACE_ISCEFIELD
+
+#include "WireCellUtil/IComponent.h"
+
+namespace WireCell {
+
+    /** Per-TPC backward (reco -> true) Space-Charge-Effect displacement field.
+     *
+     *  Implementations expose, for a given APA/TPC index and 3D position,
+     *  the SIGNED backward X displacement to be added directly to a t0-corrected
+     *  X coordinate to recover the true X.  Out-of-domain queries are clamped
+     *  internally by the implementation.  Implementations that carry no map
+     *  should return 0 (no-op safe).
+     *
+     *  Units: WCT internal (mm) in, (mm) out.  Implementations handle any
+     *  conversion required by their underlying map.
+     *
+     *  Future revisions may add displacement_y / displacement_z if the
+     *  underlying map provides those components.
+     */
+    class ISCEField : public IComponent<ISCEField> {
+       public:
+        virtual ~ISCEField() = default;
+
+        /// Backward X-displacement at (x,y,z) for APA index `apa`.
+        /// SBND convention: apa=0 East, apa=1 West.  Units: mm.
+        virtual double displacement_x(int apa, double x, double y, double z) const = 0;
+    };
+
+}  // namespace WireCell
+
+#endif

--- a/root/inc/WireCellRoot/SCEFieldTH3.h
+++ b/root/inc/WireCellRoot/SCEFieldTH3.h
@@ -1,8 +1,8 @@
 /** ISCEField implementation backed by per-TPC TH3F histograms in a
- *  ROOT file (SBND dualmap layout: TrueBkwd_Displacement_X_E,
- *  TrueBkwd_Displacement_X_W).  IConfigurable so jsonnet wiring works
- *  the usual way; the actual SCE-correction transform in clus/
- *  receives an ISCEField::pointer and never sees ROOT.
+ *  ROOT file (SBND dualmap layout: TrueBkwd_Displacement_{X,Y,Z}_{E,W}).
+ *  IConfigurable so jsonnet wiring works the usual way; the actual
+ *  SCE-correction transform in clus/ receives an ISCEField::pointer and
+ *  never sees ROOT.
  */
 
 #ifndef WIRECELLROOT_SCEFIELDTH3
@@ -30,6 +30,8 @@ namespace WireCell {
 
             // ISCEField
             virtual double displacement_x(int apa, double x, double y, double z) const override;
+            virtual double displacement_y(int apa, double x, double y, double z) const override;
+            virtual double displacement_z(int apa, double x, double y, double z) const override;
 
             // IConfigurable
             virtual void configure(const WireCell::Configuration& cfg) override;
@@ -38,19 +40,37 @@ namespace WireCell {
            private:
             // configuration
             std::string m_sce_map_file;
-            std::string m_th3_name_E;
+            std::string m_th3_name_E;     // X (mandatory)
             std::string m_th3_name_W;
+            std::string m_th3_name_E_y;   // Y (optional transverse)
+            std::string m_th3_name_W_y;
+            std::string m_th3_name_E_z;   // Z (optional transverse)
+            std::string m_th3_name_W_z;
             bool   m_axis_unit_mm{false};
             double m_sign{-1.0};
 
-            // loaded state
+            // loaded state (all owned by m_file)
             std::unique_ptr<TFile> m_file;
-            TH3F* m_hE{nullptr};  // owned by m_file
+            TH3F* m_hE{nullptr};
             TH3F* m_hW{nullptr};
+            TH3F* m_hE_y{nullptr};
+            TH3F* m_hW_y{nullptr};
+            TH3F* m_hE_z{nullptr};
+            TH3F* m_hW_z{nullptr};
 
             Log::logptr_t l;
 
+            // Shared: pick E/W histo by apa, clamp, convert units, apply sign.
+            // Returns 0 if the requested histo is absent (no-op component).
+            double interp(TH3F* hE, TH3F* hW, int apa,
+                          double x, double y, double z) const;
+
             static double clamp_axis(const TAxis* a, double v);
+
+            // Load one (E,W) histo pair; hard=true throws on missing,
+            // hard=false warns and leaves pointers null.
+            void load_pair(const std::string& nameE, const std::string& nameW,
+                           TH3F*& hE, TH3F*& hW, bool hard);
         };
 
     }  // namespace Root

--- a/root/inc/WireCellRoot/SCEFieldTH3.h
+++ b/root/inc/WireCellRoot/SCEFieldTH3.h
@@ -1,0 +1,59 @@
+/** ISCEField implementation backed by per-TPC TH3F histograms in a
+ *  ROOT file (SBND dualmap layout: TrueBkwd_Displacement_X_E,
+ *  TrueBkwd_Displacement_X_W).  IConfigurable so jsonnet wiring works
+ *  the usual way; the actual SCE-correction transform in clus/
+ *  receives an ISCEField::pointer and never sees ROOT.
+ */
+
+#ifndef WIRECELLROOT_SCEFIELDTH3
+#define WIRECELLROOT_SCEFIELDTH3
+
+#include "WireCellIface/ISCEField.h"
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellUtil/Logging.h"
+
+#include <memory>
+#include <string>
+
+class TFile;
+class TH3F;
+class TAxis;
+
+namespace WireCell {
+    namespace Root {
+
+        class SCEFieldTH3 : public WireCell::ISCEField,
+                            public WireCell::IConfigurable {
+           public:
+            SCEFieldTH3();
+            virtual ~SCEFieldTH3();
+
+            // ISCEField
+            virtual double displacement_x(int apa, double x, double y, double z) const override;
+
+            // IConfigurable
+            virtual void configure(const WireCell::Configuration& cfg) override;
+            virtual WireCell::Configuration default_configuration() const override;
+
+           private:
+            // configuration
+            std::string m_sce_map_file;
+            std::string m_th3_name_E;
+            std::string m_th3_name_W;
+            bool   m_axis_unit_mm{false};
+            double m_sign{-1.0};
+
+            // loaded state
+            std::unique_ptr<TFile> m_file;
+            TH3F* m_hE{nullptr};  // owned by m_file
+            TH3F* m_hW{nullptr};
+
+            Log::logptr_t l;
+
+            static double clamp_axis(const TAxis* a, double v);
+        };
+
+    }  // namespace Root
+}  // namespace WireCell
+
+#endif

--- a/root/src/SCEFieldTH3.cxx
+++ b/root/src/SCEFieldTH3.cxx
@@ -16,6 +16,10 @@ using namespace WireCell::Root;
 SCEFieldTH3::SCEFieldTH3()
     : m_th3_name_E("TrueBkwd_Displacement_X_E"),
       m_th3_name_W("TrueBkwd_Displacement_X_W"),
+      m_th3_name_E_y("TrueBkwd_Displacement_Y_E"),
+      m_th3_name_W_y("TrueBkwd_Displacement_Y_W"),
+      m_th3_name_E_z("TrueBkwd_Displacement_Z_E"),
+      m_th3_name_W_z("TrueBkwd_Displacement_Z_W"),
       l(Log::logger("wct"))
 {
 }
@@ -25,12 +29,35 @@ SCEFieldTH3::~SCEFieldTH3() = default;
 Configuration SCEFieldTH3::default_configuration() const
 {
     Configuration cfg;
-    cfg["sce_map_file"] = m_sce_map_file;
-    cfg["th3_name_E"]   = m_th3_name_E;
-    cfg["th3_name_W"]   = m_th3_name_W;
-    cfg["axis_unit_mm"] = m_axis_unit_mm;
-    cfg["sign"]         = m_sign;
+    cfg["sce_map_file"]  = m_sce_map_file;
+    cfg["th3_name_E"]    = m_th3_name_E;
+    cfg["th3_name_W"]    = m_th3_name_W;
+    cfg["th3_name_E_y"]  = m_th3_name_E_y;
+    cfg["th3_name_W_y"]  = m_th3_name_W_y;
+    cfg["th3_name_E_z"]  = m_th3_name_E_z;
+    cfg["th3_name_W_z"]  = m_th3_name_W_z;
+    cfg["axis_unit_mm"]  = m_axis_unit_mm;
+    cfg["sign"]          = m_sign;
     return cfg;
+}
+
+void SCEFieldTH3::load_pair(const std::string& nameE, const std::string& nameW,
+                            TH3F*& hE, TH3F*& hW, bool hard)
+{
+    hE = dynamic_cast<TH3F*>(m_file->Get(nameE.c_str()));
+    hW = dynamic_cast<TH3F*>(m_file->Get(nameW.c_str()));
+    if (!hE || !hW) {
+        if (hard) {
+            throw std::runtime_error("SCEFieldTH3: missing TH3F '" + nameE
+                                     + "' or '" + nameW + "' in " + m_sce_map_file);
+        }
+        l->warn("SCEFieldTH3: optional TH3 '{}' / '{}' absent -- that component is a no-op",
+                nameE, nameW);
+        hE = nullptr; hW = nullptr;
+        return;
+    }
+    hE->SetDirectory(nullptr);
+    hW->SetDirectory(nullptr);
 }
 
 void SCEFieldTH3::configure(const Configuration& cfg)
@@ -38,6 +65,10 @@ void SCEFieldTH3::configure(const Configuration& cfg)
     m_sce_map_file = get<std::string>(cfg, "sce_map_file", m_sce_map_file);
     m_th3_name_E   = get<std::string>(cfg, "th3_name_E",   m_th3_name_E);
     m_th3_name_W   = get<std::string>(cfg, "th3_name_W",   m_th3_name_W);
+    m_th3_name_E_y = get<std::string>(cfg, "th3_name_E_y", m_th3_name_E_y);
+    m_th3_name_W_y = get<std::string>(cfg, "th3_name_W_y", m_th3_name_W_y);
+    m_th3_name_E_z = get<std::string>(cfg, "th3_name_E_z", m_th3_name_E_z);
+    m_th3_name_W_z = get<std::string>(cfg, "th3_name_W_z", m_th3_name_W_z);
     m_axis_unit_mm = get<bool>       (cfg, "axis_unit_mm", m_axis_unit_mm);
     m_sign         = get<double>     (cfg, "sign",         m_sign);
 
@@ -51,16 +82,15 @@ void SCEFieldTH3::configure(const Configuration& cfg)
     if (!m_file || m_file->IsZombie()) {
         throw std::runtime_error("SCEFieldTH3: cannot open " + m_sce_map_file);
     }
-    m_hE = dynamic_cast<TH3F*>(m_file->Get(m_th3_name_E.c_str()));
-    m_hW = dynamic_cast<TH3F*>(m_file->Get(m_th3_name_W.c_str()));
-    if (!m_hE || !m_hW) {
-        throw std::runtime_error("SCEFieldTH3: missing TH3F '" + m_th3_name_E
-                                 + "' or '" + m_th3_name_W + "' in " + m_sce_map_file);
-    }
-    m_hE->SetDirectory(nullptr);
-    m_hW->SetDirectory(nullptr);
-    l->info("SCEFieldTH3: loaded TH3 E='{}' W='{}' axis_mm={} sign={}",
-            m_th3_name_E, m_th3_name_W, m_axis_unit_mm, m_sign);
+
+    load_pair(m_th3_name_E,   m_th3_name_W,   m_hE,   m_hW,   /*hard=*/true);
+    load_pair(m_th3_name_E_y, m_th3_name_W_y, m_hE_y, m_hW_y, /*hard=*/false);
+    load_pair(m_th3_name_E_z, m_th3_name_W_z, m_hE_z, m_hW_z, /*hard=*/false);
+
+    l->info("SCEFieldTH3: loaded X[E='{}' W='{}'] Y[{}] Z[{}] axis_mm={} sign={}",
+            m_th3_name_E, m_th3_name_W,
+            (m_hE_y ? "ok" : "absent"), (m_hE_z ? "ok" : "absent"),
+            m_axis_unit_mm, m_sign);
 }
 
 double SCEFieldTH3::clamp_axis(const TAxis* a, double v)
@@ -73,9 +103,10 @@ double SCEFieldTH3::clamp_axis(const TAxis* a, double v)
     return v;
 }
 
-double SCEFieldTH3::displacement_x(int apa, double x, double y, double z) const
+double SCEFieldTH3::interp(TH3F* hE, TH3F* hW, int apa,
+                           double x, double y, double z) const
 {
-    TH3F* h = (apa == 0) ? m_hE : (apa == 1) ? m_hW : nullptr;
+    TH3F* h = (apa == 0) ? hE : (apa == 1) ? hW : nullptr;
     if (!h) return 0.0;
 
     // WCT input is mm; map axes are cm by default (mm if m_axis_unit_mm).
@@ -85,7 +116,22 @@ double SCEFieldTH3::displacement_x(int apa, double x, double y, double z) const
     const double xq = clamp_axis(h->GetXaxis(), x * s_in);
     const double yq = clamp_axis(h->GetYaxis(), y * s_in);
     const double zq = clamp_axis(h->GetZaxis(), z * s_in);
-    const double dx_map = h->Interpolate(xq, yq, zq);
+    const double d_map = h->Interpolate(xq, yq, zq);
 
-    return m_sign * dx_map * s_out;  // signed displacement in mm
+    return m_sign * d_map * s_out;  // signed displacement in mm
+}
+
+double SCEFieldTH3::displacement_x(int apa, double x, double y, double z) const
+{
+    return interp(m_hE, m_hW, apa, x, y, z);
+}
+
+double SCEFieldTH3::displacement_y(int apa, double x, double y, double z) const
+{
+    return interp(m_hE_y, m_hW_y, apa, x, y, z);
+}
+
+double SCEFieldTH3::displacement_z(int apa, double x, double y, double z) const
+{
+    return interp(m_hE_z, m_hW_z, apa, x, y, z);
 }

--- a/root/src/SCEFieldTH3.cxx
+++ b/root/src/SCEFieldTH3.cxx
@@ -1,0 +1,91 @@
+#include "WireCellRoot/SCEFieldTH3.h"
+#include "WireCellUtil/NamedFactory.h"
+
+#include <TFile.h>
+#include <TH3F.h>
+#include <TAxis.h>
+
+#include <stdexcept>
+
+WIRECELL_FACTORY(SCEFieldTH3, WireCell::Root::SCEFieldTH3,
+                 WireCell::ISCEField, WireCell::IConfigurable)
+
+using namespace WireCell;
+using namespace WireCell::Root;
+
+SCEFieldTH3::SCEFieldTH3()
+    : m_th3_name_E("TrueBkwd_Displacement_X_E"),
+      m_th3_name_W("TrueBkwd_Displacement_X_W"),
+      l(Log::logger("wct"))
+{
+}
+
+SCEFieldTH3::~SCEFieldTH3() = default;
+
+Configuration SCEFieldTH3::default_configuration() const
+{
+    Configuration cfg;
+    cfg["sce_map_file"] = m_sce_map_file;
+    cfg["th3_name_E"]   = m_th3_name_E;
+    cfg["th3_name_W"]   = m_th3_name_W;
+    cfg["axis_unit_mm"] = m_axis_unit_mm;
+    cfg["sign"]         = m_sign;
+    return cfg;
+}
+
+void SCEFieldTH3::configure(const Configuration& cfg)
+{
+    m_sce_map_file = get<std::string>(cfg, "sce_map_file", m_sce_map_file);
+    m_th3_name_E   = get<std::string>(cfg, "th3_name_E",   m_th3_name_E);
+    m_th3_name_W   = get<std::string>(cfg, "th3_name_W",   m_th3_name_W);
+    m_axis_unit_mm = get<bool>       (cfg, "axis_unit_mm", m_axis_unit_mm);
+    m_sign         = get<double>     (cfg, "sign",         m_sign);
+
+    if (m_sce_map_file.empty()) {
+        l->info("SCEFieldTH3: no sce_map_file -- field is a no-op");
+        return;
+    }
+
+    l->info("SCEFieldTH3: opening SCE map {}", m_sce_map_file);
+    m_file.reset(TFile::Open(m_sce_map_file.c_str(), "READ"));
+    if (!m_file || m_file->IsZombie()) {
+        throw std::runtime_error("SCEFieldTH3: cannot open " + m_sce_map_file);
+    }
+    m_hE = dynamic_cast<TH3F*>(m_file->Get(m_th3_name_E.c_str()));
+    m_hW = dynamic_cast<TH3F*>(m_file->Get(m_th3_name_W.c_str()));
+    if (!m_hE || !m_hW) {
+        throw std::runtime_error("SCEFieldTH3: missing TH3F '" + m_th3_name_E
+                                 + "' or '" + m_th3_name_W + "' in " + m_sce_map_file);
+    }
+    m_hE->SetDirectory(nullptr);
+    m_hW->SetDirectory(nullptr);
+    l->info("SCEFieldTH3: loaded TH3 E='{}' W='{}' axis_mm={} sign={}",
+            m_th3_name_E, m_th3_name_W, m_axis_unit_mm, m_sign);
+}
+
+double SCEFieldTH3::clamp_axis(const TAxis* a, double v)
+{
+    const double lo  = a->GetBinCenter(1);
+    const double hi  = a->GetBinCenter(a->GetNbins());
+    const double pad = 1e-3 * a->GetBinWidth(1);
+    if (v < lo + pad) return lo + pad;
+    if (v > hi - pad) return hi - pad;
+    return v;
+}
+
+double SCEFieldTH3::displacement_x(int apa, double x, double y, double z) const
+{
+    TH3F* h = (apa == 0) ? m_hE : (apa == 1) ? m_hW : nullptr;
+    if (!h) return 0.0;
+
+    // WCT input is mm; map axes are cm by default (mm if m_axis_unit_mm).
+    const double s_in  = m_axis_unit_mm ? 1.0 : 0.1;   // mm -> axis unit
+    const double s_out = m_axis_unit_mm ? 1.0 : 10.0;  // map value -> mm
+
+    const double xq = clamp_axis(h->GetXaxis(), x * s_in);
+    const double yq = clamp_axis(h->GetYaxis(), y * s_in);
+    const double zq = clamp_axis(h->GetZaxis(), z * s_in);
+    const double dx_map = h->Interpolate(xq, yq, zq);
+
+    return m_sign * dx_map * s_out;  // signed displacement in mm
+}


### PR DESCRIPTION
## Summary

Adds an SBND-ready 3D SCE correction to the toolkit as an `IPCTransform` composed from a new `ISCEField` interface. T0 correction is built in; the SCE backward displacements (X, optionally Y / Z) are delegated to whichever `ISCEField` implementation is wired in via configuration. This PR ships one such implementation, `SCEFieldTH3`, backed by per-TPC `TH3F` histograms loaded from a ROOT file (e.g. the SBND dualmap `SCEoffsets_SBND_E500_dualmap_CV_voxelTH3.root` model).

Validation evidence: WireCell/wcp-porting-validation#9 (Stage 1, merged) and WireCell/wcp-porting-validation#12 (Stage 3a, transverse).

## Architecture

- **`iface/inc/WireCellIface/ISCEField.h`** — pure-virtual `IComponent<ISCEField>` with `displacement_x(int apa, double x, double y, double z) const` (required) plus optional `displacement_y` / `displacement_z` (default no-op, so maps without transverse components are unaffected). WCT-internal mm in, mm out.
- **`root/inc/WireCellRoot/SCEFieldTH3.{h,cxx}`** — ROOT-backed `ISCEField` + `IConfigurable`. Loads up to six `TH3F`s (X / Y / Z × East / West) from a single ROOT file via a shared `interp()` helper; transverse histograms soft-load (skipped without error if absent). Handles cm ↔ mm axis units, sign convention, and `TH3::Interpolate`'s open-interval edge clamping.
- **`clus/inc/WireCellClus/SCECorrection.h` + `clus/src/PCTransforms.cxx`** — `SCECorrection` does T0 (per-APA `drift_speed` from `DetectorVolumes` metadata) plus the optional 3D SCE displacement via an injected `ISCEField::pointer`. `PCTransformSet::configure` looks up the field by TypeName from the `DetectorVolumes` metadata key `sce_field` via `Factory::find_tn`. If `sce_field` is absent, `SCECorrection` runs as T0-only.

The interface lives in `iface/`, the ROOT-backed implementation in `root/`, the transform in `clus/`. `clus/wscript_build` is untouched — `clus/` remains ROOT-free.

**Behavior change (intentional)**: `SCECorrection`'s `output_scope` is `{x_sce, y_sce, z_sce}`; `stored_array_names` likewise. Downstream configs that cluster on the SCE scope therefore cluster in fully-corrected 3D.

## Validation

50 SBND crossing-muon DETSIM events, 226 721 / 228 762 points paired by charge (99.1 %; 0.9 % dropped on ambiguous q), comparing the reco output to the input TH3 backward map at the corrected `(x_sce, y_sce, z_sce)` coordinates:

| quantity              | East           | West           |
|-----------------------|----------------|----------------|
| Δx rms (cm)           | 1.83 × 10⁻⁴    | 2.23 × 10⁻⁴    |
| Δy rms (cm)           | 2.63 × 10⁻⁴    | 1.65 × 10⁻⁴    |
| Δz rms (cm)           | 3.35 × 10⁻⁴    | 2.99 × 10⁻⁴    |
| max residual any (cm) | 9.91 × 10⁻⁴    | 9.91 × 10⁻⁴    |
| pooled mean\|Δx\| (cm) | 0.4026         | 0.5340         |

Pooled `W / E |Δx| = 1.326` — consistent with the map volume-average (1.276) and the patched 0.33-era reco (1.271). The implementation reproduces the TH3 backward map to interpolation precision (≈ 2 µm) in **all three components**.

## Configuration

Minimal jsonnet wiring for the SBND dualmap (3D):

```jsonnet
local sce_field = {
  type: "SCEFieldTH3",
  name: "sbnd_dualmap",
  data: {
    sce_map_file: "/cvmfs/.../SCEoffsets_SBND_E500_dualmap_CV_voxelTH3.root",
    th3_name_E:   "TrueBkwd_Displacement_X_E",
    th3_name_W:   "TrueBkwd_Displacement_X_W",
    th3_name_E_y: "TrueBkwd_Displacement_Y_E",  // optional
    th3_name_W_y: "TrueBkwd_Displacement_Y_W",  // optional
    th3_name_E_z: "TrueBkwd_Displacement_Z_E",  // optional
    th3_name_W_z: "TrueBkwd_Displacement_Z_W",  // optional
    axis_unit_mm: false,  // SBND TH3 axes are in cm
    sign:         -1,     // backward map
  },
};
// in the DetectorVolumes face metadata:
//   { ..., sce_field: wc.tn(sce_field) }
// and add sce_field to the PCTransformSet's `uses` list.
```

## Files

5 files, +466 / 0 across 3 commits:

| file                                           | status   |
|------------------------------------------------|----------|
| `iface/inc/WireCellIface/ISCEField.h`          | new      |
| `root/inc/WireCellRoot/SCEFieldTH3.h`          | new      |
| `root/src/SCEFieldTH3.cxx`                     | new      |
| `clus/inc/WireCellClus/SCECorrection.h`        | new      |
| `clus/src/PCTransforms.cxx`                    | modified |

cc @HaiwangYu