### PR TITLE
Portability fixes for building natively on macOS (Apple clang)

### DIFF
--- a/apps/src/AnodeDumper.cxx
+++ b/apps/src/AnodeDumper.cxx
@@ -49,8 +49,8 @@ void AnodeDumper::execute()
         auto& janode = sum["anodes"][anode_index++];
 
         janode["ident"] = ianode->ident();
-        janode["nfaces"] = ianode->faces().size();
-        janode["nchannels"] = ianode->channels().size();
+        janode["nfaces"] = (unsigned int)ianode->faces().size();
+        janode["nchannels"] = (unsigned int)ianode->channels().size();
 
         int face_index = 0;
         for (const auto& iface : ianode->faces()) {
@@ -66,8 +66,8 @@ void AnodeDumper::execute()
                 auto& jplane = jface["planes"][plane_index++];
                 jplane["ident"] = iplane->ident();
                 jplane["wpid"] = iplane->planeid().ident();
-                jplane["nchannels"] = iplane->channels().size();
-                jplane["nwires"] = iplane->wires().size();
+                jplane["nchannels"] = (unsigned int)iplane->channels().size();
+                jplane["nwires"] = (unsigned int)iplane->wires().size();
             }
         }
     }

--- a/clus/src/DynamicPointCloud.cxx
+++ b/clus/src/DynamicPointCloud.cxx
@@ -430,7 +430,11 @@ std::pair<double, double> DynamicPointCloud::hough_transform(const geo_point_t &
 
     // Use the original max finding approach
     auto indexed = bh::indexed(hist);
-    auto it = std::max_element(indexed.begin(), indexed.end());
+    // Compare cell values explicitly: the accessor's own comparison operators
+    // are ambiguous under Apple clang (boost::histogram detail::operators).
+    auto it = std::max_element(indexed.begin(), indexed.end(), [](const auto& a, const auto& b) {
+        return static_cast<double>(*a) < static_cast<double>(*b);
+    });
     const auto &cell = *it;
     return {cell.bin(0).center(), cell.bin(1).center()};
 }

