### PR TITLE
Track segment sampling

### DIFF
--- a/aux/inc/WireCellAux/SimpleTrackSegment.h
+++ b/aux/inc/WireCellAux/SimpleTrackSegment.h
@@ -1,0 +1,41 @@
+#include "WireCellIface/ITrackSegment.h"
+
+namespace WireCell::Aux {
+
+    // A track segment that simply holds all the data it presents.
+    class SimpleTrackSegment : public WireCell::ITrackSegment {
+    public:
+        // If track_length is negative it is taken as the start to
+        // stop distance.
+        SimpleTrackSegment(const WireCell::Point& start, const WireCell::Point& stop,
+                           double start_time, double stop_time,
+                           double energy,
+                           double secondary = 0.0,
+                           double n_electrons = -1.0,
+                           double track_length = -1.0,
+                           int id = 0, int pdg = 0);
+
+        virtual const WireCell::Point& start() const;
+        virtual const WireCell::Point& stop() const;
+        virtual double start_time() const;
+        virtual double stop_time() const;
+        virtual double energy() const;
+        virtual double secondary() const;
+        virtual double n_electrons() const;
+        virtual double track_length() const;
+        virtual int id() const;
+        virtual int pdg() const;
+
+    private:
+        // bag o' data
+        WireCell::Point m_start, m_stop;
+        double m_start_time, m_stop_time;
+        double m_energy;
+        double m_secondary;
+        double m_n_electrons;
+        double m_track_length;
+        int m_id;
+        int m_pdg;
+    };
+
+}  // namespace WireCell::Aux

--- a/aux/inc/WireCellAux/SimpleTrackSegmentSet.h
+++ b/aux/inc/WireCellAux/SimpleTrackSegmentSet.h
@@ -1,0 +1,20 @@
+#include "WireCellIface/ITrackSegmentSet.h"
+
+namespace WireCell::Aux {
+
+    class SimpleTrackSegmentSet : public ITrackSegmentSet {
+        int m_ident;
+        ITrackSegment::shared_vector m_segments;
+
+       public:
+        SimpleTrackSegmentSet(int ident, const ITrackSegment::vector& segments)
+          : m_ident(ident)
+          , m_segments(std::make_shared<ITrackSegment::vector>(segments.begin(), segments.end()))
+        {
+        }
+        virtual ~SimpleTrackSegmentSet();
+        virtual int ident() const { return m_ident; }
+        virtual ITrackSegment::shared_vector segments() const { return m_segments; }
+    };
+
+}  // namespace WireCell::Aux

--- a/aux/src/AuxDestructors.cxx
+++ b/aux/src/AuxDestructors.cxx
@@ -3,6 +3,7 @@
 
 #include "WireCellAux/SimpleBlob.h"
 #include "WireCellAux/SimpleDepoSet.h"
+#include "WireCellAux/SimpleTrackSegmentSet.h"
 #include "WireCellAux/SimpleWire.h"
 
 using namespace WireCell::Aux;
@@ -10,4 +11,5 @@ using namespace WireCell::Aux;
 SimpleBlob::~SimpleBlob() {}
 SimpleBlobSet::~SimpleBlobSet() {}
 SimpleDepoSet::~SimpleDepoSet() {}
+SimpleTrackSegmentSet::~SimpleTrackSegmentSet() {}
 SimpleWire::~SimpleWire() {}

--- a/aux/src/SimpleTrackSegment.cxx
+++ b/aux/src/SimpleTrackSegment.cxx
@@ -1,0 +1,30 @@
+#include "WireCellAux/SimpleTrackSegment.h"
+
+using namespace WireCell::Aux;
+
+SimpleTrackSegment::SimpleTrackSegment(const WireCell::Point& start, const WireCell::Point& stop, double start_time,
+                                       double stop_time, double energy, double secondary, double n_electrons,
+                                       double track_length, int id, int pdg)
+  : m_start(start)
+  , m_stop(stop)
+  , m_start_time(start_time)
+  , m_stop_time(stop_time)
+  , m_energy(energy)
+  , m_secondary(secondary)
+  , m_n_electrons(n_electrons)
+  , m_track_length(track_length < 0 ? (stop - start).magnitude() : track_length)
+  , m_id(id)
+  , m_pdg(pdg)
+{
+}
+
+const WireCell::Point& SimpleTrackSegment::start() const { return m_start; }
+const WireCell::Point& SimpleTrackSegment::stop() const { return m_stop; }
+double SimpleTrackSegment::start_time() const { return m_start_time; }
+double SimpleTrackSegment::stop_time() const { return m_stop_time; }
+double SimpleTrackSegment::energy() const { return m_energy; }
+double SimpleTrackSegment::secondary() const { return m_secondary; }
+double SimpleTrackSegment::n_electrons() const { return m_n_electrons; }
+double SimpleTrackSegment::track_length() const { return m_track_length; }
+int SimpleTrackSegment::id() const { return m_id; }
+int SimpleTrackSegment::pdg() const { return m_pdg; }

