### PR TITLE
DftTools: fix replace() and convolve() (wrong operands, inverted ratio, missing inverse DFT) + regression tests

### DIFF
--- a/aux/inc/WireCellAux/DftTools.h
+++ b/aux/inc/WireCellAux/DftTools.h
@@ -108,30 +108,44 @@ namespace WireCell::Aux::DftTools {
     real_array_t inv_c2r_real(const IDFT::pointer& dft, const complex_array_t& spec, int axis);
 
 
-    /// Convolve in1 and in2 via DFT.  Returned vecgtor has size sum
-    /// of sizes of in1 and in2 less one element in order to assure no
-    /// periodic aliasing.  Caller need not (should not) pad either
-    /// input.  Caller is free to truncate result as required.
+    /// Linearly convolve wave1 and wave2 via DFT.  Returned vector has
+    /// size sum of sizes of wave1 and wave2 less one element in order
+    /// to assure no periodic aliasing.  Caller need not (should not)
+    /// pad either input.  Caller is free to truncate result as
+    /// required.
     real_vector_t convolve(const IDFT::pointer& dft,
                            const real_vector_t& wave1,
                            const real_vector_t& wave2);
 
 
-    /// Replace response res1 in meas with response res2.
+    /// Replace one response with another in a measured waveform.
     ///
-    /// This will compute the FFT of all three, in frequency space will form:
+    /// The waveform "meas" is taken to be some underlying signal
+    /// convolved with the response "res_old".  This returns the
+    /// waveform that would have been measured had the signal instead
+    /// been convolved with "res_new".  All three are zero-padded to a
+    /// common size, forward transformed and in frequency space this
+    /// forms:
     ///
-    ///     meas * resp2 / resp1
+    ///     FFT(meas) * FFT(res_new) / FFT(res_old)
     ///
-    /// apply the inverse FFT and return its real part.
+    /// The inverse FFT is applied and the real part returned.
+    ///
+    /// Frequency bins in which FFT(res_old) is exactly zero are left
+    /// unscaled (the ratio is taken as 1) rather than producing inf or
+    /// NaN.  No other regularization of the deconvolution is applied.
     ///
     /// The output vector is long enough to assure no periodic
     /// aliasing.  In general, caller should NOT pre-pad any input.
     /// Any subsequent truncation of result is up to caller.
+    ///
+    /// The argument order (new response before old response) follows
+    /// the legacy Waveform::replace_convolve(wave, newres, oldres) and
+    /// the callers Gen::Misconfigure and Gen::PerChannelVariation.
     real_vector_t replace(const IDFT::pointer& dft,
                           const real_vector_t& meas,
-                          const real_vector_t& res1,
-                          const real_vector_t& res2);
+                          const real_vector_t& res_new,
+                          const real_vector_t& res_old);
 
 
 

