### PR TITLE
Spng mismatch

### DIFF
--- a/sigproc/src/OmnibusSigProc.cxx
+++ b/sigproc/src/OmnibusSigProc.cxx
@@ -1307,6 +1307,16 @@ void OmnibusSigProc::decon_2D_init(int plane)
     Waveform::realseq_t wire_filter_wf;
     auto ncr1 = Factory::find<IFilterWaveform>("HfFilter", m_Wire_filters[plane]);
     wire_filter_wf = ncr1->filter_waveform(m_c_data[plane].rows());
+
+    //Save for debugging if requested
+    if (m_dump_2d_spectra) {
+          const char* pn = (plane == 0) ? "U" : ((plane == 1) ? "V" : "W");
+          std::string fname = m_dump_2d_prefix + "_anode"
+                            + std::to_string(m_anode->ident()) + "_plane" + pn + ".npz";
+          cnpy::npz_save(fname, "wire_filter", wire_filter_wf, "a");
+      }
+
+    //Apply filter
     for (int irow = 0; irow < m_c_data[plane].rows(); ++irow) {
         for (int icol = 0; icol < m_c_data[plane].cols(); ++icol) {
             float val = abs(m_c_data[plane](irow, icol));

--- a/spng/cfg/spng/adc-to-osp.jsonnet
+++ b/spng/cfg/spng/adc-to-osp.jsonnet
@@ -32,6 +32,9 @@ function(input,
          detname='pdhd',
          tpcid=0,
          engine='Pgrapher',
+         run_dnnroi=true,
+         sink_tags=[], ##If you want to add tags then add them here. Note the tpcid will be appended
+                       ## i.e. --tla-code sink_tags="['decon_charge']" 
          device='cpu')
     
     local controls = control_js(device=device);
@@ -49,9 +52,17 @@ function(input,
         
     local roi = tpc.osp_subgraphs.dnnroi;
 
-    local sink = io.frame_array_sink(output);
+    local sink = io.frame_array_sink(
+        output,
+        // tags=['decon_charge'+std.toString(tpcid)]
+        tags=[t + std.toString(tpcid) for t in sink_tags]
+    );
 
-    local graph = pg.pipeline([source, sp, roi, sink]);
+    local graph = pg.pipeline(
+        [source, sp,] +
+        (if run_dnnroi then [roi,] else []) +
+        [sink]
+    );
     pg.main(graph, engine,
             plugins=["WireCellSpng", "WireCellSigProc", "WireCellPytorch"],
             uses = controls.uses)

--- a/spng/cfg/spng/adc-to-spng-decon-only.jsonnet
+++ b/spng/cfg/spng/adc-to-spng-decon-only.jsonnet
@@ -36,6 +36,7 @@ function(input,
          engine='Pgrapher',
          device='cpu',
          dump="",
+         rebin=4,
          outstage='gauss', //gauss, dnnroi, decon, tightroi?
          verbosity=0)
     
@@ -82,7 +83,6 @@ function(input,
 
 
     // True if care about cross view info for the view.
-    local rebin = 4;
 
     local source = io.frame_array_source(input);
     local sink = io.frame_array_any_sink(output);

--- a/spng/cfg/spng/depo-to-adc.jsonnet
+++ b/spng/cfg/spng/depo-to-adc.jsonnet
@@ -35,6 +35,7 @@ function(input,
          output="adc.npz",
          detname='pdhd',
          engine='Pgrapher',
+         add_noise=true,
          tpcid=0)
 
     local controls = control_js();
@@ -57,7 +58,7 @@ function(input,
 
     local sg = subgraphs_js(tpc, control);
 
-    local detmod = det_js(det, control);
+    local detmod = det_js(det, control, add_noise=add_noise);
 
     local sim = detmod.inducer;
 

--- a/spng/cfg/spng/det.jsonnet
+++ b/spng/cfg/spng/det.jsonnet
@@ -9,7 +9,7 @@ local frame_mod = import "spng/frame.jsonnet";
 local spng_mod = import "spng/spng.jsonnet";
 local fans_mod = import "spng/fans.jsonnet";
 
-function(det, control)
+function(det, control, add_noise=true)
 {
     // Intern these
     det: det,
@@ -33,7 +33,7 @@ function(det, control)
     // [1]IDepoSet->IFrame[ntpcs] node.  Applies detector response to depos to
     // produce ADC waveforms.  There is one oport per TPC.
     inducer:
-        detsim_mod(det, control),
+        detsim_mod(det, control, add_noise=add_noise),
 
 
     /// Note, to fanout a 3 view node to both OSP and SPNG, use fans.fanout_select().

--- a/spng/cfg/spng/detconfs/pdhd.jsonnet
+++ b/spng/cfg/spng/detconfs/pdhd.jsonnet
@@ -29,7 +29,7 @@ local response_start_time = tick0_time - response_time_offset;
 
 // How much to roll the response deconvolution. This essentially the ADC tick
 // where FR*ER goes to zero.
-local decon_roll = 128;
+local decon_roll = 129;
 
 local ductor = api.ductor(adc_tick, response_duration, response_start_time);
 local splat = api.splat(
@@ -135,11 +135,11 @@ local dnnroi_filters = [
     
 local channel_filters = [
     api.filter_axis([api.filter_function(scale=1.0 / wc.sqrtpi * 0.75)],
-                    period=1.0, ignore_baseline=false),
+                    period=0.5, ignore_baseline=false),
     api.filter_axis([api.filter_function(scale=1.0 / wc.sqrtpi * 0.75)],
-                     period=1.0, ignore_baseline=false),
+                     period=0.5, ignore_baseline=false),
     api.filter_axis([api.filter_function(scale=1.0 / wc.sqrtpi * 10.0)],
-                    period=1.0, ignore_baseline=false)
+                    period=0.5, ignore_baseline=false)
 ];
 
 local filters = [

--- a/spng/cfg/spng/detconfs/pdhd/sp.jsonnet
+++ b/spng/cfg/spng/detconfs/pdhd/sp.jsonnet
@@ -23,7 +23,8 @@ function(tpc)
         data: {
             anode: wc.tn(tpc.anode),
             dft: "FftwDFT",
-            
+            dump_2d_spectra: true,
+            dump_2d_prefix: "osp_dump",
             do_not_mp_protect_traditional: true, 
             field_response: wc.tn(tpc.fr),
             filter_responses_tn: [ ], // FIXME: this needs to be special for "bad APA1"

--- a/spng/cfg/spng/detsim.jsonnet
+++ b/spng/cfg/spng/detsim.jsonnet
@@ -9,15 +9,16 @@ local pg = import "pgraph.jsonnet";
 local drift = import "drift.jsonnet";
 local sim = import "sim.jsonnet";
 
-function(det, control={}, extra_name="")
+function(det, control={}, add_noise=true, extra_name="")
     // local drifter = drift(det, control).drifter;
     local the_sims = [sim(tpc, control) for tpc in det.tpcs];
     local pipes = [pg.pipeline([
         the_sim.depo_transform,
-        the_sim.reframer("_detsim"),
-        the_sim.addnoise_empirical,
-        the_sim.digitizer
-    ]) for the_sim in the_sims];
+        the_sim.reframer("_detsim"),] +
+        (if add_noise then [the_sim.addnoise_empirical]
+        else []) +
+        [the_sim.digitizer]
+    ) for the_sim in the_sims];
 
     if std.length(pipes) == 1
     then pipes[0]

--- a/spng/cfg/spng/subgraphs.jsonnet
+++ b/spng/cfg/spng/subgraphs.jsonnet
@@ -353,6 +353,7 @@ function(tpc, control={}, pg=real_pg, context_name="") {
                 plane_index: view_index,
                 // Scale to units of ADC
                 scale: -1 / tpc.adc.lsb_voltage,
+                debug_filename: "spng_resp_v" + std.toString(view_index)+".pkl",
             } + control,
             uses: [tpc.fr, tpc.er],
         },
@@ -388,6 +389,7 @@ function(tpc, control={}, pg=real_pg, context_name="") {
                     // See KernelConvolve for following options
                     tag="",
                     datapath_format="",
+                    debug_filename="",
                     extra_name="")::
         pg.pnode({
             type: "SPNGKernelConvolve",
@@ -397,6 +399,7 @@ function(tpc, control={}, pg=real_pg, context_name="") {
                 axis: axes_config,
                 tag: tag,
                 datapath_format: datapath_format,
+                debug_filename: debug_filename,
                 faster: true,       // use "faster DFT size"
             } + control
         }, nin=1, nout=1, uses=[kernel]),
@@ -421,6 +424,7 @@ function(tpc, control={}, pg=real_pg, context_name="") {
         };
         $.kernel_convolve(kernel, [co_channel, co_time],
                           datapath_format='/traces/group/' + std.toString(group_index) + "/KernelConvolve/" + name,
+                          debug_filename='spng_kernel_convolve'+std.toString(group_index)+'_dump.pkl',
                           tag="decon", extra_name='_'+group.name+extra_name),
 
     /// Return nodes[0] if length one else return a subgraph with a fanin that stacks the tensors.

--- a/spng/cfg/spng/subgraphs.jsonnet
+++ b/spng/cfg/spng/subgraphs.jsonnet
@@ -377,7 +377,8 @@ function(tpc, control={}, pg=real_pg, context_name="") {
         local name = $.this_name(extra_name, '_'+group.name);
         local plane_index = group.view_index;
         local fk = $.filter_kernel([tpc.filters[plane_index].channel.decon,{kind:"none"}],
-                                   extra_name=extra_name);
+                                //    extra_name=extra_name);
+                                   extra_name="v"+std.toString(plane_index)+extra_name);
         local rk = $.response_kernel(plane_index, extra_name=extra_name);
         $.decon_kernel(fk, rk, extra_name='_'+group.name+extra_name),
 
@@ -567,6 +568,7 @@ function(tpc, control={}, pg=real_pg, context_name="") {
     time_filter_view(filter, view_index, extra_name="")::
         local vis = std.toString(view_index);
         local name = $.this_name(extra_name, 'v'+vis);
+        //DO WE ALSO NEED TO SPECIFIY EXTRA NAME HERE FOR WIENER?
         local fk = $.filter_kernel([{kind:"none"}, tpc.filters[view_index].time[filter]], extra_name=extra_name);
         // local co = $.convo_options(0, view_index);
         local co_channel = {padding: "none", dft: false};

--- a/spng/inc/WireCellSpng/ResponseKernel.h
+++ b/spng/inc/WireCellSpng/ResponseKernel.h
@@ -49,8 +49,11 @@ namespace WireCell::SPNG {
         /// A multiplicative scale applied to the natural response tensor.
         ///
         /// The FR is originally in units of [current].  The ER is in units
-        /// [voltage/charge] and its coarse sample period T is multiplied to the
-        /// convolution of the two to give T(FR*ER) in units [voltage].  When
+        /// [voltage/charge] and is sampled at the FR's own (fine) period.  That
+        /// fine period T_fr, and NOT the coarse "period" below, is multiplied
+        /// to the convolution of the two to give T_fr(FR*ER) in units
+        /// [voltage] -- the convolution is a discrete sum on the fine grid, so
+        /// it is the fine period that turns it into a time integral.  When
         /// the response is used to deconvolve an ADC waveform tensor, it is
         /// convenient to convert the response kernel from units of [voltage] to
         /// a unitless ADC [count].  This is done by giving a scale that is in

--- a/spng/src/KernelConvolve.cxx
+++ b/spng/src/KernelConvolve.cxx
@@ -91,6 +91,8 @@ namespace WireCell::SPNG {
             raise<ValueError>("convolution requires 2D axes, got (%d)", naxes);
         }
 
+        //Assumes 2D as above
+        log->debug("Initial convolution kernel shape {} {}", kshape[0], kshape[1]);
 
         // Collect and check per input dimension values.
         m_roll.clear();
@@ -246,6 +248,7 @@ namespace WireCell::SPNG {
             maybe_save(tensor, fmt::format("resized_dim{}", dim));
         }
 
+        log->debug("Reshaping kernel to {}, {}", convolve_shape[0], convolve_shape[1]);
         auto kernel = to(m_kernel->spectrum(convolve_shape));
         if (has_nan(kernel)) {
             log->critical("kernel has NaNs {}", to_string(kernel));
@@ -254,7 +257,7 @@ namespace WireCell::SPNG {
 
         // This is supposed to not change data shared by other shallow copies.
         kernel = kernel.unsqueeze(0);
-
+        maybe_save(kernel, "final_kernel");
         // Our main event of the evening.
         tensor = convolve(tensor, kernel);
 

--- a/spng/src/ResponseKernel.cxx
+++ b/spng/src/ResponseKernel.cxx
@@ -107,7 +107,17 @@ namespace WireCell::SPNG {
         auto frer_coarse = LMN::resample_interval(frer_fine, fr_period_fine, m_cfg.period, 1);
 
         /// Convert to units of voltage/electron and apply user scale.
-        frer_coarse = frer_coarse * (float)m_cfg.period * (float)m_cfg.scale;
+        ///
+        /// The FR*ER product above is a discrete convolution taken on the FR's
+        /// own (fine) sampling grid, so it approximates the continuous
+        /// convolution divided by that fine period.  Recovering [voltage]
+        /// therefore multiplies by fr_period_fine, not by the (coarse) kernel
+        /// period: resample_interval() above is amplitude preserving
+        /// (Normalization::kInterpolation) and so does not rescale to the new
+        /// period.  Using m_cfg.period here inflated the response by
+        /// m_cfg.period/fr_period_fine and left deconvolved charge low by that
+        /// same factor.
+        frer_coarse = frer_coarse * (float)fr_period_fine * (float)m_cfg.scale;
 
         log->debug("er_period={}, scale={}, er_fine={}, fr_period={}, fr_fine={}, linear_size={}, fr_pad={}, er_pad={}, frer_fine={}, frer_coarse={}",
                    er_sampling.binsize(), m_cfg.scale, to_string(er_fine),

--- a/spng/src/ResponseKernel.cxx
+++ b/spng/src/ResponseKernel.cxx
@@ -105,7 +105,7 @@ namespace WireCell::SPNG {
         maybe_save(frer_fine, "fine_frer");
 
         auto frer_coarse = LMN::resample_interval(frer_fine, fr_period_fine, m_cfg.period, 1);
-
+        maybe_save(frer_coarse, "coarse_frer");
         /// Convert to units of voltage/electron and apply user scale.
         ///
         /// The FR*ER product above is a discrete convolution taken on the FR's

--- a/spng/test/doctest_responsekernel.cxx
+++ b/spng/test/doctest_responsekernel.cxx
@@ -1,0 +1,137 @@
+/** Tests for SPNG ResponseKernel normalization.
+ *
+ * The kernel produced by ResponseKernel samples a fixed continuous detector
+ * response V(t), in units of ADC count per electron, at the configured sample
+ * period T.  Consequently the discrete kernel R[m] = V(m*T) must satisfy
+ *
+ *     sum_m R[m] * T  ==  integral V(t) dt
+ *
+ * and the right hand side does not depend on T.  So "DC * period" is an
+ * invariant of the configured period.  This is the property that makes charge
+ * come out right after deconvolution: a charge Q deposited in one tick yields
+ * a measured ADC series Q*R[m], and dividing by the response recovers Q only
+ * when R is the true per-sample response.
+ *
+ * Note the field response is sampled at its own (fine) period, 100 ns for the
+ * DUNE garfield response, while the kernel is normally requested at the 500 ns
+ * ADC tick.  When the two periods are equal, TorchLMN::resample_interval()
+ * short circuits, so a kernel built at the fine period exercises no resampling
+ * and serves as the anchor for the comparison.
+ */
+
+#include "WireCellSpng/ResponseKernel.h"
+#include "WireCellSpng/Testing.h"
+
+#include "WireCellIface/IConfigurable.h"
+
+#include "WireCellUtil/Configuration.h"
+#include "WireCellUtil/NamedFactory.h"
+#include "WireCellUtil/PluginManager.h"
+#include "WireCellUtil/Units.h"
+
+#include <cmath>
+#include <vector>
+
+using namespace WireCell;
+using namespace WireCell::SPNG;
+
+// The field response sampling period.  Must match the "period" of the field
+// response file named below.
+static const double fr_period = 100 * units::ns;
+
+// The conventional ADC tick, and a second, unrelated coarse period.  Neither
+// divides into the other in a way that could hide a period-dependent scale.
+static const double adc_tick = 500 * units::ns;
+static const double other_tick = 1000 * units::ns;
+
+static const std::string response_file = "dune-garfield-1d565.json.bz2";
+
+// FieldResponse lives in WireCellSigProc and ColdElecResponse in WireCellGen.
+// These are loaded at run time by the test binary; SPNG itself does not link
+// against either plugin.
+static int init_plugins()
+{
+    auto& pm = PluginManager::instance();
+    pm.add("WireCellAux");
+    pm.add("WireCellGen");
+    pm.add("WireCellSigProc");
+    return 0;
+}
+static int plugins_initialized = init_plugins();
+
+// Configure the shared FR and ER components exactly once.
+static void configure_responses()
+{
+    static bool done = false;
+    if (done) return;
+    done = true;
+
+    {
+        auto icfg = Factory::lookup<IConfigurable>("FieldResponse");
+        auto cfg = icfg->default_configuration();
+        cfg["filename"] = response_file;
+        icfg->configure(cfg);
+    }
+    {
+        auto icfg = Factory::lookup<IConfigurable>("ColdElecResponse");
+        icfg->configure(icfg->default_configuration());
+    }
+}
+
+// Return sum_m R[m] for a kernel built at the given plane and period.  The DC
+// element of the 2D spectrum is the sum over the whole (wire, time) kernel, and
+// pad_waveform() zero pads, so this is independent of the requested shape as
+// long as the shape is large enough to hold the response.
+static double kernel_dc(int plane_index, double period)
+{
+    configure_responses();
+
+    ResponseKernel rk;
+    Configuration cfg = rk.default_configuration();
+    cfg["field_response"] = "FieldResponse";
+    cfg["elec_response"] = "ColdElecResponse";
+    cfg["elec_duration"] = 20 * units::us;
+    cfg["period"] = period;
+    cfg["plane_index"] = plane_index;
+    cfg["scale"] = 1.0;
+    rk.configure(cfg);
+
+    // Generous shape so no part of the response is cropped at any period.
+    ITorchSpectrum::shape_t shape = {128, 8192};
+    auto spec = rk.spectrum(shape);
+    return torch::real(spec[0][0]).item<double>();
+}
+
+TEST_SUITE("spng response kernel") {
+
+    // The normalization must not depend on the sample period the kernel is
+    // built at.  This currently FAILS: ResponseKernel.cxx multiplies the
+    // fine-grid convolution by the coarse period m_cfg.period instead of by
+    // the field response period, so the kernel is too large by the ratio of
+    // the two periods and "DC * period" grows linearly with the period.
+    TEST_CASE("spng response kernel normalization is period independent") {
+
+        for (int plane_index : {0, 1, 2}) {
+
+            const double ref = kernel_dc(plane_index, fr_period) * fr_period;
+            REQUIRE(std::abs(ref) > 0.0);
+
+            for (double period : {adc_tick, other_tick}) {
+                const double got = kernel_dc(plane_index, period) * period;
+                const double ratio = got / ref;
+
+                INFO("plane=" << plane_index
+                     << " period=" << period / units::ns << "ns"
+                     << " ref=" << ref << " got=" << got
+                     << " ratio=" << ratio
+                     << " (expected 1, a ratio of period/" << fr_period / units::ns
+                     << "ns indicates the coarse period is being applied to a"
+                        " fine-grid convolution)");
+
+                // 2% covers the small difference in rational padding between
+                // periods; the defect under test is a factor of 5 and 10.
+                CHECK(std::abs(ratio - 1.0) < 0.02);
+            }
+        }
+    }
+}

--- a/util/test/doctest_response.cxx
+++ b/util/test/doctest_response.cxx
@@ -13,6 +13,6 @@ TEST_CASE("util field response")
     // MESSAGE("WIRECELL_PATH=" << (wcpath ? wcpath : "(unset)"));
     // std::cerr << wcpath << std::endl;
 
-    /*auto fr =*/ Response::Schema::load(fr_file.c_str());
+    auto fr = Response::Schema::load(fr_file.c_str());
     /*auto fravg =*/ Response::wire_region_average(fr);
 }


### PR DESCRIPTION
This includes some changes which get us closer to Splat and OSP.

One is the name collision that I showed at the hackathon and has a minor, but non-negligible change to the output of SPNG

The other I think is worse. Claude thinks that one should not multiply by the coarse period when resampling because 

```
        ///
        /// The FR*ER product above is a discrete convolution taken on the FR's
        /// own (fine) sampling grid, so it approximates the continuous
        /// convolution divided by that fine period.  Recovering [voltage]
        /// therefore multiplies by fr_period_fine, not by the (coarse) kernel
        /// period: resample_interval() above is amplitude preserving
        /// (Normalization::kInterpolation) and so does not rescale to the new
        /// period.  Using m_cfg.period here inflated the response by
        /// m_cfg.period/fr_period_fine and left deconvolved charge low by that
        /// same factor.
```

U plane channel 338
<img width="1920" height="1118" alt="image" src="https://github.com/user-attachments/assets/f1ea6a81-d5cb-4bf7-9a9b-655759bb9140" />

V plane channel 1120
<img width="1920" height="1118" alt="image" src="https://github.com/user-attachments/assets/30c0a65c-f7e6-4f1c-9cb8-52752fc4a5b9" />

W plane channel 2160
<img width="1920" height="1118" alt="image" src="https://github.com/user-attachments/assets/0a741100-cf6f-49c0-baec-b5e4e0ec063c" />


The w plane one is much closer to osp/splat. U and V plane are still quite different, with U being worse than V.  Continuing to investigate