--- a/aux/test/doctest_tracksegment.cxx
+++ b/aux/test/doctest_tracksegment.cxx
@@ -1,0 +1,75 @@
+#include "WireCellUtil/doctest.h"
+#include "WireCellUtil/Units.h"
+#include "WireCellAux/SimpleTrackSegment.h"
+#include "WireCellAux/SimpleTrackSegmentSet.h"
+
+using namespace WireCell;
+using namespace WireCell::Aux;
+
+TEST_CASE("aux simpletracksegment accessors") {
+    const Point start(1 * units::mm, 2 * units::mm, 3 * units::mm);
+    const Point stop(1 * units::mm, 2 * units::mm, 8 * units::mm);
+    const double t0 = 10 * units::ns;
+    const double t1 = 11 * units::ns;
+    const double energy = 1.05 * units::MeV;
+    const double secondary = 0.35 * units::MeV;
+    const double nele = 3.0e4;
+    const double tlen = 6 * units::mm;
+
+    SimpleTrackSegment ts(start, stop, t0, t1, energy, secondary, nele, tlen, 42, 13);
+
+    CHECK(ts.start() == start);
+    CHECK(ts.stop() == stop);
+    CHECK(ts.start_time() == t0);
+    CHECK(ts.stop_time() == t1);
+    CHECK(ts.energy() == energy);
+    CHECK(ts.secondary() == secondary);
+    CHECK(ts.n_electrons() == nele);
+    CHECK(ts.track_length() == tlen);
+    CHECK(ts.id() == 42);
+    CHECK(ts.pdg() == 13);
+}
+
+TEST_CASE("aux simpletracksegment defaults") {
+    const Point start(0, 0, 0);
+    const Point stop(3 * units::mm, 4 * units::mm, 0);
+
+    SimpleTrackSegment ts(start, stop, 0, 0, 2.1 * units::MeV);
+
+    // default track_length falls back to the start->stop distance
+    CHECK(ts.track_length() == doctest::Approx(5 * units::mm));
+    // unknown partition/count defaults
+    CHECK(ts.secondary() == 0.0);
+    CHECK(ts.n_electrons() < 0);
+    CHECK(ts.id() == 0);
+    CHECK(ts.pdg() == 0);
+
+    // a producer-given track length may exceed the straight-line distance
+    SimpleTrackSegment folded(start, stop, 0, 0, 2.1 * units::MeV, 0, -1, 7 * units::mm);
+    CHECK(folded.track_length() == 7 * units::mm);
+}
+
+TEST_CASE("aux simpletracksegmentset") {
+    ITrackSegment::vector segs;
+    for (int ind = 0; ind < 3; ++ind) {
+        const Point start(0, 0, ind * units::mm);
+        const Point stop(0, 0, (ind + 1) * units::mm);
+        segs.push_back(std::make_shared<SimpleTrackSegment>(start, stop, ind * units::ns, (ind + 1) * units::ns,
+                                                            0.21 * units::MeV, 0.07 * units::MeV, 6.0e3,
+                                                            1 * units::mm, ind, 11));
+    }
+
+    SimpleTrackSegmentSet tss(5, segs);
+    CHECK(tss.ident() == 5);
+    auto got = tss.segments();
+    REQUIRE(got != nullptr);
+    REQUIRE(got->size() == 3);
+
+    // access polymorphically through the interface
+    ITrackSegment::pointer one = got->at(1);
+    CHECK(one->start().z() == 1 * units::mm);
+    CHECK(one->stop().z() == 2 * units::mm);
+    CHECK(one->id() == 1);
+    CHECK(one->pdg() == 11);
+    CHECK(one->n_electrons() == doctest::Approx(6.0e3));
+}