--- a/aux/src/DftTools.cxx
+++ b/aux/src/DftTools.cxx
@@ -189,58 +189,68 @@ DftTools::real_array_t DftTools::inv_c2r_real(const IDFT::pointer& dft, const Df
 
 /*** high level functions ***/
 
+// Zero-pad a real waveform to the given size and forward transform it.
+static DftTools::complex_vector_t padded_spectrum(const IDFT::pointer& dft,
+                                                  const DftTools::real_vector_t& wave,
+                                                  size_t size)
+{
+    DftTools::real_vector_t padded(size, 0);
+    std::copy(wave.begin(), wave.end(), padded.begin());
+    return DftTools::fwd_r2c(dft, padded);
+}
+
 DftTools::real_vector_t DftTools::convolve(const IDFT::pointer& dft,
                                  const DftTools::real_vector_t& in1,
                                  const DftTools::real_vector_t& in2)
 {
-    size_t size = in1.size() + in2.size() - 1;
-    DftTools::complex_vector_t cin1(size,0), cin2(size,0);
+    const size_t size = in1.size() + in2.size() - 1;
 
-    std::transform(in1.begin(), in1.end(), cin1.begin(),
-                   [](float re) { return DftTools::complex_t(re,0.0); } );
-    std::transform(in2.begin(), in2.end(), cin2.begin(),
-                   [](float re) { return DftTools::complex_t(re,0.0); } );
-
-    dft->fwd1d(cin1.data(), cin1.data(), size);
-    dft->fwd1d(cin2.data(), cin2.data(), size);
+    auto spec1 = padded_spectrum(dft, in1, size);
+    const auto spec2 = padded_spectrum(dft, in2, size);
 
     for (size_t ind=0; ind<size; ++ind) {
-        cin1[ind] *= cin2[ind];
+        spec1[ind] *= spec2[ind];
     }
 
-    DftTools::real_vector_t ret(size);
-    std::transform(cin1.begin(), cin1.end(), ret.begin(),
-                   [](const complex_t& c) { return std::real(c); });
-    return ret;
+    // Inverse transform back to the time domain.  (Prior to the fix
+    // for issue #531 this step was missing and the real part of the
+    // spectrum was returned.)
+    return DftTools::inv_c2r(dft, spec1);
 }
 
 DftTools::real_vector_t DftTools::replace(const IDFT::pointer& dft,
                                 const DftTools::real_vector_t& meas,
-                                const DftTools::real_vector_t& res1,
-                                const DftTools::real_vector_t& res2)
+                                const DftTools::real_vector_t& res_new,
+                                const DftTools::real_vector_t& res_old)
 {
-    size_t sizes[3] = {meas.size(), res1.size(), res2.size()};
-    size_t size = sizes[0] + sizes[1] + sizes[2] - *std::min_element(sizes, sizes + 3) - 1;
+    // Pad to a size large enough that the linear convolution of meas
+    // with the (new/old) response ratio suffers no periodic aliasing.
+    // This is the same size rule as the legacy Waveform::replace_convolve().
+    const size_t sizes[3] = {meas.size(), res_new.size(), res_old.size()};
+    const size_t size = sizes[0] + sizes[1] + sizes[2] - *std::min_element(sizes, sizes + 3) - 1;
 
-    DftTools::complex_vector_t cmeas(size,0), cres1(size,0), cres2(size,0);
-    std::transform(meas.begin(), meas.end(), cmeas.begin(),
-                   [](float re) { return DftTools::complex_t(re,0.0); } );
-    std::transform(res1.begin(), res1.end(), cres1.begin(),
-                   [](float re) { return DftTools::complex_t(re,0.0); } );
-    std::transform(res2.begin(), res2.end(), cres2.begin(),
-                   [](float re) { return DftTools::complex_t(re,0.0); } );
+    auto smeas = padded_spectrum(dft, meas, size);
+    const auto snew = padded_spectrum(dft, res_new, size);
+    const auto sold = padded_spectrum(dft, res_old, size);
 
-    dft->fwd1d(cmeas.data(), cmeas.data(), size);
-    dft->fwd1d(cres1.data(), cres1.data(), size);
-    dft->fwd1d(cres2.data(), cres2.data(), size);
-
+    // Form meas * new / old in frequency space.
+    //
+    // Issue #531: the previous implementation divided by the untransformed,
+    // unpadded time-domain response samples (reading past their ends),
+    // had the new/old ratio inverted and never applied the inverse
+    // transform.  See the doctest in aux/test/doctest_dfttools_replace.cxx.
+    const complex_t zero{0, 0};
     for (size_t ind=0; ind<size; ++ind) {
-        cmeas[ind] *= res2[ind]/res1[ind];
+        const complex_t den = sold[ind];
+        if (den == zero) {
+            // Old response has no power at this frequency so the
+            // measurement should not either.  Leave the bin unscaled
+            // rather than emit inf/NaN.
+            continue;
+        }
+        smeas[ind] *= snew[ind] / den;
     }
-    DftTools::real_vector_t ret(size);
-    std::transform(cmeas.begin(), cmeas.end(), ret.begin(),
-                   [](const complex_t& c) { return std::real(c); });
 
-    return ret;
+    return DftTools::inv_c2r(dft, smeas);
 }
 