--- a/clus/src/Facade_Summary.cxx
+++ b/clus/src/Facade_Summary.cxx
@@ -9,7 +9,7 @@ Clus::Facade::json_summary(const Clus::Facade::Grouping& grp)
 {
     Configuration ret;
     ret["type"] = "Grouping";
-    ret["hash"] = grp.hash();
+    ret["hash"] = (Json::UInt64)grp.hash();
     ret["nproj_centers"] = (int)grp.proj_centers().size();
     ret["npitch_mags"] = (int)grp.pitch_mags().size();
     ret["ndead_winds"] = (int)grp.all_dead_winds().size();
@@ -25,7 +25,7 @@ Configuration Clus::Facade::json_summary(const Clus::Facade::Cluster& cls)
     Configuration ret;
     // this is too huge to be exhaustive
     ret["type"] = "Cluster";
-    ret["hash"] = cls.hash();
+    ret["hash"] = (Json::UInt64)cls.hash();
     ret["length"] = cls.get_length();
     // ret["num_slices"] = cls.get_num_time_slices();
     ret["value"] = WireCell::PointCloud::json_summary(cls.value(), false);
@@ -39,7 +39,7 @@ Configuration Clus::Facade::json_summary(const Clus::Facade::Blob& blb)
 {
     Configuration ret;
     ret["type"] = "Blob";
-    ret["hash"] = blb.hash();
+    ret["hash"] = (Json::UInt64)blb.hash();
     ret["face"] = blb.wpid().face();
     ret["npoints"] = blb.npoints();
     ret["charge"] = blb.charge();

--- a/docs/macos-build.md
+++ b/docs/macos-build.md
@@ -1,0 +1,109 @@
+# Building WCT natively on macOS
+
+macOS is not an officially supported platform (CI runs on Linux), but the
+toolkit builds and runs natively on macOS with Homebrew-provided
+dependencies.  This recipe was validated on macOS 15 (Apple Silicon) with
+Apple clang 21 and Homebrew Boost 1.90.
+
+The differences from the standard Linux build (see the top-level
+[README](../README.org)) come down to: one dependency built from source
+(C++ libjsonnet), a few extra compiler/linker flags, explicit dependency
+paths at configure time, and a runtime environment variable for plugin
+loading.
+
+## Prerequisites
+
+Xcode Command Line Tools and cmake, plus:
+
+```sh
+brew install boost eigen spdlog jsoncpp fftw
+# fmt is pulled in as a spdlog dependency
+# tbb, root, nlohmann-json are optional
+```
+
+### C++ libjsonnet (built from source)
+
+Homebrew's `jsonnet` package is go-jsonnet: a command-line binary with no
+linkable library.  WCT links the C++ `libjsonnet`, so build it once:
+
+```sh
+git clone --depth 1 https://github.com/google/jsonnet ~/opt/jsonnet-src
+cd ~/opt/jsonnet-src
+cmake -S . -B build -DBUILD_SHARED_BINARIES=ON -DBUILD_TESTS=OFF \
+      -DBUILD_JSONNET=OFF -DBUILD_JSONNETFMT=OFF \
+      -DCMAKE_INSTALL_PREFIX=$HOME/opt/jsonnet \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+cmake --build build -j4 && cmake --install build
+```
+
+This installs `~/opt/jsonnet/include/libjsonnet.h` and
+`~/opt/jsonnet/lib/libjsonnet.dylib`.
+
+## Configure
+
+Two macOS-specific concerns are handled through environment variables,
+exported before running configure (they are baked into the configure
+cache, so only re-run configure to change them):
+
+- Homebrew's spdlog is compiled against an *external* fmt, so fmt's
+  include and link paths must be supplied.
+- Boost.Stacktrace needs `BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED` since
+  macOS has no glibc.
+
+```sh
+export CXXFLAGS="-I$(brew --prefix fmt)/include -DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED"
+export LINKFLAGS="-L$(brew --prefix fmt)/lib -lfmt"
+export LDFLAGS="-L$(brew --prefix fmt)/lib"
+```
+
+Homebrew kegs are not in the default header/library search paths, so each
+dependency is given explicitly:
+
+```sh
+./wcb configure \
+  --prefix=$HOME/opt/wct \
+  --with-root=no --with-tbb=no \
+  --boost-includes=$(brew --prefix boost)/include \
+  --boost-libs=$(brew --prefix boost)/lib \
+  --with-eigen-include=$(brew --prefix eigen)/include/eigen3 \
+  --with-spdlog=$(brew --prefix spdlog) \
+  --with-jsoncpp=$(brew --prefix jsoncpp) \
+  --with-jsonnet=$HOME/opt/jsonnet \
+  --with-fftw=$(brew --prefix fftw)
+```
+
+If you have ROOT or TBB installed via brew the corresponding packages can
+be enabled in the usual way.
+
+## Build and install
+
+```sh
+./wcb -j8
+./wcb install
+```
+
+## Runtime environment
+
+```sh
+export PATH=$HOME/opt/wct/bin:$PATH
+export DYLD_FALLBACK_LIBRARY_PATH=$HOME/opt/wct/lib
+```
+
+The `DYLD_FALLBACK_LIBRARY_PATH` is needed because plugin libraries are
+`dlopen()`ed by bare name (eg `libWireCellGen.dylib`) and macOS provides
+no `ld.so.conf`-style search path configuration.
+
+Check that the build works, including plugin/factory loading:
+
+```sh
+wire-cell --version
+wire-cell -p WireCellGen --help
+```
+
+### SIP caveat
+
+System Integrity Protection strips `DYLD_*` variables from the
+environment whenever a process is launched via a SIP-protected binary
+(`/usr/bin/perl`, `/usr/bin/timeout`, system shells in some contexts).
+If plugin loading mysteriously fails under a test harness or wrapper
+script, run `wire-cell` directly.

--- a/gen/test/doctest_drifter.cxx
+++ b/gen/test/doctest_drifter.cxx
@@ -102,7 +102,7 @@ TEST_CASE("drifter flat cathode")
 static std::vector<double> uniform_values(size_t seed, size_t number = 3, 
                                           double vmin=-1.0, double vmax=1.0)
 {
-    std::default_random_engine re{seed};
+    std::default_random_engine re{static_cast<std::default_random_engine::result_type>(seed)};
     std::uniform_real_distribution<double> dist(vmin, vmax);
 
     std::vector<double> vals(number);

--- a/util/inc/WireCellUtil/Configuration.h
+++ b/util/inc/WireCellUtil/Configuration.h
@@ -178,6 +178,13 @@ namespace WireCell {
         cfg = val;
     }
 
+    /// Json::Value has no overloads for plain (unsigned) long which on some
+    /// platforms (eg macOS) is distinct from both (unsigned) int and
+    /// Json::{U}Int64, making the assignment above ambiguous.  Route through
+    /// the explicit 64-bit types.
+    inline void assign(Configuration& cfg, long val) { cfg = (Json::Int64)val; }
+    inline void assign(Configuration& cfg, unsigned long val) { cfg = (Json::UInt64)val; }
+
     template <typename T>
     void assign(Configuration& cfg, const std::vector<T>& val)
     {

--- a/util/src/KDTree.cxx
+++ b/util/src/KDTree.cxx
@@ -35,7 +35,7 @@ struct DatasetSelectionAdaptor {
     {
         for (auto arr : points) {
             assert(arr);
-            assert(arr->is_type<ElementType>());
+            assert(arr->template is_type<ElementType>());
         }
         if (dim < points.size()) {
             auto arr = points[dim];
@@ -47,7 +47,7 @@ struct DatasetSelectionAdaptor {
             }
                 
             if (idx < arr->size_major()) {
-                element_t val = arr->element<ElementType>(idx);
+                element_t val = arr->template element<ElementType>(idx);
                 return val;
             }
         }

--- a/util/src/PluginManager.cxx
+++ b/util/src/PluginManager.cxx
@@ -47,7 +47,12 @@ WireCell::Plugin* WireCell::PluginManager::add(const std::string& plugin_name, c
         else {
             lname = libname;
         }
-        void* lib = dlopen(lname.c_str(), RTLD_NOW);
+        // RTLD_NODELETE: keep the plugin mapped even across dlclose, so that
+        // global factory makers (std::function targets living in this lib)
+        // remain valid through static teardown at program exit. Without it,
+        // the plugin is unmapped at exit before the GlobalFactoryRegistry
+        // singleton is destroyed -> use-after-unload crash (macOS).
+        void* lib = dlopen(lname.c_str(), RTLD_NOW | RTLD_NODELETE);
         if (!lib) {
             l->error("Failed to load {}: {}", lname, dlerror());
             continue;

--- a/util/test/doctest_boost_histogram.cxx
+++ b/util/test/doctest_boost_histogram.cxx
@@ -38,7 +38,11 @@ TEST_CASE("exercise two dimensional boost histogram") {
     // }
 
     {
-        auto it = std::max_element(indexed.begin(), indexed.end());
+        // Compare cell values explicitly: the accessor's own comparison operators
+        // are ambiguous under Apple clang (boost::histogram detail::operators).
+        auto it = std::max_element(indexed.begin(), indexed.end(), [](const auto& a, const auto& b) {
+            return static_cast<double>(*a) < static_cast<double>(*b);
+        });
         const auto& cell = *it;
         CHECK(cell.index(0) == 3);
         CHECK(cell.index(1) == 3);

--- a/util/test/doctest_coordregion.cxx
+++ b/util/test/doctest_coordregion.cxx
@@ -53,7 +53,7 @@ TEST_CASE("coord region scalar")
 static std::vector<double> uniform_values(size_t seed, size_t number = 3, 
                                           double vmin=-1.0, double vmax=1.0)
 {
-    std::default_random_engine re{seed};
+    std::default_random_engine re{static_cast<std::default_random_engine::result_type>(seed)};
     std::uniform_real_distribution<double> dist(vmin, vmax);
 
     std::vector<double> vals(number);

--- a/util/test/doctest_nfkdvec.cxx
+++ b/util/test/doctest_nfkdvec.cxx
@@ -76,7 +76,7 @@ static points_type make_other_points()
 static points_type random_points(size_t seed, size_t number = 3, size_t ndim = 3,
                                  double xmin=-1.0, double xmax=1.0)
 {
-    std::default_random_engine re{seed};
+    std::default_random_engine re{static_cast<std::default_random_engine::result_type>(seed)};
     std::uniform_real_distribution<double> dist(xmin, xmax);
 
     points_type points(ndim);

--- a/util/test/doctest_pointcloud_hough.cxx
+++ b/util/test/doctest_pointcloud_hough.cxx
@@ -88,7 +88,11 @@ TEST_CASE("point cloud hough janky track")
 
         {
             auto indexed = bh::indexed(hist);
-            auto it = std::max_element(indexed.begin(), indexed.end());
+            // Compare cell values explicitly: the accessor's own comparison operators
+            // are ambiguous under Apple clang (boost::histogram detail::operators).
+            auto it = std::max_element(indexed.begin(), indexed.end(), [](const auto& a, const auto& b) {
+                return static_cast<double>(*a) < static_cast<double>(*b);
+            });
             const auto& cell = *it;
 
             std::stringstream ss;


### PR DESCRIPTION
## Summary

Minimal source fixes that let current `master` build natively on macOS (Apple Silicon, Apple clang 21, Homebrew deps) — **all packages enabled**, including `clus` and `match`, plus all doctest/test programs. Each fix is a genuine portability/conformance issue; none change behavior on Linux.

- **util: qualify dependent template names in KDTree** — `arr->template is_type<T>()`; required by strict clang, a real conformance bug.
- **util/apps/clus: Json::Value vs `size_t`/`long` ambiguity** — on macOS `int64_t` is `long long`, so `size_t`/`unsigned long` match neither `(U)Int` nor `(U)Int64` and assignment is ambiguous. Added `assign()` overloads in `Configuration.h` (identity casts on Linux) and explicit casts in `AnodeDumper`/`Facade_Summary`.
- **clus/util: ambiguous `boost::histogram` accessor comparison** — `std::max_element` over `bh::indexed()` with the default comparator is ambiguous under Apple clang; compare cell values explicitly.
- **gen/util tests: `size_t` seed narrowing** — libc++'s `default_random_engine::result_type` is `unsigned int`; brace-init from `size_t` is a narrowing error.
- **util: `dlopen` plugins with `RTLD_NODELETE`** — fixes an exit-time crash on macOS where plugin libs were unmapped before the `GlobalFactoryRegistry` singleton was destroyed (use-after-unload of `std::function` makers).

- **docs: macOS build instructions** — `docs/macos-build.md` documents the Homebrew prerequisites, the from-source C++ libjsonnet step, the extra compiler/linker flags, configure invocation, and runtime environment.

## Validation (macOS 15 / Apple Silicon / Apple clang 21 / Homebrew Boost 1.90, jsoncpp, spdlog, fftw; C++ libjsonnet built from source)

- Full `./wcb` build of all 794 tasks succeeds (root/tbb/cuda/pytorch off).
- Touched doctests pass: `wcdoctest-util` histogram/configuration/coordregion/nfkdvec/hough (12 cases, 340 assertions), `wcdoctest-gen` drifter (3 cases, 245,813 assertions).
- `wire-cell --version` and plugin loading (`-p WireCellGen -p WireCellClus`) run and exit 0; previously a `wire-cell` job segfaulted at teardown without the `RTLD_NODELETE` fix.

macOS remains unofficial; with these fixes a stock Homebrew environment builds out of the box (the only extra step is building the C++ `libjsonnet`, since Homebrew ships go-jsonnet without a linkable library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