--- a/gen/inc/WireCellGen/TrackSegmentSampler.h
+++ b/gen/inc/WireCellGen/TrackSegmentSampler.h
@@ -1,0 +1,73 @@
+// Sample track segments into point depositions, applying an ionization model
+// to turn deposited energy into a (negative) count of ionization electrons.
+
+#ifndef WIRECELLGEN_TRACKSEGMENTSAMPLER
+#define WIRECELLGEN_TRACKSEGMENTSAMPLER
+
+#include "WireCellIface/ITrackSegmentSampler.h"
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellAux/Logger.h"
+
+#include <functional>
+#include <string>
+
+namespace WireCell::Gen {
+
+    /** TrackSegmentSampler converts each segment of an input
+     *  ITrackSegmentSet into point depos placed uniformly along the
+     *  start->stop line (energy is deposited uniformly along a segment)
+     *  and emits them as one IDepoSet.
+     *
+     *  The ionization model turning a segment into a total electron count
+     *  is selected ONCE at configure() time and held as a function object
+     *  (no per-call mode dispatch).  Configuration:
+     *
+     *  - ionization: "recombination" (default) or "quanta".
+     *
+     *    "recombination" recomputes the electron count from the segment
+     *    energy and dE/dX = energy/track_length via the IRecombinationModel
+     *    component named by the "recombination" parameter (default
+     *    "BoxRecombination"; also "BirksRecombination", "MipRecombination").
+     *    The E-field, density and W-value are configured on that component.
+     *
+     *    "quanta" trusts the producer's per-segment n_electrons() (eg the
+     *    edep-sim 19.5 eV quanta split, already fluctuated -- it is not
+     *    re-fluctuated here).  A segment with unknown (negative)
+     *    n_electrons() is an error in this mode.
+     *
+     *  - step_size: sample spacing along the segment (default 1 mm).  A
+     *    segment of straight-line length L becomes N = max(1, ceil(L/step))
+     *    depos at the centers of N equal sub-intervals, each carrying 1/N of
+     *    the segment's charge and energy; times interpolate likewise.
+     *
+     *  Emitted depo charge follows the WCT convention that ionization
+     *  electrons are NEGATIVE (as the recombination models' Wi = 23.6
+     *  eV/-eplus yields); depo id/pdg come from the segment and extents are
+     *  zero (drifting adds diffusion).
+     */
+    class TrackSegmentSampler : public Aux::Logger, public ITrackSegmentSampler, public IConfigurable {
+       public:
+        TrackSegmentSampler();
+        virtual ~TrackSegmentSampler();
+
+        // ITrackSegmentSampler
+        virtual bool operator()(const input_pointer& in, output_pointer& out);
+
+        /// WireCell::IConfigurable interface.
+        virtual void configure(const WireCell::Configuration& config);
+        virtual WireCell::Configuration default_configuration() const;
+
+       private:
+        // Return the SIGNED total ionization charge (electrons negative)
+        // for one segment, per the configured ionization mode.
+        std::function<double(const ITrackSegment&)> m_ionize;
+
+        double m_step_size;
+        std::string m_ionization;
+        std::string m_recombination;
+        std::size_t m_count{0};
+    };
+
+}  // namespace WireCell::Gen
+
+#endif