--- a/aux/test/doctest_dfttools_replace.cxx
+++ b/aux/test/doctest_dfttools_replace.cxx
@@ -1,0 +1,209 @@
+// Regression tests for the high level 1D helpers
+// DftTools::convolve() and DftTools::replace().
+//
+// Issue #531: DftTools::replace() divided by the untransformed, unpadded
+// time-domain response samples (reading past their ends), had the
+// new/old ratio inverted and never applied the inverse transform.  This
+// corrupted every channel run through Gen::PerChannelVariation (the
+// MicroBooNE overlay simulation) and the selected channels run through
+// Gen::Misconfigure.  DftTools::convolve() had the same missing inverse
+// transform.
+//
+// These tests compare against direct O(N*M) linear convolution so they
+// fail on the pre-fix implementation and pass on the fixed one.
+
+#include "WireCellUtil/doctest.h"
+#include "WireCellUtil/PluginManager.h"
+#include "WireCellUtil/NamedFactory.h"
+
+#include "WireCellAux/DftTools.h"
+#include "WireCellIface/IDFT.h"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+
+using namespace WireCell;
+using namespace WireCell::Aux;
+
+using RV = DftTools::real_vector_t;
+
+static IDFT::pointer get_dft()
+{
+    PluginManager& pm = PluginManager::instance();
+    pm.add("WireCellAux");
+    return Factory::lookup_tn<IDFT>("FftwDFT");
+}
+
+// Direct linear convolution, size a.size()+b.size()-1.
+static RV linear_convolve(const RV& a, const RV& b)
+{
+    if (a.empty() || b.empty()) return RV{};
+    RV out(a.size() + b.size() - 1, 0.0f);
+    for (size_t i = 0; i < a.size(); ++i) {
+        for (size_t j = 0; j < b.size(); ++j) {
+            out[i + j] += a[i] * b[j];
+        }
+    }
+    return out;
+}
+
+static RV random_wave(size_t n, unsigned seed)
+{
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    RV v(n);
+    for (auto& x : v) x = dist(rng);
+    return v;
+}
+
+// A causal, exponentially decaying "response" of n samples.  Its DFT
+// is a geometric sum that never vanishes so deconvolution by it is
+// well-conditioned.
+static RV decay_response(size_t n, float tau, float scale)
+{
+    RV v(n);
+    for (size_t i = 0; i < n; ++i) v[i] = scale * std::exp(-float(i) / tau);
+    return v;
+}
+
+static float max_abs(const RV& v)
+{
+    float m = 0;
+    for (auto x : v) m = std::max(m, std::abs(x));
+    return m;
+}
+
+static bool all_finite(const RV& v)
+{
+    return std::all_of(v.begin(), v.end(), [](float x) { return std::isfinite(x); });
+}
+
+// Check that got matches want (over want's length) to within a
+// tolerance relative to the largest expected value, and that any
+// samples beyond want's length are compatible with zero.
+static void check_close(const RV& got, const RV& want, float rel_tol)
+{
+    REQUIRE(got.size() >= want.size());
+    REQUIRE(all_finite(got));
+    const float tol = rel_tol * max_abs(want);
+    for (size_t i = 0; i < want.size(); ++i) {
+        INFO("index " << i);
+        CHECK(std::abs(got[i] - want[i]) <= tol);
+    }
+    for (size_t i = want.size(); i < got.size(); ++i) {
+        INFO("tail index " << i);
+        CHECK(std::abs(got[i]) <= tol);
+    }
+}
+
+TEST_SUITE("DftTools high level 1D helpers") {
+
+    TEST_CASE("convolve matches direct linear convolution") {
+        auto dft = get_dft();
+        const RV a = random_wave(37, 1u);
+        const RV b = random_wave(11, 2u);
+
+        const RV got = DftTools::convolve(dft, a, b);
+        const RV want = linear_convolve(a, b);
+
+        CHECK(got.size() == a.size() + b.size() - 1);
+        check_close(got, want, 1e-4f);
+    }
+
+    TEST_CASE("convolve is commutative") {
+        auto dft = get_dft();
+        const RV a = random_wave(20, 3u);
+        const RV b = random_wave(33, 4u);
+        const RV ab = DftTools::convolve(dft, a, b);
+        const RV ba = DftTools::convolve(dft, b, a);
+        check_close(ab, ba, 1e-5f);
+    }
+
+    TEST_CASE("replace swaps old response for new response") {
+        auto dft = get_dft();
+
+        // Underlying "true" signal: a few impulses of differing sign.
+        RV signal(100, 0.0f);
+        signal[10] = 1.0f;
+        signal[40] = -2.5f;
+        signal[41] = -2.5f;
+        signal[77] = 0.7f;
+
+        // Responses of differing length and shape, in the caller's
+        // (Gen::Misconfigure / Gen::PerChannelVariation) convention:
+        // the measurement was made with res_old, we want res_new.
+        const RV res_old = decay_response(20, 5.0f, 1.0f);
+        const RV res_new = decay_response(25, 3.0f, 2.0f);
+
+        const RV meas = linear_convolve(signal, res_old);
+        const RV want = linear_convolve(signal, res_new);
+
+        const RV got = DftTools::replace(dft, meas, res_new, res_old);
+
+        // Size rule shared with legacy Waveform::replace_convolve().
+        const size_t sizes[3] = {meas.size(), res_new.size(), res_old.size()};
+        const size_t expected_size = sizes[0] + sizes[1] + sizes[2]
+            - *std::min_element(sizes, sizes + 3) - 1;
+        CHECK(got.size() == expected_size);
+
+        // Deconvolution amplifies round-off; 1e-3 relative is still
+        // orders of magnitude below the pre-fix garbage.
+        check_close(got, want, 1e-3f);
+    }
+
+    TEST_CASE("replace with identical responses is the identity") {
+        auto dft = get_dft();
+        const RV meas = random_wave(64, 5u);
+        const RV res = decay_response(16, 4.0f, 1.5f);
+
+        const RV got = DftTools::replace(dft, meas, res, res);
+        check_close(got, meas, 1e-4f);
+    }
+
+    TEST_CASE("replace with a truncated measurement, as callers use it") {
+        // Callers do wave.resize(charge.size()) after replace().  The
+        // leading charge.size() samples must match the expectation to
+        // within the truncation error of the tail.
+        auto dft = get_dft();
+        RV signal(200, 0.0f);
+        signal[50] = 1.0f;
+        const RV res_old = decay_response(30, 6.0f, 1.0f);
+        const RV res_new = decay_response(30, 2.0f, 3.0f);
+
+        RV meas = linear_convolve(signal, res_old);
+        meas.resize(signal.size());          // as a fixed-length trace
+        RV want = linear_convolve(signal, res_new);
+        want.resize(signal.size());
+
+        RV got = DftTools::replace(dft, meas, res_new, res_old);
+        REQUIRE(got.size() >= signal.size());
+        got.resize(signal.size());
+        check_close(got, want, 1e-3f);
+    }
+
+    TEST_CASE("replace with an all-zero old response is finite and unscaled") {
+        // Policy: bins where FFT(res_old) is exactly zero are left
+        // unscaled.  An all-zero response gives an exactly-zero spectrum
+        // in every bin, so the output must equal the (padded) input and
+        // contain no inf/NaN.
+        auto dft = get_dft();
+        const RV meas = random_wave(48, 6u);
+        const RV res_new = decay_response(8, 2.0f, 1.0f);
+        const RV res_old(8, 0.0f);
+
+        const RV got = DftTools::replace(dft, meas, res_new, res_old);
+        check_close(got, meas, 1e-5f);
+    }
+
+    TEST_CASE("replace with an all-zero new response gives zero") {
+        auto dft = get_dft();
+        const RV meas = random_wave(48, 7u);
+        const RV res_new(8, 0.0f);
+        const RV res_old = decay_response(8, 2.0f, 1.0f);
+
+        const RV got = DftTools::replace(dft, meas, res_new, res_old);
+        REQUIRE(all_finite(got));
+        CHECK(max_abs(got) <= 1e-5f * max_abs(meas));
+    }
+}


