### PR TITLE
cmake: build the flash package (light reconstruction for ProtoDUNEs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ set(WCT_PACKAGES util iface aux gen sigproc sig img pgraph sio quickhull)
 if(WCT_HAVE_PYTHON)
   list(APPEND WCT_PACKAGES pyutil)
 endif()
-list(APPEND WCT_PACKAGES clus match apps test cfg docs)
+list(APPEND WCT_PACKAGES clus match flash apps test cfg docs)
 
 # Optional packages, each gated on the WCT_HAVE_<DEP> flags discovered by
 # WCTDependencies.  This mirrors the per-package removal table in waft/wcb.py:

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -53,7 +53,7 @@ will and will not be built.
 -- WCT package 'pytorch' disabled (missing dependency: LIBTORCH)
 -- WCT package 'root' disabled (missing dependency: ROOTSYS)
 -- WCT package 'cuda' disabled (missing dependency: CUDA)
--- WCT packages configured: util;iface;aux;gen;sigproc;sig;img;pgraph;sio;quickhull;pyutil;clus;match;apps;test;cfg;docs;tbb;hio
+-- WCT packages configured: util;iface;aux;gen;sigproc;sig;img;pgraph;sio;quickhull;pyutil;clus;match;flash;apps;test;cfg;docs;tbb;hio
 -- Wire-Cell Toolkit cmake-build-0.35.0-904-g6ad16499 [triplet 0.35.0]
 --   build mode      : development (relaxed warnings)
 --   C++ standard    : c++17

--- a/flash/CMakeLists.txt
+++ b/flash/CMakeLists.txt
@@ -1,0 +1,1 @@
+wct_package(WireCellFlash  USE WireCellUtil WireCellIface WireCellAux)


### PR DESCRIPTION
This is a fix to include the build of the flash package, so that these can be used to do flash light reconstruction for ProtoDUNEs.

<details><summary>Claude Opus 5 (1M context)</summary>

**What was wrong.** `flash/` was the only WCT sub-package with a `wscript_build` but no `CMakeLists.txt`, and it appears in none of the package lists in the top-level `CMakeLists.txt`. waf discovers packages by globbing `*/wscript_build` (`waft/wcb.py:95`), so `libWireCellFlash.so` has always built there; the cmake build keeps a hand-maintained list, so a cmake build silently produced no `libWireCellFlash.so` and ran none of the flash doctests.

**The change.**
- `flash/CMakeLists.txt`: the same one-liner as `match/CMakeLists.txt`.
- `flash` added to the always-on core `WCT_PACKAGES` list rather than `WCT_OPTIONAL_PACKAGES`: its only externals are std headers plus `WireCellUtil`/`WireCellIface`/`WireCellAux`, with no ROOT usage.
- `cmake/README.md`: the sample configure transcript updated to match the new output.

**Verification** (cmake 3.30.2, configured into a scratch build dir with `-DWCT_WITH_TESTS=ON`):
- `-- WCT packages configured: util;iface;aux;gen;sigproc;sig;img;pgraph;sio;quickhull;pyutil;clus;match;flash;apps;test;cfg;docs;tbb;hio`
- `libWireCellFlash.so` links; `wcdoctest-obj-WireCellFlash` compiles both `doctest_opflashfinder.cxx` and `doctest_ophitfinder.cxx`
- the aggregate `wcdoctest` links with flash's objects and runs its cases: **12 passed | 0 failed**, 82 assertions

**Notes.** No new external dependency is introduced, and the `USE` set is the `util`/`iface`/`aux` spine rather than another plugin. The waf build is unaffected: every per-package glob in `waft/smplpkgs.py` is rooted in a subdirectory (`inc/`, `src/`, `dict/`, `apps/`, `docs/`, `test/`), so a `CMakeLists.txt` at the package root cannot enter any waf task.

</details>