--- a/gen/src/RecombinationModels.cxx
+++ b/gen/src/RecombinationModels.cxx
@@ -51,13 +51,17 @@ Gen::BirksRecombination::BirksRecombination(double Efield, double A3t, double k3
 Gen::BirksRecombination::~BirksRecombination() {}
 double Gen::BirksRecombination::operator()(double dE, double dX)
 {
-    const double R = m_a3t / (1 + (dE * units::cm / dX) * m_k3t / (m_efield * m_rho));
+    // dE/dX and k3t/(Efield*rho) are both expressed in the WCT system of
+    // units so their product is already dimensionless.  (An earlier version
+    // multiplied dE/dX by a spurious units::cm, inflating the quenching
+    // term 10x and yielding R~0.32 instead of ~0.70 for a MIP at 500 V/cm.)
+    const double R = m_a3t / (1 + (dE / dX) * m_k3t / (m_efield * m_rho));
     return R * dE / m_wi;
 }
 double Gen::BirksRecombination::dE(double dQ, double dX)
 {
     const double numerator = dQ;
-    const double denominator = m_a3t/m_wi - dQ/dX*units::cm * m_k3t/(m_efield*m_rho);
+    const double denominator = m_a3t/m_wi - dQ/dX * m_k3t/(m_efield*m_rho);
 
     return numerator / denominator;
 }
@@ -94,18 +98,18 @@ Gen::BoxRecombination::BoxRecombination(double Efield, double A, double B, doubl
 Gen::BoxRecombination::~BoxRecombination() {}
 double Gen::BoxRecombination::operator()(double dE, double dX)
 {
-    const double tmp = (dE /units::MeV*units::cm/ dX) * m_b / (m_efield * m_rho);
+    // See the units note in BirksRecombination::operator() -- dE/dX times
+    // B/(Efield*rho) is already dimensionless in the WCT system of units.
+    const double tmp = (dE / dX) * m_b / (m_efield * m_rho);
     const double R = std::log(m_a + tmp) / tmp;
     return R * dE / m_wi;
 }
 double Gen::BoxRecombination::dE(double dQ, double dX)
 {
     const double coeff = m_b / (m_efield * m_rho);
-    const double a_exp = std::exp(dQ/dX*units::cm * coeff * m_wi);
-    const double numerator = (a_exp - m_a) * units::MeV/units::cm *dX;
+    const double a_exp = std::exp(dQ/dX * coeff * m_wi);
+    const double numerator = (a_exp - m_a) * dX;
     const double denominator = coeff;
-
-    // std::cout << "Test: " << m_a << " " << m_b << " " << coeff << " " << a_exp << " " << numerator << " " << denominator << std::endl;
 
     return numerator / denominator;
 }

--- a/gen/src/TrackSegmentSampler.cxx
+++ b/gen/src/TrackSegmentSampler.cxx
@@ -1,0 +1,121 @@
+#include "WireCellGen/TrackSegmentSampler.h"
+
+#include "WireCellAux/SimpleDepo.h"
+#include "WireCellAux/SimpleDepoSet.h"
+#include "WireCellIface/IRecombinationModel.h"
+#include "WireCellUtil/Exceptions.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/Units.h"
+
+#include <cmath>
+
+WIRECELL_FACTORY(TrackSegmentSampler, WireCell::Gen::TrackSegmentSampler, WireCell::INamed,
+                 WireCell::ITrackSegmentSampler, WireCell::IConfigurable)
+
+using namespace WireCell;
+using namespace WireCell::Gen;
+
+TrackSegmentSampler::TrackSegmentSampler()
+  : Aux::Logger("TrackSegmentSampler", "gen")
+  , m_step_size(1.0 * units::mm)
+  , m_ionization("recombination")
+  , m_recombination("BoxRecombination")
+{
+}
+TrackSegmentSampler::~TrackSegmentSampler() {}
+
+WireCell::Configuration TrackSegmentSampler::default_configuration() const
+{
+    Configuration cfg;
+    cfg["ionization"] = m_ionization;
+    cfg["recombination"] = m_recombination;
+    cfg["step_size"] = m_step_size;
+    return cfg;
+}
+
+void TrackSegmentSampler::configure(const WireCell::Configuration& cfg)
+{
+    m_step_size = get<double>(cfg, "step_size", m_step_size);
+    if (m_step_size <= 0) {
+        THROW(ValueError() << errmsg{"TrackSegmentSampler: step_size must be positive"});
+    }
+
+    m_ionization = get<std::string>(cfg, "ionization", m_ionization);
+    m_recombination = get<std::string>(cfg, "recombination", m_recombination);
+
+    // Select the ionization model ONCE; operator() has no mode dispatch.
+    if (m_ionization == "quanta") {
+        m_ionize = [](const ITrackSegment& seg) -> double {
+            const double ne = seg.n_electrons();
+            if (ne < 0) {
+                THROW(ValueError() << errmsg{"TrackSegmentSampler: segment lacks n_electrons "
+                                             "required by ionization mode 'quanta'"});
+            }
+            return -ne;  // electrons are negative charge
+        };
+        log->debug("ionization mode 'quanta' (producer n_electrons)");
+        return;
+    }
+    if (m_ionization == "recombination") {
+        auto model = Factory::find_tn<IRecombinationModel>(m_recombination);
+        const double step = m_step_size;
+        m_ionize = [model, step](const ITrackSegment& seg) -> double {
+            // dE/dX from the full charged path length; fall back to the
+            // straight-line length, then to one step, for degenerate input.
+            double dX = seg.track_length();
+            if (dX <= 0) {
+                dX = (seg.stop() - seg.start()).magnitude();
+            }
+            if (dX <= 0) {
+                dX = step;
+            }
+            return (*model)(seg.energy(), dX);
+        };
+        log->debug("ionization mode 'recombination' via '{}'", m_recombination);
+        return;
+    }
+    THROW(ValueError() << errmsg{"TrackSegmentSampler: unknown ionization mode '" + m_ionization +
+                                 "' (expected 'recombination' or 'quanta')"});
+}
+
+bool TrackSegmentSampler::operator()(const input_pointer& in, output_pointer& out)
+{
+    out = nullptr;
+    if (!in) {
+        log->debug("EOS at call={}", m_count);
+        ++m_count;
+        return true;
+    }
+    if (!m_ionize) {
+        THROW(ValueError() << errmsg{"TrackSegmentSampler: not configured"});
+    }
+
+    IDepo::vector depos;
+    auto segments = in->segments();
+    if (segments) {
+        for (const auto& seg : *segments) {
+            const Point step_vec = seg->stop() - seg->start();
+            const double dist = step_vec.magnitude();
+            const int nsamples = std::max(1, static_cast<int>(std::ceil(dist / m_step_size)));
+
+            const double charge = m_ionize(*seg) / nsamples;
+            const double energy = seg->energy() / nsamples;
+            const double dtime = seg->stop_time() - seg->start_time();
+
+            for (int ind = 0; ind < nsamples; ++ind) {
+                const double frac = (ind + 0.5) / nsamples;
+                const Point pos = seg->start() + frac * step_vec;
+                const double time = seg->start_time() + frac * dtime;
+                depos.push_back(std::make_shared<Aux::SimpleDepo>(time, pos, charge, nullptr, 0.0,
+                                                                  0.0, seg->id(), seg->pdg(),
+                                                                  energy));
+            }
+        }
+    }
+
+    log->debug("call={} segments={} depos={}", m_count, segments ? segments->size() : 0,
+               depos.size());
+    ++m_count;
+    out = std::make_shared<Aux::SimpleDepoSet>(in->ident(), depos);
+    return true;
+}

--- a/gen/test/doctest_tracksegmentsampler.cxx
+++ b/gen/test/doctest_tracksegmentsampler.cxx
@@ -1,0 +1,170 @@
+#include "WireCellUtil/doctest.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/PluginManager.h"
+#include "WireCellUtil/Units.h"
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellIface/IRecombinationModel.h"
+#include "WireCellIface/ITrackSegmentSampler.h"
+#include "WireCellAux/SimpleTrackSegment.h"
+#include "WireCellAux/SimpleTrackSegmentSet.h"
+
+#include <cmath>
+#include <memory>
+
+using namespace WireCell;
+using WireCell::Aux::SimpleTrackSegment;
+using WireCell::Aux::SimpleTrackSegmentSet;
+
+namespace {
+
+// Instantiate + configure a named component with its defaults, as a WCT job's
+// config sequence would before any component that references it.
+void preconfigure(const std::string& tn)
+{
+    auto icfg = Factory::lookup_tn<IConfigurable>(tn);
+    icfg->configure(icfg->default_configuration());
+}
+
+ITrackSegmentSampler::pointer make_sampler(const std::string& name, Configuration extra)
+{
+    auto icfg = Factory::lookup_tn<IConfigurable>("TrackSegmentSampler:" + name);
+    auto cfg = icfg->default_configuration();
+    for (const auto& key : extra.getMemberNames()) {
+        cfg[key] = extra[key];
+    }
+    icfg->configure(cfg);
+    return Factory::lookup_tn<ITrackSegmentSampler>("TrackSegmentSampler:" + name);
+}
+
+double total_charge(const IDepoSet::pointer& ds)
+{
+    double tot = 0;
+    for (const auto& depo : *ds->depos()) {
+        tot += depo->charge();
+    }
+    return tot;
+}
+
+}  // namespace
+
+TEST_CASE("gen tracksegmentsampler recombination MIP") {
+    PluginManager& pm = PluginManager::instance();
+    pm.add("WireCellGen");
+
+    preconfigure("BoxRecombination");
+    Configuration extra;
+    extra["ionization"] = "recombination";
+    extra["recombination"] = "BoxRecombination";
+    auto sampler = make_sampler("mip", extra);
+
+    // A MIP-like 1 cm segment: dE/dx ~ 2.1 MeV/cm at the default 500 V/cm.
+    const double energy = 2.1 * units::MeV;
+    const double length = 1 * units::cm;
+    const Point start(10 * units::cm, 0, 0);
+    const Point stop(10 * units::cm, 0, length);
+    ITrackSegment::vector segs{std::make_shared<SimpleTrackSegment>(
+        start, stop, 0.0, 0.05 * units::us, energy, 0.0, -1.0, length, 42, 13)};
+
+    ITrackSegmentSampler::output_pointer out;
+    REQUIRE((*sampler)(std::make_shared<SimpleTrackSegmentSet>(3, segs), out));
+    REQUIRE(out != nullptr);
+    CHECK(out->ident() == 3);
+
+    auto depos = out->depos();
+    REQUIRE(depos != nullptr);
+    // 10 mm at the default 1 mm step.
+    REQUIRE(depos->size() == 10);
+
+    // Total charge matches the model called directly, and is NEGATIVE.
+    auto model = Factory::lookup_tn<IRecombinationModel>("BoxRecombination");
+    const double expected = (*model)(energy, length);
+    const double got = total_charge(out);
+    CHECK(got < 0);
+    CHECK(got == doctest::Approx(expected).epsilon(1e-9));
+
+    // Physics anchor: recombination factor ~0.7 at 500 V/cm, so the electron
+    // count for 2.1 MeV/cm is ~6e4/cm (23.6 eV ionization W-value).
+    const double nele = std::abs(got);
+    CHECK(nele > 5.5e4);
+    CHECK(nele < 7.0e4);
+    const double rfactor = nele * 23.6 * units::eV / energy;
+    CHECK(rfactor > 0.6);
+    CHECK(rfactor < 0.8);
+
+    // The model's inverse recovers the deposited energy.
+    CHECK(model->dE(got, length) == doctest::Approx(energy).epsilon(1e-6));
+
+    // Geometry/time interpolation: samples at the sub-interval centers.
+    const auto& first = depos->at(0);
+    const auto& last = depos->at(9);
+    CHECK(first->pos().z() == doctest::Approx(0.5 * units::mm));
+    CHECK(last->pos().z() == doctest::Approx(9.5 * units::mm));
+    CHECK(first->pos().x() == doctest::Approx(10 * units::cm));
+    CHECK(first->time() == doctest::Approx(0.05 * 0.05 * units::us));
+    CHECK(last->time() == doctest::Approx(0.95 * 0.05 * units::us));
+    // Truth keys and per-sample energy conservation.
+    CHECK(first->id() == 42);
+    CHECK(first->pdg() == 13);
+    CHECK(first->energy() == doctest::Approx(energy / 10));
+    CHECK(first->extent_long() == 0.0);
+    CHECK(first->extent_tran() == 0.0);
+}
+
+TEST_CASE("gen tracksegmentsampler quanta mode") {
+    PluginManager& pm = PluginManager::instance();
+    pm.add("WireCellGen");
+
+    Configuration extra;
+    extra["ionization"] = "quanta";
+    auto sampler = make_sampler("quanta", extra);
+
+    const Point start(0, 0, 0);
+    const Point stop(0, 0, 2 * units::mm);
+    const double nele = 1.2e4;
+
+    ITrackSegment::vector segs{std::make_shared<SimpleTrackSegment>(
+        start, stop, 0.0, 1 * units::ns, 0.42 * units::MeV, 0.14 * units::MeV, nele,
+        2 * units::mm, 7, 11)};
+    ITrackSegmentSampler::output_pointer out;
+    REQUIRE((*sampler)(std::make_shared<SimpleTrackSegmentSet>(1, segs), out));
+    REQUIRE(out->depos()->size() == 2);
+    CHECK(total_charge(out) == doctest::Approx(-nele));
+
+    // A segment lacking n_electrons is an error in quanta mode.
+    ITrackSegment::vector bad{std::make_shared<SimpleTrackSegment>(
+        start, stop, 0.0, 1 * units::ns, 0.42 * units::MeV)};
+    ITrackSegmentSampler::output_pointer bad_out;
+    CHECK_THROWS((*sampler)(std::make_shared<SimpleTrackSegmentSet>(2, bad), bad_out));
+}
+
+TEST_CASE("gen tracksegmentsampler edge cases") {
+    PluginManager& pm = PluginManager::instance();
+    pm.add("WireCellGen");
+
+    preconfigure("BoxRecombination");
+    auto sampler = make_sampler("edges", Configuration());
+
+    // Zero-length segment: one depo at the (degenerate) midpoint.
+    const Point at(1 * units::mm, 2 * units::mm, 3 * units::mm);
+    ITrackSegment::vector segs{std::make_shared<SimpleTrackSegment>(
+        at, at, 5 * units::ns, 5 * units::ns, 0.1 * units::MeV)};
+    ITrackSegmentSampler::output_pointer out;
+    REQUIRE((*sampler)(std::make_shared<SimpleTrackSegmentSet>(1, segs), out));
+    REQUIRE(out->depos()->size() == 1);
+    CHECK(out->depos()->at(0)->pos() == at);
+    CHECK(out->depos()->at(0)->time() == 5 * units::ns);
+    CHECK(out->depos()->at(0)->charge() < 0);
+
+    // EOS passes through.
+    ITrackSegmentSampler::output_pointer eos_out;
+    REQUIRE((*sampler)(nullptr, eos_out));
+    CHECK(eos_out == nullptr);
+
+    // Empty set -> empty depo set, same ident.
+    ITrackSegmentSampler::output_pointer empty_out;
+    REQUIRE((*sampler)(std::make_shared<SimpleTrackSegmentSet>(9, ITrackSegment::vector{}),
+                       empty_out));
+    REQUIRE(empty_out != nullptr);
+    CHECK(empty_out->ident() == 9);
+    CHECK(empty_out->depos()->size() == 0);
+}

--- a/iface/inc/WireCellIface/ITrackSegment.h
+++ b/iface/inc/WireCellIface/ITrackSegment.h
@@ -1,0 +1,67 @@
+#ifndef WIRECELL_ITRACKSEGMENT
+#define WIRECELL_ITRACKSEGMENT
+
+#include "WireCellIface/IData.h"
+#include "WireCellUtil/Point.h"
+
+namespace WireCell {
+
+    /** An interface to information about a track segment.
+     *
+     *  A track segment is a straight-line, calorimetric summary of
+     *  energy deposited along the path of a charged particle track.
+     *  A producer typically aggregates many tracking (eg Geant4)
+     *  steps into one segment and, depending on the producer's
+     *  configuration, may fold in energy deposited by secondary (eg
+     *  delta-ray) tracks.  The id() and pdg() thus identify a single,
+     *  possibly heuristic, "most important" associated track and not
+     *  necessarily the only contributor.
+     *
+     *  Values are expressed in the WCT system of units.
+     */
+    class ITrackSegment : public IData<ITrackSegment> {
+       public:
+        virtual ~ITrackSegment();
+
+        /// The location of the start of the segment.
+        virtual const Point& start() const = 0;
+
+        /// The location of the end of the segment.
+        virtual const Point& stop() const = 0;
+
+        /// The time at which the track was at start().
+        virtual double start_time() const = 0;
+
+        /// The time at which the track was at stop().
+        virtual double stop_time() const = 0;
+
+        /// The total energy deposited over the segment.
+        virtual double energy() const = 0;
+
+        /// The part of energy() lost to secondary (eg scintillation)
+        /// processes and thus not producing ionization, as determined
+        /// by the producer's quenching/recombination model.  Zero if
+        /// the producer does not provide the partition.
+        virtual double secondary() const = 0;
+
+        /// The number of ionization electrons produced over the
+        /// segment as determined by the producer.  Negative if the
+        /// producer does not provide the count.
+        virtual double n_electrons() const = 0;
+
+        /// The total charged particle path length contributing to
+        /// the segment.  This includes the path of any secondary
+        /// tracks folded into the segment and so may exceed the
+        /// start() to stop() distance.
+        virtual double track_length() const = 0;
+
+        /// The track ID of the associated track.
+        virtual int id() const = 0;
+
+        /// The PDG code of the associated track.
+        virtual int pdg() const = 0;
+    };
+
+}  // namespace WireCell
+
+#endif

--- a/iface/inc/WireCellIface/ITrackSegmentSampler.h
+++ b/iface/inc/WireCellIface/ITrackSegmentSampler.h
@@ -1,0 +1,30 @@
+#ifndef WIRECELL_ITRACKSEGMENTSAMPLER
+#define WIRECELL_ITRACKSEGMENTSAMPLER
+
+#include "WireCellIface/IFunctionNode.h"
+#include "WireCellIface/ITrackSegmentSet.h"
+#include "WireCellIface/IDepoSet.h"
+
+namespace WireCell {
+
+    /** TrackSegmentSet -> DepoSet
+     *
+     *  A track segment sampler converts each track segment in a set
+     *  into some number of point-like depositions, applying an
+     *  ionization model to determine the number of electrons.
+     */
+    class ITrackSegmentSampler : public IFunctionNode<ITrackSegmentSet, IDepoSet> {
+       public:
+        virtual ~ITrackSegmentSampler();
+
+        typedef std::shared_ptr<ITrackSegmentSampler> pointer;
+
+        virtual std::string signature() { return typeid(ITrackSegmentSampler).name(); }
+
+        // supply:
+        // virtual bool operator()(const input_pointer& in, output_pointer& out);
+    };
+
+}  // namespace WireCell
+
+#endif

--- a/iface/inc/WireCellIface/ITrackSegmentSet.h
+++ b/iface/inc/WireCellIface/ITrackSegmentSet.h
@@ -1,0 +1,23 @@
+#ifndef WIRECELL_ITRACKSEGMENTSET
+#define WIRECELL_ITRACKSEGMENTSET
+
+#include "WireCellIface/ITrackSegment.h"
+
+namespace WireCell {
+
+    /** An interface to information about a set of track segments.
+     */
+    class ITrackSegmentSet : public IData<ITrackSegmentSet> {
+       public:
+        virtual ~ITrackSegmentSet();
+
+        /// Return some identifier number that is unique to this set.
+        virtual int ident() const = 0;
+
+        /// Return the track segments in this set.
+        virtual ITrackSegment::shared_vector segments() const = 0;
+    };
+
+}  // namespace WireCell
+
+#endif

--- a/iface/src/IfaceDesctructors.cxx
+++ b/iface/src/IfaceDesctructors.cxx
@@ -102,6 +102,9 @@
 #include "WireCellIface/ITiling.h"
 #include "WireCellIface/ITrace.h"
 #include "WireCellIface/ITraceRanker.h"
+#include "WireCellIface/ITrackSegment.h"
+#include "WireCellIface/ITrackSegmentSampler.h"
+#include "WireCellIface/ITrackSegmentSet.h"
 #include "WireCellIface/IWaveform.h"
 #include "WireCellIface/IWaveformMap.h"
 #include "WireCellIface/IWireGenerator.h"
@@ -208,6 +211,9 @@ ITerminal::~ITerminal() {}
 ITiling::~ITiling() {}
 ITrace::~ITrace() {}
 ITraceRanker::~ITraceRanker() {}
+ITrackSegment::~ITrackSegment() {}
+ITrackSegmentSampler::~ITrackSegmentSampler() {}
+ITrackSegmentSet::~ITrackSegmentSet() {}
 IWaveform::~IWaveform() {}
 IWaveformMap::~IWaveformMap() {}
 IWireGenerator::~IWireGenerator() {}


### PR DESCRIPTION
This adds a new `ITrackSegmentSampler` interface and implementation and related `ITrackSegment` dadta and fixes bugs in the recombination models that WCT has provided for a long time (yet, never actually put into use as users have so far relied on models in upstream LArSoft).

A "track segment" here is essentially a G4 step, but could also represent an accumulation of nearly overlapping steps.  The "sampler" produces "depos" along a segment so that we may hook up WCT drift sim more directly to Geant4.  Specifically, this addition allows edep-sim to talk to WCT in the context of the DUNE Xerosere integration with Phlex.

The PR includes doctests.

Since this only adds code and fixes previously unused code, I don't expect any changes to existing workflows.