### PR DESCRIPTION
This fix was made before #532. The core fix is the same as #532 with some other additions (see CC's comments below).
Also this one is master based so merging is cleaner, so I will close #532 and use this one.
Thanks for @JoeBateman's investigations on this.
For more details check these:
https://github.com/WireCell/wire-cell-toolkit/issues/531
https://github.com/HaiwangYu/wire-cell-toolkit-ai-helper/issues/25

CC comments below:
---
Closes #531. Complements/supersedes #532 (see below).

## Bug

`Aux::DftTools::replace(dft, meas, res1, res2)` never worked (the offending line is unchanged since the first draft, `cd3369d3`, 2021-11):

1. the per-bin loop divided by the **time-domain** `res2[ind]/res1[ind]` instead of the transformed `cres2/cres1`; the raw response vectors are shorter than the padded transform size, so most iterations read out of bounds and in-range samples routinely divided by zero (inf/NaN);
2. the ratio was inverted relative to both callers, `Gen::Misconfigure` and `Gen::PerChannelVariation`, which pass `(new_response, old_response)` exactly like the legacy `Waveform::replace_convolve(wave, newres, oldres)` they were ported from;
3. the inverse transform was never applied: the real part of the frequency spectrum was returned as a waveform.

`DftTools::convolve()` had the same missing inverse transform.

Impact (details in HaiwangYu/wire-cell-toolkit-ai-helper#25): the MicroBooNE overlay simulation runs `PerChannelVariation` on all 8256 channels without a channel-selector bypass, so every RawDigit was corrupted (pedestal 0, railing, saturated final mixer). `Misconfigure` corrupted the DB-selected misconfigured channels in every MicroBooNE WCT simulation. DUNE, SBND and ICARUS configurations do not instantiate either component. `convolve()` has no production callers in WCT or in larwirecell, dunereco, sbndcode, icaruscode, uboonecode, ubsim, ubreco, ubevt (only two ROOT plotting tests in `root/test`).

## Fix

- `replace()`: zero-pad, `fwd_r2c()` all three inputs, form `FFT(meas) * FFT(res_new) / FFT(res_old)`, return `inv_c2r()`. Bins where `FFT(res_old)` is exactly zero are left unscaled instead of producing inf/NaN. This is legacy parity, not new regularization: for real ColdElec responses the spectrum is never exactly zero and near-zero bins amplify noise exactly as the legacy code did.
- Arguments renamed `res_new`/`res_old` (no signature/ABI change) and the header doc rewritten. It previously documented the *opposite* order from what the callers use.
- `convolve()`: same fix (inverse transform added).
- New `aux/test/doctest_dfttools_replace.cxx`: 7 cases comparing `convolve()` and `replace()` against direct O(N*M) linear convolution, plus identity (`res_new == res_old`), truncated-trace usage as the callers do it, and all-zero old/new responses.

| build | `wcdoctest-aux -ts="DftTools high level 1D helpers"` |
|---|---|
| this branch | 7/7 cases pass, 593 assertions |
| unfixed `DftTools.*` from 0.37.1 swapped in | 6/7 cases fail, output non-finite |

Also verified: `root/test/test_misconfigure` and `root/test/test_convo_binning` (the only in-tree `convolve()` users) build and exit 0; the other per-package doctests pass. Compile/test was done on a 0.37.1-based worktree with this commit cherry-picked (applies cleanly; the changed region is identical between 0.37.1 and master), because current master requires an external-fmt spdlog that the Fermilab UPS environments do not provide.

## Relation to #532

@JoeBateman found and diagnosed this bug and his PR #532 carries the same core correction (use `cres1/cres2`, guard exact-zero denominators, return `inv_c2r`). Thank you, Joe. This PR is offered instead of #532 for these reasons:

- **Base branch.** #532 is built on tag `0.37.1`, so its diff against `master` also carries the 0.37.x release-branch commits: the cherry-picked #493 `OmnibusSigProc` fix (already on master) and `version.txt` (git-ignored on master, only meant to exist on release branches). GitHub currently reports #532 as conflicting. This branch is on current master and touches only `aux/`.
- **`convolve()`** is fixed too; it had the same missing inverse transform.
- **Header/API doc** now matches the caller convention (the Copilot review on #532 flagged the mismatch).
- **Regression test** that fails on the old implementation and passes on the new one (also flagged as missing on #532).

Joe's one-event MicroBooNE overlay validation of the same math (all 8256 channels at the correct plane baseline, 0 railing / flat-zero / saturated channels) applies to this implementation as well; a re-run with this branch is planned. A backport to the release branch used by MicroBooNE will follow once this is merged.

## Side finding (not addressed here)

Both callers ignore their `truncate` configuration and always `resize(charge.size())`; the legacy function honored it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qEa16AWbtE5qYNdU4uJwT
